### PR TITLE
topic/2026.0/1052-warning-suppression

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/WellKnownTemplateWarningSuppressions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/WellKnownTemplateWarningSuppressions.cs
@@ -67,7 +67,10 @@ public static class WellKnownTemplateWarningSuppressions
             new WellKnownTemplateWarningSuppression( "IDE0044", "A template field may be set by target code.", [SymbolKind.Field] ),
 
             // CS9113: Parameter is unread.
-            new WellKnownTemplateWarningSuppression( "CS9113", "A template parameter may be read by target code.", [SymbolKind.Method] )
+            new WellKnownTemplateWarningSuppression( "CS9113", "A template parameter may be read by target code.", [SymbolKind.Method] ),
+            
+            // IDE0062 : Local function can be made static.
+            new WellKnownTemplateWarningSuppression( "IDE0062", "A local function can reference state using meta.Proceed or any other meta member.", [SymbolKind.Method] )
         }.ToDictionary( d => d.DiagnosticId, d => d );
     
     // NOTE: Also add suppressions to Metalama.Testing.AspectTesting.props when updating this file.

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/Metalama.Testing.AspectTesting.targets
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/Metalama.Testing.AspectTesting.targets
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <!-- We suppress all warnings present in WellKnownTemplateWarningSuppressions because the suppressor does not run in aspect tests,
              and it's harmless to disable these warnings in tests. -->
-        <NoWarn>$(NoWarn);CA1822;IDE0031;IDE0053;IDE1005;IDE0059;CS0628;CS8618;CS0169;CS0649;IDE0044;CS9113</NoWarn>
+        <NoWarn>$(NoWarn);CA1822;IDE0031;IDE0053;IDE1005;IDE0059;CS0628;CS8618;CS0169;CS0649;IDE0044;CS9113;IDE0062</NoWarn>
         
         <!-- Also suppress warnings from Microsoft.VisualStudio.Threading.Analyzers -->
         <NoWarn>$(NoWarn);VSTHRD001;VSTHRD002;VSTHRD003;VSTHRD004;VSTHRD010;VSTHRD011;VSTHRD012;VSTHRD102;VSTHRD103;


### PR DESCRIPTION
Suppress 'IDE0062 : Local function can be made static' from templates