### PR TITLE
Enhance XML documentation for async and iterator methods (#1225)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework/Code/AsyncInfo.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/AsyncInfo.cs
@@ -7,35 +7,62 @@ using Metalama.Framework.Aspects;
 namespace Metalama.Framework.Code;
 
 /// <summary>
-/// Information about an async method, returned by the <see cref="MethodExtensions.GetAsyncInfo"/> extension method of <see cref="IMethod"/>.
+/// Provides information about the async characteristics of a method, returned by the <see cref="MethodExtensions.GetAsyncInfo"/> extension method of <see cref="IMethod"/>.
 /// </summary>
+/// <remarks>
+/// <para>Use this struct to inspect async method properties at compile time, for example in <c>BuildAspect</c>.</para>
+/// <para>The <see cref="ResultType"/> property is particularly useful when you need the actual result type instead of the task type.
+/// For example, for a method returning <c>Task&lt;string&gt;</c>, <see cref="ResultType"/> is <c>string</c>.</para>
+/// </remarks>
+/// <seealso cref="MethodExtensions.GetAsyncInfo"/>
+/// <seealso cref="IteratorInfo"/>
+/// <seealso href="@overriding-methods#async-iterator-default-template"/>
 [CompileTime]
 public readonly struct AsyncInfo
 {
     /// <summary>
-    /// Gets a value indicating whether the method has an async implementation, i.e. has the <c>async</c> modifier.
+    /// Gets a value indicating whether the method has an async implementation, i.e., whether it has the <c>async</c> modifier.
     /// </summary>
+    /// <value>
+    /// <c>true</c> if the method has the <c>async</c> modifier; <c>false</c> if it does not;
+    /// <c>null</c> if the method is not defined in the current project and the information is not available.
+    /// </value>
     public bool? IsAsync { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the return type of the method is awaitable, i.e. whether it can be used with the <c>await</c> keyword.
-    /// This does not include <c>IAsyncEnumerable</c>, which can be used with <c>await foreach</c> but not <c>await</c>.
+    /// Gets a value indicating whether the return type of the method is awaitable, i.e., whether it can be used with the <c>await</c> keyword.
     /// </summary>
+    /// <value>
+    /// <c>true</c> if the return type can be used with <c>await</c>; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// This does not include <c>IAsyncEnumerable&lt;T&gt;</c>, which can be used with <c>await foreach</c> but not <c>await</c>.
+    /// </remarks>
     public bool IsAwaitable { get; }
 
     /// <summary>
     /// Gets a value indicating whether the return type of the method has an <c>AsyncMethodBuilderAttribute</c> custom attribute.
     /// </summary>
+    /// <value>
+    /// <c>true</c> if the return type has an <c>AsyncMethodBuilderAttribute</c>; otherwise, <c>false</c>.
+    /// </value>
     public bool HasMethodBuilder { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the return type of the method is either awaitable (see <see cref="IsAwaitable"/>) either <c>void</c>.
+    /// Gets a value indicating whether the return type of the method is either awaitable (see <see cref="IsAwaitable"/>) or <c>void</c>.
     /// </summary>
+    /// <value>
+    /// <c>true</c> if the return type is awaitable or <c>void</c>; otherwise, <c>false</c>.
+    /// </value>
     public bool IsAwaitableOrVoid => this.IsAwaitable || this.ResultType.Equals( SpecialType.Void );
 
     /// <summary>
-    /// Gets the type of the result of the async method, i.e. the type of the <c>await</c> expression.
+    /// Gets the unwrapped result type of the async method, i.e., the type of the <c>await</c> expression.
     /// </summary>
+    /// <value>
+    /// The unwrapped result type. For example, for a method returning <c>Task&lt;string&gt;</c>, this property returns <c>string</c>.
+    /// For a method returning <c>Task</c> or <c>void</c>, this property returns <c>void</c>.
+    /// </value>
     public IType ResultType { get; }
 
     internal AsyncInfo( bool? isAsync, bool isAwaitable, IType resultType, bool hasMethodBuilder )

--- a/Metalama.Framework/src/Metalama.Framework/Code/EnumerableKind.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/EnumerableKind.cs
@@ -9,21 +9,23 @@ using Metalama.Framework.Aspects;
 namespace Metalama.Framework.Code;
 
 /// <summary>
-/// Kinds of iterators.
+/// Specifies the kind of enumerable or enumerator type returned by a method.
 /// </summary>
 /// <remarks>
-/// To get the <see cref="EnumerableKind"/> of a method, use the <see cref="MethodExtensions.GetIteratorInfo"/> extension method,
-/// which returns an <see cref="IteratorInfo"/> struct. The <see cref="IteratorInfo.EnumerableKind"/> property contains the enumerable kind.
+/// <para>To get the <see cref="EnumerableKind"/> of a method, use the <see cref="MethodExtensions.GetIteratorInfo"/> extension method,
+/// which returns an <see cref="IteratorInfo"/> struct. The <see cref="IteratorInfo.EnumerableKind"/> property contains the enumerable kind.</para>
+/// <para>This enum distinguishes between generic and non-generic (untyped) variants, as well as between synchronous and async variants.</para>
 /// </remarks>
 /// <seealso cref="IMethod"/>
 /// <seealso cref="IteratorInfo"/>
 /// <seealso cref="MethodExtensions.GetIteratorInfo"/>
 /// <seealso cref="IFieldOrPropertyOrIndexer.GetMethod"/>
+/// <seealso href="@overriding-methods#async-iterator-default-template"/>
 [CompileTime]
 public enum EnumerableKind
 {
     /// <summary>
-    /// None. The method does not returns an enumerable or enumerator.
+    /// None. The method does not return an enumerable or enumerator.
     /// </summary>
     None,
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/IteratorInfo.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/IteratorInfo.cs
@@ -8,23 +8,44 @@ using System;
 namespace Metalama.Framework.Code;
 
 /// <summary>
-/// Information about an iterator method, returned by the <see cref="MethodExtensions.GetIteratorInfo"/> extension method of <see cref="IMethod"/>.
-/// </summary>    
+/// Provides information about the iterator characteristics of a method, returned by the <see cref="MethodExtensions.GetIteratorInfo"/> extension method of <see cref="IMethod"/>.
+/// </summary>
+/// <remarks>
+/// <para>Use this struct to inspect iterator method properties at compile time, for example in <c>BuildAspect</c>.</para>
+/// <para>Note that <see cref="IsIteratorMethod"/> indicates whether the method uses <c>yield return</c> or <c>yield break</c>,
+/// while <see cref="EnumerableKind"/> indicates the return type regardless of the implementation.</para>
+/// </remarks>
+/// <seealso cref="MethodExtensions.GetIteratorInfo"/>
+/// <seealso cref="EnumerableKind"/>
+/// <seealso cref="AsyncInfo"/>
+/// <seealso href="@overriding-methods#async-iterator-default-template"/>
 [CompileTime]
 public readonly struct IteratorInfo
 {
     private readonly IType? _returnType;
 
     /// <summary>
-    /// Gets a value indicating whether the method is an iterator (i.e., has a <c>yield return</c> or <c>yield break</c> statement).
-    /// This property evaluates to <c>false</c> for methods that return an enumerable type but do not use <c>yield</c>,
-    /// and <c>null</c> for methods that are not defined in the current project.
+    /// Gets a value indicating whether the method is an iterator, i.e., whether it has a <c>yield return</c> or <c>yield break</c> statement.
     /// </summary>
+    /// <value>
+    /// <c>true</c> if the method uses <c>yield return</c> or <c>yield break</c>;
+    /// <c>false</c> if the method returns an enumerable type but does not use <c>yield</c>;
+    /// <c>null</c> if the method is not defined in the current project and the information is not available.
+    /// </value>
+    /// <remarks>
+    /// This property only indicates whether the method uses yield-based iteration. To determine the kind of enumerable
+    /// returned by the method regardless of implementation, use <see cref="EnumerableKind"/>.
+    /// </remarks>
     public bool? IsIteratorMethod { get; }
 
     /// <summary>
-    /// Gets the type of items being enumerated (the <c>int</c> in <c>IEnumerable&lt;int&gt;</c>).
+    /// Gets the type of items being enumerated.
     /// </summary>
+    /// <value>
+    /// The item type. For example, for a method returning <c>IEnumerable&lt;int&gt;</c>, this property returns <c>int</c>.
+    /// For non-generic enumerable types like <see cref="System.Collections.IEnumerable"/>, this property returns <see cref="object"/>.
+    /// </value>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="EnumerableKind"/> is <see cref="Code.EnumerableKind.None"/>.</exception>
     public IType ItemType
     {
         get
@@ -46,9 +67,13 @@ public readonly struct IteratorInfo
     }
 
     /// <summary>
-    /// Gets the kind of enumerable (<see cref="EnumerableKind.IEnumerable"/>, <see cref="EnumerableKind.IEnumerator"/>,
-    /// <see cref="EnumerableKind.IAsyncEnumerable"/>, ...), regardless of whether the method is a yield-base iterator (see <see cref="IsIteratorMethod"/>).
+    /// Gets the kind of enumerable or enumerator returned by the method, regardless of whether the method is a yield-based iterator (see <see cref="IsIteratorMethod"/>).
     /// </summary>
+    /// <value>
+    /// One of the <see cref="Code.EnumerableKind"/> values: <see cref="Code.EnumerableKind.None"/>, <see cref="Code.EnumerableKind.IEnumerable"/>,
+    /// <see cref="Code.EnumerableKind.IEnumerator"/>, <see cref="Code.EnumerableKind.UntypedIEnumerable"/>, <see cref="Code.EnumerableKind.UntypedIEnumerator"/>,
+    /// <see cref="Code.EnumerableKind.IAsyncEnumerable"/>, or <see cref="Code.EnumerableKind.IAsyncEnumerator"/>.
+    /// </value>
     public EnumerableKind EnumerableKind { get; }
 
     internal IteratorInfo( bool? isIteratorMethod, EnumerableKind enumerableKind, IType? returnType )

--- a/Metalama.Framework/src/Metalama.Framework/Code/MethodExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/MethodExtensions.cs
@@ -8,24 +8,46 @@ namespace Metalama.Framework.Code
 {
     /// <summary>
     /// Extension methods for the <see cref="IMethod"/> interface.
-    /// </summary> 
+    /// </summary>
+    /// <seealso cref="AsyncInfo"/>
+    /// <seealso cref="IteratorInfo"/>
+    /// <seealso cref="EnumerableKind"/>
     [CompileTime]
     public static class MethodExtensions
     {
         /// <summary>
-        /// Determines whether a method is a <c>yield</c>-based iterator and returns an <see cref="IteratorInfo"/> value
-        /// exposing details about the iterator.
+        /// Gets information about whether a method is a <c>yield</c>-based iterator and returns an <see cref="IteratorInfo"/> value
+        /// exposing details about the iterator, such as the <see cref="IteratorInfo.ItemType"/> and <see cref="IteratorInfo.EnumerableKind"/>.
         /// </summary>
-        /// <param name="method">The method to check.</param>
-        /// <returns>An <see cref="IteratorInfo"/> containing information about the iterator, or a default value if the method is not an iterator.</returns>
+        /// <param name="method">The method to inspect.</param>
+        /// <returns>An <see cref="IteratorInfo"/> containing information about the iterator. The <see cref="IteratorInfo.EnumerableKind"/>
+        /// property is set to <see cref="EnumerableKind.None"/> if the method does not return an enumerable or enumerator type.</returns>
+        /// <remarks>
+        /// <para>This method is useful for aspects that need to inspect iterator method properties at compile time, for example in <c>BuildAspect</c>.</para>
+        /// <para>Note that <see cref="IteratorInfo.IsIteratorMethod"/> indicates whether the method uses <c>yield return</c> or <c>yield break</c>,
+        /// while <see cref="IteratorInfo.EnumerableKind"/> indicates the return type regardless of the implementation.</para>
+        /// </remarks>
+        /// <seealso cref="IteratorInfo"/>
+        /// <seealso cref="EnumerableKind"/>
+        /// <seealso cref="GetAsyncInfo"/>
+        /// <seealso href="@overriding-methods#async-iterator-default-template"/>
         [CompileTime]
         public static IteratorInfo GetIteratorInfo( this IMethod method ) => ((ICompilationInternal) method.Compilation).Helpers.GetIteratorInfo( method );
 
         /// <summary>
-        /// Gets the <see cref="AsyncInfo"/> for a method.
+        /// Gets information about the async characteristics of a method, including whether it is awaitable and its result type.
         /// </summary>
-        /// <param name="method">The method to analyze.</param>
-        /// <returns>An <see cref="AsyncInfo"/> containing information about the async characteristics of the method.</returns>
+        /// <param name="method">The method to inspect.</param>
+        /// <returns>An <see cref="AsyncInfo"/> containing information about the async characteristics of the method,
+        /// including whether it has the <c>async</c> modifier, whether its return type is awaitable, and the unwrapped result type.</returns>
+        /// <remarks>
+        /// <para>This method is useful for aspects that need to inspect async method properties at compile time, for example in <c>BuildAspect</c>.</para>
+        /// <para>The <see cref="AsyncInfo.ResultType"/> property returns the unwrapped result type. For example, for a method returning
+        /// <c>Task&lt;string&gt;</c>, the <see cref="AsyncInfo.ResultType"/> is <c>string</c>.</para>
+        /// </remarks>
+        /// <seealso cref="AsyncInfo"/>
+        /// <seealso cref="GetIteratorInfo"/>
+        /// <seealso href="@overriding-methods#async-iterator-default-template"/>
         [CompileTime]
         public static AsyncInfo GetAsyncInfo( this IMethod method ) => ((ICompilationInternal) method.Compilation).Helpers.GetAsyncInfo( method );
 


### PR DESCRIPTION
## Summary

This PR enhances the XML documentation for async and iterator method inspection APIs in response to issue #1225:

- **AsyncInfo.cs**: Added comprehensive documentation including remarks, value tags for all properties, and cross-references to related types and conceptual documentation
- **IteratorInfo.cs**: Enhanced documentation with detailed explanations of properties, including the distinction between `IsIteratorMethod` and `EnumerableKind`
- **MethodExtensions.cs**: Improved documentation for `GetAsyncInfo()` and `GetIteratorInfo()` extension methods with usage examples and cross-references
- **EnumerableKind.cs**: Added clarifying remarks and fixed pre-existing grammatical error ("does not returns" → "does not return")

All documentation now includes:
- Clear summaries explaining the purpose of each member
- `<value>` tags describing property values
- `<remarks>` sections with usage guidance
- `<see>` and `<seealso>` tags for cross-references
- Links to conceptual documentation via `<seealso href="@..."/>` tags
- Proper `<exception>` documentation where applicable

Closes #1225