### PR TITLE
Update Roslyn to 5.0.0 GA (#1212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,3 +16,13 @@
 ## Aspect tests
 
 - In aspect tests, Foo.t.cs is the result file of Foo.cs
+
+## Git branches
+
+- Branch naming convention: `topic/YYYY.N/XXXX-short-description` where `XXXX` is the issue number
+- For a branch named `topic/YYYY.N/*`, the merge branch is always `develop/YYYY.N` - do not use the default merge branch
+
+## Commits
+
+- Commit messages must include the issue number, e.g. `(#1212)`
+- Do not sign commits with "Generated with Claude Code"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
     <RoslynApiMinVersion>4.8.0</RoslynApiMinVersion>
 
     <!-- RoslynApiMaxVersion is the maximum version of the Roslyn API we support. -->
-    <RoslynApiMaxVersion>5.0.0-2.final</RoslynApiMaxVersion>
+    <RoslynApiMaxVersion>5.0.0</RoslynApiMaxVersion>
     <!-- RoslynMaxVersion is the version of Roslyn that should be referenced by the Workspaces package. -->
-    <RoslynMaxVersion>5.0.0-2.final</RoslynMaxVersion>
+    <RoslynMaxVersion>5.0.0</RoslynMaxVersion>
 
     <!-- xUnitApiVersion is the version of xUnit against which we build the testing framework -->
     <xUnitApiVersion>2.9.3</xUnitApiVersion>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SupportedCSharpVersions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SupportedCSharpVersions.cs
@@ -81,7 +81,7 @@ public static class SupportedCSharpVersions
             RoslynApiVersion.V4_4_0 => "4.4.0",
             RoslynApiVersion.V4_8_0 => "4.8.0",
             RoslynApiVersion.V4_12_0 => "4.12.0",
-            RoslynApiVersion.V5_0_0 => "5.0.0-2.final",
+            RoslynApiVersion.V5_0_0 => "5.0.0",
             _ => throw new AssertionFailedException( $"Unexpected Roslyn version {roslynVersion}." )
         };
 


### PR DESCRIPTION
## Summary
- Update Roslyn from 5.0.0-2.final to 5.0.0 GA
- Update CLAUDE.md with branch naming and commit conventions

Closes #1212