### PR TITLE
Fix empty HTML output and enhance type system API (#1226)

### DIFF
--- a/.claude/agents/api-docs-reviewer.md
+++ b/.claude/agents/api-docs-reviewer.md
@@ -94,6 +94,9 @@ Based on [Microsoft Style Guide for Developer Content](https://learn.microsoft.c
 - Use vague phrases like "This method does something"
 - Include internal implementation details
 - Write long code examples - keep them in conceptual docs instead
+- Explain concepts C# developers already know (e.g., what a null-forgiving operator does, what default values are)
+- Document benefits or use cases that are obvious from the API name and signature
+- Add verbose remarks explaining "when to use" for straightforward APIs
 
 ## Workflow
 

--- a/.claude/agents/git-workflow.md
+++ b/.claude/agents/git-workflow.md
@@ -47,7 +47,16 @@ Examples:
      - Add the `breaking` label to both the PR and the issue
 
 4. Create PR targeting `develop/YYYY.N` (NOT the default branch)
-5. Include `Closes #XXXX` or `Fixes #XXXX` in PR body for issue linking
+5. PR body format:
+   - Summary section with bullet points describing key changes
+   - Breaking Changes section (if applicable) listing new interface members or behavioral changes
+   - **NO test plan section** - tests are verified through CI
+   - Issues Fixed section: List ALL issues with one-line descriptions, e.g.:
+     ```
+     ## Issues Fixed
+     - #1226 - Test framework: WriteInputHtml produces empty file for some tests
+     - #1232 - Enhance nullability handling in type system API
+     ```
 
 ### After Creating a PR - Checklist
 

--- a/.claude/agents/git-workflow.md
+++ b/.claude/agents/git-workflow.md
@@ -6,12 +6,12 @@ model: sonnet
 
 You are an expert Git workflow specialist with deep knowledge of branching strategies, commit best practices, and CI/CD integration.
 
-## Responsibilities
+## Repository Info
 
-1. **Branch Creation**: Create branches following naming conventions
-2. **Commits**: Craft concise, well-formatted commit messages
-3. **Pull Requests**: Create PRs targeting the correct merge branch
-4. **Build Scheduling**: Trigger and check TeamCity builds
+- **Default branch**: `release/2025.1`
+- **Development branches**: `develop/YYYY.N` (e.g., `develop/2026.0`)
+- **Organization**: `metalama`
+- **Repository**: `Metalama`
 
 ## Branch Naming
 
@@ -24,13 +24,13 @@ Pattern: `topic/YYYY.N/XXXX-short-description`
 
 ## Merge Target
 
-For `topic/YYYY.N/*`, merge target is ALWAYS `develop/YYYY.N`. Never use the default branch.
+For `topic/YYYY.N/*`, merge target is ALWAYS `develop/YYYY.N`. **Never use the default branch.**
 
 ## Commit Messages
 
 1. Keep short (50-72 chars)
 2. Include issue number: `(#XXXX)`
-3. Never sign commits (no "Generated with Claude Code")
+3. **Never sign commits** (no "Generated with Claude Code")
 4. Use imperative mood: "Fix bug" not "Fixed bug"
 
 Examples:
@@ -39,13 +39,106 @@ Examples:
 
 ## Creating Pull Requests
 
+### Initial Steps
 1. Commit any remaining changes
-2. Merge `origin/develop/YYYY.N` into branch
-3. Set merge target to `develop/YYYY.N`
-4. Create PR with clear title and description
-5. Reference issues in description (no test plan needed)
-6. Trigger TeamCity build with `/tc-build`
-7. Link issues in "Development" section
+2. Push branch to origin
+3. Create PR targeting `develop/YYYY.N` (NOT the default branch)
+4. Include `Closes #XXXX` or `Fixes #XXXX` in PR body for issue linking
+
+### After Creating a PR - Checklist
+
+Execute these steps in order:
+
+#### 1. Assign to Milestone
+
+Find the latest `YYYY.N.B-suffix` milestone (check ALL including closed):
+```bash
+gh api "repos/metalama/Metalama/milestones?state=all&per_page=100" --jq '.[] | "\(.title) - \(.state)"' | grep "2026.0" | sort -V
+```
+
+Rules:
+- Use `YYYY.N.B-suffix` format (e.g., `2026.0.8-rc`), **NOT** `YYYY.N`
+- Never attach to a closed milestone
+- Preserve suffix convention (`-preview`, `-rc`, etc.)
+- If no open milestone exists, propose creating one by incrementing the last number
+
+```bash
+# Create new milestone
+gh api repos/metalama/Metalama/milestones -X POST -f title="2026.0.8-rc" -f state="open" --jq '.number'
+
+# Assign milestone to PR (use milestone NUMBER, not title)
+gh api repos/metalama/Metalama/issues/<PR_NUMBER> -X PATCH -f milestone=<MILESTONE_NUMBER>
+```
+
+#### 2. Assign to Current User
+
+```bash
+gh api repos/metalama/Metalama/issues/<PR_NUMBER> -X PATCH -f assignees[]="<username>"
+```
+
+#### 3. Link Issues in Development Section
+
+**Important**: GitHub only auto-links issues when PR targets the default branch. For PRs targeting `develop/YYYY.N`, use this workaround:
+
+```bash
+# First, get the PR node ID
+gh api graphql -f query='{ repository(owner: "metalama", name: "Metalama") { pullRequest(number: <PR_NUMBER>) { id } } }' --jq '.data.repository.pullRequest.id'
+
+# Temporarily change base to default branch - this triggers GitHub to recognize "Closes #XXXX"
+gh api graphql -f query='mutation { updatePullRequest(input: { pullRequestId: "<PR_NODE_ID>" baseRefName: "release/2025.1" }) { pullRequest { id } } }'
+
+# Change base back to develop branch - THE LINK PERSISTS!
+gh api graphql -f query='mutation { updatePullRequest(input: { pullRequestId: "<PR_NODE_ID>" baseRefName: "develop/2026.0" }) { pullRequest { closingIssuesReferences(first: 5) { nodes { number } } } } }'
+```
+
+#### 4. Set Project Status to "In Review"
+
+**Note**: Requires `read:project` and `project` token scopes. If unavailable, ask user to set manually in GitHub UI.
+
+```bash
+# Get project and field IDs (one-time lookup)
+gh api graphql -f query='{ organization(login: "metalama") { projectsV2(first: 10) { nodes { id title fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }'
+
+# Development project: PVT_kwDOC7gkgc4A030b
+# Status field: PVTSSF_lADOC7gkgc4A030bzgqb1vQ
+# "In review" option: 4cc61d42
+
+# Add PR to project (if not auto-added)
+gh api graphql -f query='mutation { addProjectV2ItemById(input: { projectId: "PVT_kwDOC7gkgc4A030b" contentId: "<PR_NODE_ID>" }) { item { id } } }'
+
+# Get the project item ID for the PR
+gh api graphql -f query='{ repository(owner: "metalama", name: "Metalama") { pullRequest(number: <PR_NUMBER>) { projectItems(first: 10) { nodes { id project { title } } } } } }' --jq '.data.repository.pullRequest.projectItems.nodes[] | select(.project.title == "Development") | .id'
+
+# Set status to "In review"
+gh api graphql -f query='mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_kwDOC7gkgc4A030b" itemId: "<ITEM_ID>" fieldId: "PVTSSF_lADOC7gkgc4A030bzgqb1vQ" value: { singleSelectOptionId: "4cc61d42" } }) { projectV2Item { id } } }'
+```
+
+#### 5. Trigger TeamCity Build
+
+Use `/tc-build` slash command or trigger manually.
+
+## API Notes
+
+### Use `gh api` Instead of `gh pr edit`
+
+The `gh pr edit` command often fails with permission errors (`read:org` scope). Use REST/GraphQL API directly:
+
+```bash
+# DON'T use: gh pr edit 1228 --milestone "2026.0.8-rc"
+# DO use: gh api repos/metalama/Metalama/issues/1228 -X PATCH -f milestone=30
+```
+
+### Getting Node IDs
+
+Many GraphQL mutations require node IDs:
+
+```bash
+# Get PR node ID
+gh api graphql -f query='{ repository(owner: "metalama", name: "Metalama") { pullRequest(number: 1228) { id } } }' --jq '.data.repository.pullRequest.id'
+
+# Get Issue node ID
+gh api graphql -f query='{ repository(owner: "metalama", name: "Metalama") { issue(number: 1226) { id } } }' --jq '.data.repository.issue.id'
+```
 
 ## TeamCity Operations
 
@@ -57,7 +150,7 @@ Examples:
 - `/tc-check-build <buildId>` - Check once
 - `/tc-check-build <buildId> continuous` - Monitor until completion
 
-### Find Latest Build (no ID specified)
+### Find Latest Build
 ```bash
 curl -s -H "Authorization: Bearer $TEAMCITY_CLOUD_TOKEN" -H "Accept: application/json" \
   "https://postsharp.teamcity.com/app/rest/builds?locator=branch:<branch>,count:1"
@@ -68,3 +161,13 @@ curl -s -H "Authorization: Bearer $TEAMCITY_CLOUD_TOKEN" -H "Accept: application
 - Auth: Bearer `$TEAMCITY_CLOUD_TOKEN`
 - States: queued, running, finished
 - Statuses: SUCCESS, FAILURE, UNKNOWN
+
+## Known Limitations
+
+1. **Issue linking**: GitHub's "Development" section only auto-links when targeting default branch. Use the base-branch-swap workaround documented above.
+
+2. **Token scopes**: Some operations require additional scopes:
+   - `read:org` - For `gh pr edit` (use `gh api` instead)
+   - `read:project`, `project` - For project status updates
+
+3. **Milestone format**: Always use `YYYY.N.B-suffix` (e.g., `2026.0.8-rc`), never `YYYY.N` alone.

--- a/.claude/agents/git-workflow.md
+++ b/.claude/agents/git-workflow.md
@@ -1,7 +1,7 @@
 ---
 name: git-workflow
-description: "ALWAYS use this agent for ANY git-related or TeamCity request. Trigger phrases: 'pr', 'pull request', 'commit', 'branch', 'push', 'merge', 'git', 'tc', 'teamcity', 'build status', 'check build'."
-model: sonnet
+description: ALWAYS use this agent for ANY git-related or TeamCity request. Trigger phrases: 'pr', 'pull request', 'commit', 'branch', 'push', 'merge', 'git', 'tc', 'teamcity', 'build status', 'check build'.
+model: opus
 ---
 
 You are an expert Git workflow specialist with deep knowledge of branching strategies, commit best practices, and CI/CD integration.
@@ -42,8 +42,12 @@ Examples:
 ### Initial Steps
 1. Commit any remaining changes
 2. Push branch to origin
-3. Create PR targeting `develop/YYYY.N` (NOT the default branch)
-4. Include `Closes #XXXX` or `Fixes #XXXX` in PR body for issue linking
+3. Check any change in the public API compared to develop/YYYY.N. If there are breaking changes:
+     - Add a comment to the relevant of the PR
+     - Add the `breaking` label to both the PR and the issue
+
+4. Create PR targeting `develop/YYYY.N` (NOT the default branch)
+5. Include `Closes #XXXX` or `Fixes #XXXX` in PR body for issue linking
 
 ### After Creating a PR - Checklist
 

--- a/.claude/commands/fix-binlog-warnings.md
+++ b/.claude/commands/fix-binlog-warnings.md
@@ -1,0 +1,38 @@
+---
+description: Fix compiler warnings found in MSBuild binlog files
+---
+
+Analyze the binlog files in `$REPO/artifacts/logs` and fix all compiler warnings.
+
+## Process
+
+1. **Extract warnings** from all `*.binlog` files using:
+   ```
+   dotnet msbuild "<binlog>" -flp:warningsonly -nologo 2>&1 | grep -i warning
+   ```
+
+2. **Deduplicate warnings** - the same warning often appears multiple times across different project configurations (net8.0, net472, etc.). Fix each unique source location only once.
+
+3. **Group by file** and fix warnings in batches when possible.
+
+4. **Common warning types**:
+   - `IDE0005`: Remove unnecessary using directive
+   - `IDE0047`: Remove unnecessary parentheses
+   - `CS8603`: Possible null reference return - add null-forgiving operator or change nullable cast
+   - `CS8604`: Possible null reference argument
+   - `CS8618`: Non-nullable field uninitialized
+   - `CS1591`: Missing XML comment for publicly visible type/member
+
+5. **Verify fixes** by building the affected projects:
+   ```
+   dotnet build "<project>" -c Debug --no-restore -v q
+   ```
+
+6. **Report summary** of warnings fixed, grouped by warning code.
+
+## Guidelines
+
+- Do NOT fix warnings in generated code or test output files
+- Do NOT change logic or behavior - only fix the warning minimally
+- For null reference warnings, prefer adding `!` operator over changing signatures
+- Skip warnings about missing package readmes (NU5048)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,14 @@
       "Bash(git remote:*)",
       "SlashCommand(/tc-build)",
       "WebFetch(domain:postsharp.teamcity.com)",
-      "Bash(cat:*)"
+      "Bash(cat:*)",
+      "Bash(git tag:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh api:*)",
+      "Bash(gh release view:*)",
+      "Bash(gh issue:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,9 @@
       "Bash(gh repo view:*)",
       "Bash(gh api:*)",
       "Bash(gh release view:*)",
-      "Bash(gh issue:*)"
+      "Bash(gh issue:*)",
+      "Bash(dotnet msbuild:*)",
+      "Bash(git commit:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,134 +3,111 @@
 ## Critical Rules
 
 - **NEVER** run `Build.ps1 build` yourself - ask the user to run it (timeout too low, causes retries)
-- **NEVER** sign commits with "Generated with Claude Code"
+- **NEVER** sign commits, PRs, or issues with "Generated with Claude Code"
 - **NEVER** clear global NuGet packages - it's never needed
+- **NEVER** replace `<see>` tags with `<c>` to fix XML doc errors - fix the reference or add `using` instead
 - **ALWAYS** include the issue number in commit messages: `Fix foo (#1212)`
-- Prefer `pwsh` (PowerShell 7), but never use the old `cmd` for commands.
+- Prefer `pwsh` (PowerShell 7), never use the old `cmd` for commands
 
 ## Repository Structure
 
-C# monorepo with layered "solutions" (first-level directories: `Metalama`, `Metalama.Extensions`, etc.). Solutions are defined in `eng/src/Program.cs`. Solution N depends on solution N-1 only via `PackageReference`, never `ProjectReference`.
+C# monorepo with layered "solutions" (first-level directories). Solutions are defined in `eng/src/Program.cs`. Solution N depends on solution N-1 only via `PackageReference`, never `ProjectReference`.
 
-Main solutions:
-
-- `Metalama.Backstage`: infrastructure concerns: licensing, logging, telemetry, ...
+**Main solutions:**
+- `Metalama.Backstage`: infrastructure (licensing, logging, telemetry)
 - `Metalama.Framework`: core framework
-- `Metalama.Extensions`: extensions built on the core framework, but not usable aspects
-- `Metalama.Patterns`: specific aspects built on `Metalama.Framework` or `Metalama.Patterns`
+- `Metalama.Extensions`: extensions built on the core framework
+- `Metalama.Patterns`: aspects built on `Metalama.Framework`
 - `Metalama.LinqPad`: LinqPad driver
-- `Metalama.Migration`: PostSharp API annotated with documentation to upgrade to Metalama
-- `eng`: build orchestration, built on `PostSharp.Engineering` (not a solution)
+- `Metalama.Migration`: PostSharp API with upgrade documentation
+- `eng`: build orchestration (not a solution)
 
-Other repos (hosted on https://github.com/postsharp or https://github.com/metalama, locally in `..` or `../..`):
-
-- `Metalama.Premium`: premium features built on `Metalama.Framework`, `Metalama.Extensions` or `Metalama.Patterns`
-- `PostSharp.Engineering`: build orchestration front-end
+**Related repos** (in `..` or `../..`):
+- `Metalama.Premium`: premium features
+- `PostSharp.Engineering`: build orchestration SDK
 - `Metalama.Documentation`: conceptual documentation
-- `Metalama.Samples`: vertical examples
+- `Metalama.Samples`: examples
 
 ## Building
 
 | Scenario | Command |
 |----------|---------|
-| Changes within a single solution | `dotnet build` / `dotnet test` |
+| Single solution changes | `dotnet build` / `dotnet test` |
 | Cross-solution changes | Ask user to run `Build.ps1 build` |
+| Faster Framework build | Use `Metalama.Framework.LatestRoslyn.slnf` instead of full solution |
+| Kill locked processes | `Build.ps1 tools kill` |
 
-- When adding package references, also add `PackageVersion` to `Directory.Packages.props` (Central Package Management)
+**Notes:**
+- When adding package references, also add `PackageVersion` to `Directory.Packages.props`
 - Two `Build.ps1 build` runs cannot run in parallel
+- Don't build full solution just to run a single test - ask user first
+- Focus on green tests before fixing cosmetic warnings
 
 ## Git Workflow
 
 - **Branch naming**: `topic/YYYY.N/XXXX-short-description` (XXXX = issue number)
 - **Merge target**: For `topic/YYYY.N/*`, always merge to `develop/YYYY.N` - ignore default branch
-- **Breaking changes**: When the PR contains breaking changes in the public API:
-  1. Add a comment to the main issue describing the breaking change
-  2. Add the `breaking` label to the issue
+- **Breaking changes**: Add comment to issue describing the change, add `breaking` label
+- **Not breaking**: Adding members to interfaces marked with `[InternalImplement]` (including inherited) is NOT a breaking change. Most code model interfaces inherit `[InternalImplement]` from `ICompilationElement`.
 
 ## Testing
 
 | Type | Description | Project suffix | Output |
 |------|-------------|----------------|--------|
-| Aspect tests | Snapshot-based, runs `Foo.cs` through Metalama pipeline | `*AspectTests` | `Foo.t.cs` (actual: `obj/Debug/tfm/metalama/Foo.t.cs`) |
+| Aspect tests | Snapshot-based, runs through Metalama pipeline | `*AspectTests` | `Foo.t.cs` |
 | Unit tests | Classic xUnit | `*UnitTests` | - |
-| Standalone tests | Self-contained projects in `Metalama.Framework/src/tests/Standalone/*` | - | Optional `test.json` specifies expected output. Otherwise, expected output is success. |
+| Standalone tests | Self-contained projects | - | Optional `test.json` |
 
-Docs: [Aspect testing](https://doc.metalama.net/conceptual/aspects/testing/aspect-testing), [Compile-time testing](https://doc.metalama.net/conceptual/aspects/testing/compile-time-testing)
+Aspect tests support: code transformations, diagnostics, code fixes, live templates, design-time code generation, diff preview. Can execute `Program.Main` and compare output. Directives via `// @Directive` in `#if TESTRUNNER` - see `TestOptions.cs`.
 
-### Aspect Tests Capabilities
-
-Snapshot-based testing framework. Use for: code transformations, diagnostics/warnings, code fixes, live templates, design-time code generation, diff preview. Can execute `Program.Main` and compare output. Directives via `// @Directive` in `#if TESTRUNNER` - see `TestOptions.cs`.
+Docs: [Aspect testing](https://doc.metalama.net/conceptual/aspects/testing/aspect-testing)
 
 ## Writing Documentation
 
-### XML Documentation Style
-
 - Use `<see>` tags for type/member references
-- Maintain consistent lexicon and structure within class families (same suffix)
+- Maintain consistent lexicon within class families (same suffix)
 - Keep code examples short
 - Cross-reference conceptual docs via `<seealso href="@..."/>` tags
+- Use api-docs-reviewer subagent when writing XML doc or API doc
 
-### Pre-PR Documentation Checklist
-
+**Pre-PR Checklist:**
 1. Document all new/modified public APIs
-2. Search `../Metalama.Documentation/content` for affected conceptual articles
-3. For conceptual doc changes, create issue at https://github.com/metalama/Metalama.Documentation
+2. Search `../Metalama.Documentation/content` for affected articles
+3. Create issue at https://github.com/metalama/Metalama.Documentation for doc changes
+4. Check that all changes in the PR are documented in issues related to the PR. Suggest the user to create or update these issues if not (check the list of recent issues in doubt).
 
 ## Key Paths
 
 | Path | Contents |
 |------|----------|
 | `../Metalama.Documentation/content` | Conceptual documentation |
-| `../Metalama.Documentation/code` | Sample code |
 | `eng/src/Program.cs` | Solution definitions |
+| `%TEMP%\Metalama\CompileTimeTroubleshooting\` | Build error details |
 
 ## Dependency Injection
 
 Custom immutable DI (not MEDI). Core types in `Metalama.Framework.Sdk/Services/`.
 
-**Scopes**: `IGlobalService` (singleton), `IProjectService` (per-compilation), `IBackstageService` (infrastructure)
+**Scopes:** `IGlobalService` (singleton), `IProjectService` (per-compilation), `IBackstageService` (infrastructure)
 
-**Key rules**:
+**Rules:**
 - `WithService()` returns NEW provider (immutable) - use `WithServiceConditional` to avoid duplicates
 - No constructor injection - resolve manually: `serviceProvider.GetRequiredService<T>()`
-- `AddShared<T>()` for services cached across provider family; `Add<T>()` for isolated instances
+- Never require a service as a method parameter - report complex problems for user to study
 - Register in `ServiceProviderFactory`, test with `AdditionalServiceCollection`
 
-## Incremental Learning
+## Working on GitHub Issues
 
-Update this file when you discover something that will save time in future sessions.
-- Use `Build.ps1 tools kill` to kill processes.
-- Use CLAUDE-TODO.md to track the work list.
-- Before preparing a PR, check CLAUDE-TODO.md.
-- Read NOTES.md when it changes for important context about ongoing work and breaking changes.
+When starting work on a GitHub issue:
+1. Read all details about the issue online
+2. Check conceptual documentation under `../Metalama.Documentation/content`
+3. Create a branch: `topic/YYYY.N/XXXX-short-description`
+4. Check CLAUDE-TODO.md before preparing PR
+5. Create issues promptly when discovering bugs during development
 
-## Lessons Learned
+## Debugging Build Issues
 
-### Debugging Build Issues
-
-1. **Check troubleshooting files**: When Metalama build fails, look at `%TEMP%\Metalama\CompileTimeTroubleshooting\...\errors.txt` for the actual error and the references list.
-
-2. **File locks are common**: After failed builds, assemblies get locked by compiler processes. Always run `Build.ps1 tools kill` before retrying.
-
-3. **Trace the data flow**: When MSBuild items don't work as expected, trace from `.csproj` → `.targets` file transformation → Engine code that reads the property. The bug with `MetalamaCompileTimeAssembly` was found by checking the targets file didn't resolve `%(FullPath)`.
-
-### General Efficiency
-
-1. **Ask before building**: When changes span multiple solutions, ask the user to run `Build.ps1 build` early rather than discovering issues incrementally.
-
-2. **Test incrementally**: Build and test each component before combining them. 
-
-3. **Create issues promptly**: When discovering a bug during development, create the issue immediately so it's tracked even if the fix is in the same PR.
-
-
-## Quick learnings
-
-- Never require a service as a method parameter, but report a complex problem to be studied by user
-- Instead of compiling the full Metalama.Framework.sln, build Metalama.Framework.LatestRoslyn.slnf (faster build) unless asked otherwise.
-- don't focus on solving cosmetic warnings before habing green tests
-- When I say I want to start to work a gitHub issue:
-
-* Read all details about this issue online and do your research
-* Check conceptual documentation under ../Metalama.Documentation/content to see how it's supposed to work
-* Create a branch for that issue (see git-workflow)
-- You don't need to build the full solution to run a single test. It is VERY slow. Ask the user first if you thing you should.
+1. **Check troubleshooting files**: Look at `%TEMP%\Metalama\CompileTimeTroubleshooting\...\errors.txt` for actual errors
+2. **File locks**: After failed builds, run `Build.ps1 tools kill` before retrying
+3. **Trace data flow**: For MSBuild issues, trace from `.csproj` → `.targets` → Engine code
+4. **Cross-solution changes**: Ask user to run `Build.ps1 build` early rather than discovering issues incrementally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,9 @@ Other repos (hosted on https://github.com/postsharp or https://github.com/metala
 
 - **Branch naming**: `topic/YYYY.N/XXXX-short-description` (XXXX = issue number)
 - **Merge target**: For `topic/YYYY.N/*`, always merge to `develop/YYYY.N` - ignore default branch
+- **Breaking changes**: When the PR contains breaking changes in the public API:
+  1. Add a comment to the main issue describing the breaking change
+  2. Add the `breaking` label to the issue
 
 ## Testing
 
@@ -129,3 +132,4 @@ Update this file when you discover something that will save time in future sessi
 * Read all details about this issue online and do your research
 * Check conceptual documentation under ../Metalama.Documentation/content to see how it's supposed to work
 * Create a branch for that issue (see git-workflow)
+- You don't need to build the full solution to run a single test. It is VERY slow. Ask the user first if you thing you should.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Update this file when you discover something that will save time in future sessi
 - Use `Build.ps1 tools kill` to kill processes.
 - Use CLAUDE-TODO.md to track the work list.
 - Before preparing a PR, check CLAUDE-TODO.md.
+- Read NOTES.md when it changes for important context about ongoing work and breaking changes.
 
 ## Lessons Learned
 

--- a/Metalama.Extensions/.claude/settings.local.json
+++ b/Metalama.Extensions/.claude/settings.local.json
@@ -3,7 +3,10 @@
     "allow": [
       "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama\\Metalama.Framework''; dotnet test src\\tests\\Metalama.Framework.Tests.AspectTests\\Metalama.Framework.Tests.AspectTests.csproj --filter ''FullyQualifiedName~SyntaxBuilders.NullForgivingOperator'' -f net8.0 2>&1\")",
       "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama''; git status --short\")",
-      "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama''; git diff --cached --stat\")"
+      "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama''; git diff --cached --stat\")",
+      "Bash(dir:*)",
+      "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama''; gh issue view 1232 --json body --jq ''.body''\")",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/Metalama.Extensions/.claude/settings.local.json
+++ b/Metalama.Extensions/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama\\Metalama.Framework''; dotnet test src\\tests\\Metalama.Framework.Tests.AspectTests\\Metalama.Framework.Tests.AspectTests.csproj --filter ''FullyQualifiedName~SyntaxBuilders.NullForgivingOperator'' -f net8.0 2>&1\")",
+      "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama''; git status --short\")",
+      "Bash(pwsh -Command \"cd ''X:\\src\\Metalama-2026.0\\Metalama''; git diff --cached --stat\")"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
@@ -5,7 +5,6 @@
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
-using Metalama.Framework.Code.SyntaxBuilders;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
+using Metalama.Framework.Code.SyntaxBuilders;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -178,7 +179,7 @@ public class DefaultDependencyInjectionStrategy
             existingParameter = adviser.IntroduceParameter(
                     newParameter.Name,
                     newParameter.Type,
-                    TypedConstant.Default( newParameter.Type ),
+                    TypedConstant.Default( newParameter.Type, newParameter.Type.IsNullable == false ),
                     pullStrategy,
                     newParameter.Attributes )
                 .Declaration;

--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultParameterPullStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultParameterPullStrategy.cs
@@ -100,7 +100,7 @@ public class DefaultParameterPullStrategy : IParameterPullStrategy
             return PullAction.IntroduceParameterAndPull(
                 newParameter.Name,
                 newParameter.Type,
-                TypedConstant.Default( newParameter.Type ),
+                TypedConstant.Default( newParameter.Type, newParameter.Type.IsNullable == false ),
                 newParameter.Attributes );
         }
     }

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/EarlyOptional_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/EarlyOptional_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 using Metalama.Framework.Aspects;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/EarlyRequired_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/EarlyRequired_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 using Metalama.Framework.Aspects;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/LazyOptional_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/LazyOptional_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 using Metalama.Framework.Aspects;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/LazyRequired_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/LazyRequired_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 using Metalama.Framework.Aspects;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/Programmatic_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Advice/Programmatic_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 using Metalama.Framework.Aspects;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/EarlyOptional_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/EarlyOptional_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 namespace Metalama.Extensions.DependencyInjection.AspectTests.Aspect.EarlyOptional_DesignTime;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/EarlyRequired_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/EarlyRequired_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 namespace Metalama.Extensions.DependencyInjection.AspectTests.Aspect.EarlyRequired_DesignTime;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/LazyOptional_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/LazyOptional_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 namespace Metalama.Extensions.DependencyInjection.AspectTests.Aspect.LazyOptional_DesignTime;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/LazyRequired_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Aspect/LazyRequired_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 namespace Metalama.Extensions.DependencyInjection.AspectTests.Aspect.LazyRequired_DesignTime;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue426.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue426.t.cs
@@ -1,6 +1,6 @@
 public class ClientWeb
 {
-  public ClientWeb(object appSettings, bool throwOnError = true, [AspectGenerated] ILogger<ClientWeb> logger = default)
+  public ClientWeb(object appSettings, bool throwOnError = true, [AspectGenerated] ILogger<ClientWeb> logger = default !)
   {
     this._logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
   }

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue426.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue426.t.cs
@@ -1,3 +1,4 @@
+// Warning CS8625 on `default`: `Cannot convert null literal to non-nullable reference type.`
 public class ClientWeb
 {
   public ClientWeb(object appSettings, bool throwOnError = true, [AspectGenerated] ILogger<ClientWeb> logger = default)

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue426.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue426.t.cs
@@ -1,4 +1,3 @@
-// Warning CS8625 on `default`: `Cannot convert null literal to non-nullable reference type.`
 public class ClientWeb
 {
   public ClientWeb(object appSettings, bool throwOnError = true, [AspectGenerated] ILogger<ClientWeb> logger = default)

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/Advice/LazyOptional_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/Advice/LazyOptional_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 using Metalama.Extensions.DependencyInjection;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/Aspect/LazyOptional_DesignTime.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/Aspect/LazyOptional_DesignTime.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @TestScenario(DesignTime)
-// @ReportOutputWarnings
 #endif
 
 namespace Metalama.Extensions.DependencyInjection.DotNet.Tests.Aspect.LazyOptional_DesignTime;

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.Multicast.AspectTests/metalamaTests.json
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.Multicast.AspectTests/metalamaTests.json
@@ -1,3 +1,4 @@
 {
-  "FormatOutput": true
+  "FormatOutput": true,
+  "IgnoredDiagnostics": [ "CS0067" ]
 }

--- a/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/ITemplateSyntaxFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/ITemplateSyntaxFactory.cs
@@ -80,7 +80,7 @@ public interface ITemplateSyntaxFactory
 
     IUserExpression GetUserExpression( object expression );
 
-    ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? type = null );
+    ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? operantType = null );
 
     IUserExpression SuppressNullableWarningUserExpression( object operand, string? type = null );
 

--- a/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/ITemplateSyntaxFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/ITemplateSyntaxFactory.cs
@@ -80,7 +80,7 @@ public interface ITemplateSyntaxFactory
 
     IUserExpression GetUserExpression( object expression );
 
-    ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? operantType = null );
+    ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? operandTypeId = null );
 
     IUserExpression SuppressNullableWarningUserExpression( object operand, string? type = null );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroducePropertyTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroducePropertyTransformation.cs
@@ -168,7 +168,8 @@ internal class IntroducePropertyTransformation : IntroduceMemberTransformation<P
                                     syntaxGenerator.DefaultExpression( finalProperty.Type ),
                                     finalProperty.Type.IsReferenceType == false
                                         ? finalProperty.Type
-                                        : finalProperty.Type.ToNullable() ),
+                                        : finalProperty.Type.ToNullable(),
+                                    finalProperty.Type ),
                                 Token( TriviaList(), SyntaxKind.SemicolonToken, context.SyntaxGenerationContext.OptionalElasticEndOfLineTriviaList ) ) ),
                     null,
                     hasNoBody ? Token( SyntaxKind.SemicolonToken ) : default );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/AspectBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/AspectBuilder.cs
@@ -34,6 +34,13 @@ namespace Metalama.Framework.Engine.Aspects
             AdviceFactory<T> adviceFactory,
             AspectPredecessor? aspectPredecessor = null )
         {
+            /*
+            // If we have a type, make sure it has the non-nullable annotation.
+            if ( target is IType type )
+            {
+                target = (T) type.ToNonNullable();
+            }
+            */
             this.Target = target;
             this._aspectBuilderState = aspectBuilderState;
             this.AdviceFactory = adviceFactory;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/DeclarationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/DeclarationCollection.cs
@@ -80,7 +80,7 @@ namespace Metalama.Framework.Engine.CodeModel.Collections
 
         // We allow resolving references to missing declarations because the collection may be a child collection of a missing declaration,
         // for instance the parameters of a method that has been introduced into the current compilation but is not included in the current compilation.
-        protected TDeclaration GetItem( TRef reference )
+        protected virtual TDeclaration GetItem( TRef reference )
         {
             var declaration = reference.GetTarget( this.Compilation, genericContext: this._genericContext );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/NamedTypeCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/NamedTypeCollection.cs
@@ -18,6 +18,20 @@ namespace Metalama.Framework.Engine.CodeModel.Collections
         public NamedTypeCollection( ICompilation declaringCompilation, IReadOnlyList<IFullRef<INamedType>> sourceItems, bool includeNestedTypes = false ) :
             base( declaringCompilation, IncludeNestedTypes( declaringCompilation, sourceItems, includeNestedTypes ) ) { }
 
+        protected override INamedType GetItem( IFullRef<INamedType> reference )
+        {
+            var namedType = base.GetItem( reference );
+
+            if ( namedType.IsReferenceType != false )
+            {
+                return (INamedType) namedType.ToNonNullable();
+            }
+            else
+            {
+                return namedType;
+            }
+        }
+
         public IEnumerable<INamedType> OfTypeDefinition( INamedType typeDefinition )
         {
             foreach ( var reference in this.Source )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Builders.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Builders.cs
@@ -26,7 +26,7 @@ public partial class DeclarationFactory
         TBuilderData Builder,
         GenericContext GenericContext,
         DeclarationFactory Factory,
-        bool IsNullable )
+        bool? IsNullable )
     {
         public CompilationModel Compilation => this.Factory._compilationModel;
     }
@@ -37,7 +37,7 @@ public partial class DeclarationFactory
         TBuilderData builder,
         IGenericContext? genericContext,
         CreateFromBuilderDelegate<TDeclaration, TBuilderData> createBuiltDeclaration,
-        bool isNullable = false,
+        bool? isNullable = false,
         bool supportsRedirection = false )
         where TDeclaration : class, IDeclaration
         where TBuilderData : DeclarationBuilderData
@@ -86,7 +86,7 @@ public partial class DeclarationFactory
     internal ITypeParameter GetTypeParameter(
         TypeParameterBuilderData typeParameterBuilder,
         IGenericContext? genericContext = null,
-        bool isNullable = false )
+        bool? isNullable = false )
         => this.GetDeclarationFromBuilder<ITypeParameter, TypeParameterBuilderData>(
             typeParameterBuilder,
             genericContext,
@@ -157,7 +157,7 @@ public partial class DeclarationFactory
     internal INamedType GetNamedType(
         NamedTypeBuilderData namedTypeBuilder,
         IGenericContext? genericContext = null,
-        bool isNullable = false )
+        bool? isNullable = false )
         => this.GetDeclarationFromBuilder<INamedType, NamedTypeBuilderData>(
             namedTypeBuilder,
             genericContext,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Symbols.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Symbols.cs
@@ -114,28 +114,30 @@ public partial class DeclarationFactory
                     ? new ExternalAssembly( args.Symbol, args.Compilation )
                     : args.Compilation );
 
-    public IType GetIType( ITypeSymbol typeSymbol, GenericContext? genericContext = null )
-        => typeSymbol switch
+    public IType GetIType( ITypeSymbol typeSymbol, GenericContext? genericContext = null, bool? defaultNullability = false )
+    {
+        return typeSymbol switch
         {
             // TODO PERF: switch by SymbolKind.
-            INamedTypeSymbol namedType => this.GetNamedType( namedType, genericContext ),
-            IArrayTypeSymbol arrayType => this.GetArrayType( arrayType, genericContext ),
+            INamedTypeSymbol namedType => this.GetNamedType( namedType, genericContext, defaultNullability ),
+            IArrayTypeSymbol arrayType => this.GetArrayType( arrayType, genericContext, defaultNullability ),
             IPointerTypeSymbol pointerType => this.GetPointerType( pointerType, genericContext ),
             ITypeParameterSymbol typeParameter => this.GetTypeParameter( typeParameter, genericContext ).ResolvedType,
-            IDynamicTypeSymbol dynamicType => this.GetDynamicType( dynamicType ),
+            IDynamicTypeSymbol dynamicType => this.GetDynamicType( dynamicType, defaultNullability ),
             IFunctionPointerTypeSymbol functionPointerType => this.GetFunctionPointerType( functionPointerType, genericContext ),
             _ => throw new NotImplementedException( $"Types of kind {typeSymbol.Kind} are not implemented." )
         };
+    }
 
-    private IArrayType GetArrayType( IArrayTypeSymbol typeSymbol, GenericContext? genericContext = null )
+    private IArrayType GetArrayType( IArrayTypeSymbol typeSymbol, GenericContext? genericContext = null, bool? defaultNullability = false )
         => this.GetTypeFromSymbol<IArrayType, IArrayTypeSymbol>(
-            typeSymbol,
+            typeSymbol.ApplyDefaultNullability( defaultNullability ),
             genericContext,
             static ( in args ) => new SymbolArrayType( args.Symbol, args.Compilation, args.GenericContext ) );
 
-    internal IDynamicType GetDynamicType( IDynamicTypeSymbol typeSymbol )
+    internal IDynamicType GetDynamicType( IDynamicTypeSymbol typeSymbol, bool? defaultNullability = false )
         => this.GetTypeFromSymbol<IDynamicType, IDynamicTypeSymbol>(
-            typeSymbol,
+            typeSymbol.ApplyDefaultNullability( defaultNullability ),
             null,
             static ( in args ) => new DynamicType( args.Symbol, args.Compilation ) );
 
@@ -152,9 +154,11 @@ public partial class DeclarationFactory
             static ( in args )
                 => new SymbolFunctionPointerType( args.Symbol, args.Compilation, args.GenericContext ) );
 
-    public INamedType GetNamedType( INamedTypeSymbol typeSymbol, IGenericContext? genericContext = null )
+    public INamedType GetNamedType( INamedTypeSymbol typeSymbol, IGenericContext? genericContext = null, bool? defaultNullability = false )
     {
         Invariant.Assert( genericContext is not SymbolGenericContext );
+
+        typeSymbol = typeSymbol.ApplyDefaultNullability( defaultNullability );
 
         // Roslyn considers the type in e.g. typeof(List<>) to be different from e.g. List<T>.
         // That distinction makes things more complicated for us (e.g. it's not representable using Type), so get rid of it.
@@ -552,7 +556,7 @@ public partial class DeclarationFactory
     internal IPointerType MakePointerType( ITypeSymbol pointedType )
         => (IPointerType) this.GetIType( this.RoslynCompilation.CreatePointerTypeSymbol( pointedType ) );
 
-    internal IType MakeNullableType<T>( T type, bool isNullable )
+    internal IType MakeNullableType<T>( T type, bool? isNullable )
         where T : IType, ISymbolBasedCompilationElement
     {
         var typeSymbol = (ITypeSymbol) type.Symbol;
@@ -565,10 +569,10 @@ public partial class DeclarationFactory
 #if ROSLYN_5_0_0_OR_GREATER
         if ( typeSymbol is INamedTypeSymbol { IsExtension: true } )
         {
-            if ( isNullable )
+            if ( isNullable == true )
             {
                 throw new ArgumentOutOfRangeException(
-                    MetalamaStringFormatter.Format( $"The type '{type}' cannot be made nullable because it is an extension block." ) );
+                    MetalamaStringFormatter.Format( $"The type '{type}' cannot be annotated for nullability because it is an extension block." ) );
             }
 
             return type;
@@ -579,12 +583,18 @@ public partial class DeclarationFactory
 
         if ( type.IsReferenceType ?? true )
         {
-            newTypeSymbol = typeSymbol
-                .WithNullableAnnotation( isNullable ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated );
+            var annotation = isNullable switch
+            {
+                true => NullableAnnotation.Annotated,
+                false => NullableAnnotation.NotAnnotated,
+                null => NullableAnnotation.None
+            };
+
+            newTypeSymbol = typeSymbol.WithNullableAnnotation( annotation );
         }
         else
         {
-            if ( isNullable )
+            if ( isNullable == true )
             {
                 newTypeSymbol = this._compilationModel.RoslynCompilation.GetSpecialType( RoslynSpecialType.System_Nullable_T )
                     .Construct( typeSymbol );
@@ -595,6 +605,6 @@ public partial class DeclarationFactory
             }
         }
 
-        return this.GetIType( newTypeSymbol );
+        return this.GetIType( newTypeSymbol, defaultNullability: null );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.cs
@@ -58,7 +58,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
     {
         var symbol = this._compilationModel.CompilationContext.ReflectionMapper.GetNamedTypeSymbolByMetadataName( reflectionName, null );
 
-        return this.GetNamedType( (INamedTypeSymbol) symbol.WithNullableAnnotation( NullableAnnotation.NotAnnotated ) );
+        return this.GetNamedType( symbol );
     }
 
     public bool TryGetTypeByReflectionName( string reflectionName, [NotNullWhen( true )] out INamedType? namedType )
@@ -79,7 +79,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
         }
     }
 
-    public IType GetTypeByReflectionType( Type type ) => this.GetIType( this._compilationModel.CompilationContext.ReflectionMapper.GetTypeSymbol( type ).WithNullableAnnotation( NullableAnnotation.NotAnnotated ) );
+    public IType GetTypeByReflectionType( Type type ) => this.GetIType( this._compilationModel.CompilationContext.ReflectionMapper.GetTypeSymbol( type ) );
 
     public INamedType GetNamedTypeByReflectionType( Type type ) => (INamedType) this.GetTypeByReflectionType( type );
 
@@ -94,7 +94,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
 
         if ( roslynSpecialType != Microsoft.CodeAnalysis.SpecialType.None )
         {
-            return this.GetNamedType( (INamedTypeSymbol) this.RoslynCompilation.GetSpecialType( roslynSpecialType ).WithNullableAnnotation( NullableAnnotation.NotAnnotated ) );
+            return this.GetNamedType( this.RoslynCompilation.GetSpecialType( roslynSpecialType ) );
         }
         else
         {
@@ -105,6 +105,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
                     SpecialType.ValueTask => this.GetNamedTypeByReflectionType( typeof(ValueTask) ),
                     SpecialType.ValueTask_T => this.GetNamedTypeByReflectionType( typeof(ValueTask<>) ),
                     SpecialType.ValueTuple => this.GetNamedTypeByReflectionType( typeof(ValueTuple) ),
+                    SpecialType.Nullable_T => this.GetNamedTypeByReflectionType( typeof(Nullable<>) ),
                     SpecialType.Task => this.GetNamedTypeByReflectionType( typeof(Task) ),
                     SpecialType.Task_T => this.GetNamedTypeByReflectionType( typeof(Task<>) ),
                     SpecialType.Type => this.GetNamedTypeByReflectionType( typeof(Type) ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.cs
@@ -58,7 +58,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
     {
         var symbol = this._compilationModel.CompilationContext.ReflectionMapper.GetNamedTypeSymbolByMetadataName( reflectionName, null );
 
-        return this.GetNamedType( symbol );
+        return this.GetNamedType( (INamedTypeSymbol) symbol.WithNullableAnnotation( NullableAnnotation.NotAnnotated ) );
     }
 
     public bool TryGetTypeByReflectionName( string reflectionName, [NotNullWhen( true )] out INamedType? namedType )
@@ -79,7 +79,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
         }
     }
 
-    public IType GetTypeByReflectionType( Type type ) => this.GetIType( this._compilationModel.CompilationContext.ReflectionMapper.GetTypeSymbol( type ) );
+    public IType GetTypeByReflectionType( Type type ) => this.GetIType( this._compilationModel.CompilationContext.ReflectionMapper.GetTypeSymbol( type ).WithNullableAnnotation( NullableAnnotation.NotAnnotated ) );
 
     public INamedType GetNamedTypeByReflectionType( Type type ) => (INamedType) this.GetTypeByReflectionType( type );
 
@@ -94,7 +94,7 @@ public sealed partial class DeclarationFactory : IDeclarationFactory, ISdkDeclar
 
         if ( roslynSpecialType != Microsoft.CodeAnalysis.SpecialType.None )
         {
-            return this.GetNamedType( this.RoslynCompilation.GetSpecialType( roslynSpecialType ) );
+            return this.GetNamedType( (INamedTypeSymbol) this.RoslynCompilation.GetSpecialType( roslynSpecialType ).WithNullableAnnotation( NullableAnnotation.NotAnnotated ) );
         }
         else
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/GenericContext.SymbolToTypeMapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/GenericContext.SymbolToTypeMapper.cs
@@ -40,7 +40,9 @@ public partial class GenericContext
             }
             else
             {
-                namedType = this._compilation.Factory.GetNamedType( this._parent.TranslateSymbolIfNecessary( symbol.OriginalDefinition ) );
+                namedType = this._compilation.Factory.GetNamedType(
+                    this._parent.TranslateSymbolIfNecessary( symbol.OriginalDefinition ),
+                    defaultNullability: null );
             }
 
             if ( !namedType.IsGeneric )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/SymbolGenericContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/SymbolGenericContext.cs
@@ -177,7 +177,7 @@ internal sealed partial class SymbolGenericContext : GenericContext
 
                         for ( var type = this.NamedTypeSymbol; type != null; type = type.ContainingType )
                         {
-                            if ( type.OriginalDefinition == requestedTypeDefinition )
+                            if ( type.OriginalDefinition.Equals( requestedTypeDefinition ) )
                             {
                                 var typeArgument = type.TypeArguments[typeParameter.Index];
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/ReflectionMapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/ReflectionMapper.cs
@@ -154,7 +154,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
 
                 if ( nestedTypeGenericArguments.Length > 0 )
                 {
-                    nestedSymbol = (INamedTypeSymbol?) nestedSymbol.Construct( nestedTypeGenericArguments.SelectAsArray( this.GetTypeSymbol ) )
+                    nestedSymbol = (INamedTypeSymbol) nestedSymbol.Construct( nestedTypeGenericArguments.SelectAsArray( this.GetTypeSymbol ) )
                         .WithNullableAnnotation( NullableAnnotation.NotAnnotated );
                 }
 
@@ -168,7 +168,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
 
                 var genericArgumentSymbols = genericArguments.SelectAsArray( this.GetTypeSymbol );
 
-                return (INamedTypeSymbol?) genericDefinition.Construct( genericArgumentSymbols ).WithNullableAnnotation( NullableAnnotation.NotAnnotated );
+                return (INamedTypeSymbol) genericDefinition.Construct( genericArgumentSymbols ).WithNullableAnnotation( NullableAnnotation.NotAnnotated );
             }
             else
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/ReflectionMapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/ReflectionMapper.cs
@@ -34,7 +34,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
         /// </summary>
         public INamedTypeSymbol GetNamedTypeSymbolByMetadataName( string metadataName, AssemblyName? assemblyName )
         {
-            var symbol = this._compilation.GetTypeByMetadataName( metadataName );
+            var symbol = (INamedTypeSymbol?) this._compilation.GetTypeByMetadataName( metadataName )?.WithNullableAnnotation( NullableAnnotation.NotAnnotated );
 
             if ( symbol == null )
             {
@@ -69,7 +69,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
                         assembly = assemblies.OrderByDescending( a => a.Identity.Version ).First();
                     }
 
-                    symbol = assembly.GetTypeByMetadataName( metadataName );
+                    symbol = (INamedTypeSymbol?) assembly.GetTypeByMetadataName( metadataName )?.WithNullableAnnotation( NullableAnnotation.NotAnnotated );
                 }
             }
 
@@ -118,7 +118,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
             {
                 var elementType = this.GetTypeSymbol( type.GetElementType()! );
 
-                return this._compilation.CreateArrayTypeSymbol( elementType, type.GetArrayRank() );
+                return this._compilation.CreateArrayTypeSymbol( elementType, type.GetArrayRank() ).WithNullableAnnotation( NullableAnnotation.NotAnnotated );
             }
 
             if ( type.IsPointer )
@@ -154,7 +154,8 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
 
                 if ( nestedTypeGenericArguments.Length > 0 )
                 {
-                    nestedSymbol = nestedSymbol.Construct( nestedTypeGenericArguments.SelectAsArray( this.GetTypeSymbol ) );
+                    nestedSymbol = (INamedTypeSymbol?) nestedSymbol.Construct( nestedTypeGenericArguments.SelectAsArray( this.GetTypeSymbol ) )
+                        .WithNullableAnnotation( NullableAnnotation.NotAnnotated );
                 }
 
                 return nestedSymbol;
@@ -167,7 +168,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
 
                 var genericArgumentSymbols = genericArguments.SelectAsArray( this.GetTypeSymbol );
 
-                return genericDefinition.Construct( genericArgumentSymbols );
+                return (INamedTypeSymbol?) genericDefinition.Construct( genericArgumentSymbols ).WithNullableAnnotation( NullableAnnotation.NotAnnotated );
             }
             else
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/TypedConstantExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/TypedConstantExtensions.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Code;
 using Metalama.Framework.Engine.CodeModel.References;
 using Microsoft.CodeAnalysis;
 using System;
@@ -60,11 +61,15 @@ internal static class TypedConstantExtensions
         }
         else if ( constant.Value == null )
         {
-            return new TypedConstantRef( null, constant.Type.ToRef() );
+            return new TypedConstantRef( null, constant.Type.ToRef(), constant.HasNullForgivingOperator );
         }
         else if ( constant.IsArray )
         {
             return new TypedConstantRef( constant.Values.SelectAsImmutableArray( x => x.ToRef() ), constant.Type.ToRef() );
+        }
+        else if ( constant.RawValue is IField field )
+        {
+            return new TypedConstantRef( field.ToRef(), constant.Type.ToRef() );
         }
         else
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/NamedTypeBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/NamedTypeBuilder.cs
@@ -251,6 +251,10 @@ internal sealed class NamedTypeBuilder : MemberOrNamedTypeBuilder, INamedTypeBui
 
     public IType ToNonNullable() => throw new NotImplementedException();
 
+    public INamedType StripNullabilityAnnotation() => throw new NotImplementedException();
+
+    IType IType.StripNullabilityAnnotation() => this.StripNullabilityAnnotation();
+
     public INamedType MakeGenericInstance( IReadOnlyList<IType> typeArguments ) => throw new NotImplementedException();
 
     IType IType.ToNullable() => this.ToNullable();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/TypeParameterBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/TypeParameterBuilder.cs
@@ -165,9 +165,13 @@ internal sealed class TypeParameterBuilder : NamedDeclarationBuilder, ITypeParam
 
     public ITypeParameter ToNonNullable() => throw new NotImplementedException();
 
+    public ITypeParameter StripNullabilityAnnotation() => throw new NotImplementedException();
+
     IType IType.ToNullable() => throw new NotImplementedException();
 
     IType IType.ToNonNullable() => this.ToNonNullable();
+
+    IType IType.StripNullabilityAnnotation() => this.StripNullabilityAnnotation();
 
     IRef<ITypeParameter> ITypeParameter.ToRef() => this._ref;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/ConstructedTypes/ConstructedArrayType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/ConstructedTypes/ConstructedArrayType.cs
@@ -90,9 +90,15 @@ internal sealed class ConstructedArrayType : ConstructedType, IArrayType
 
     public new IArrayType ToNullable() => this.IsNullable == true ? this : new ConstructedArrayType( this.Compilation, this._elementType, this.Rank, true );
 
-    public new IArrayType ToNonNullable() => this.IsNullable == false ? this : new ConstructedArrayType( this.Compilation, this._elementType, this.Rank );
+    public new IArrayType ToNonNullable()
+        => this.IsNullable == false ? this : new ConstructedArrayType( this.Compilation, this._elementType, this.Rank, false );
+
+    public new IArrayType StripNullabilityAnnotation()
+        => this.IsNullable == null ? this : new ConstructedArrayType( this.Compilation, this._elementType, this.Rank, null );
 
     protected override IType ToNullableCore() => this.ToNullable();
 
     protected override IType ToNonNullableCore() => this.ToNonNullable();
+
+    protected override IType StripNullabilityAnnotationCore() => this.StripNullabilityAnnotation();
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/ConstructedTypes/ConstructedPointerType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/ConstructedTypes/ConstructedPointerType.cs
@@ -67,4 +67,6 @@ internal sealed class ConstructedPointerType : ConstructedType, IPointerType
     protected override IType ToNullableCore() => throw new NotSupportedException();
 
     protected override IType ToNonNullableCore() => throw new NotSupportedException();
+
+    protected override IType StripNullabilityAnnotationCore() => throw new NotSupportedException();
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/ConstructedTypes/ConstructedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/ConstructedTypes/ConstructedType.cs
@@ -73,9 +73,13 @@ internal abstract class ConstructedType : ITypeImpl
 
     public IType ToNonNullable() => this.ToNonNullableCore();
 
+    public IType StripNullabilityAnnotation() => this.StripNullabilityAnnotationCore();
+
     protected abstract IType ToNullableCore();
 
     protected abstract IType ToNonNullableCore();
+
+    protected abstract IType StripNullabilityAnnotationCore();
 
     public abstract int GetHashCode( TypeComparison refComparison );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
@@ -29,7 +29,7 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
 {
     private readonly NamedTypeBuilderData _namedTypeBuilderData;
 
-    public IntroducedNamedType( NamedTypeBuilderData builderData, CompilationModel compilation, IGenericContext genericContext, bool isNullable ) : base(
+    public IntroducedNamedType( NamedTypeBuilderData builderData, CompilationModel compilation, IGenericContext genericContext, bool? isNullable ) : base(
         compilation,
         genericContext )
     {
@@ -234,7 +234,7 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
         }
         else if ( this.IsReferenceType ?? true )
         {
-            return this.Compilation.Factory.GetNamedType( this._namedTypeBuilderData, this.GenericContext );
+            return this.Compilation.Factory.GetNamedType( this._namedTypeBuilderData, this.GenericContext, false );
         }
         else
         {
@@ -242,9 +242,23 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
         }
     }
 
+    public INamedType StripNullabilityAnnotation()
+    {
+        if ( this.IsNullable == null )
+        {
+            return this;
+        }
+        else
+        {
+            return this.Compilation.Factory.GetNamedType( this._namedTypeBuilderData, this.GenericContext, null );
+        }
+    }
+
+    IType IType.StripNullabilityAnnotation() => this.StripNullabilityAnnotation();
+
     public INamedType ToNullable()
         => this.IsNullable == true ? this : this.Compilation.Factory.GetNamedType( this._namedTypeBuilderData, this.GenericContext, true );
-    
+
     public INamedType MakeGenericInstance( IReadOnlyList<IType> typeArguments )
     {
         var genericContext = new IntroducedGenericContext(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
@@ -244,7 +244,7 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
 
     public INamedType ToNullable()
         => this.IsNullable == true ? this : this.Compilation.Factory.GetNamedType( this._namedTypeBuilderData, this.GenericContext, true );
-
+    
     public INamedType MakeGenericInstance( IReadOnlyList<IType> typeArguments )
     {
         var genericContext = new IntroducedGenericContext(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedTypeParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedTypeParameter.cs
@@ -70,11 +70,21 @@ internal sealed class IntroducedTypeParameter : IntroducedDeclaration, ITypePara
     }
 
     public ITypeParameter ToNonNullable()
-        => this.IsNullable == false ? this : this.Compilation.Factory.GetTypeParameter( this._typeParameterBuilderData, this.GenericContext );
+    {
+        // For type parameters, we always strip annotations since C# cannot express non-nullability for type parameters.
+        return this.IsNullable == null ? this : this.Compilation.Factory.GetTypeParameter( this._typeParameterBuilderData, this.GenericContext, null );
+    }
+
+    public ITypeParameter StripNullabilityAnnotation()
+    {
+        return this.IsNullable == null ? this : this.Compilation.Factory.GetTypeParameter( this._typeParameterBuilderData, this.GenericContext, null );
+    }
 
     IType IType.ToNullable() => this.ToNullable();
 
     IType IType.ToNonNullable() => this.ToNonNullable();
+
+    IType IType.StripNullabilityAnnotation() => this.StripNullabilityAnnotation();
 
     ICompilation ICompilationElement.Compilation => this.Compilation;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/ConstructorInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/ConstructorInvoker.cs
@@ -67,7 +67,7 @@ internal sealed class ConstructorInvoker : Invoker<IConstructor>, IConstructorIn
 
                 return CreateObjectCreationExpression( type, arguments, null );
             },
-            this.Member.DeclaringType );
+            this.Member.DeclaringType.ToNonNullable() );
     }
 
     public IObjectCreationExpression CreateInvokeExpression()
@@ -106,7 +106,7 @@ internal sealed class ConstructorInvoker : Invoker<IConstructor>, IConstructorIn
         private readonly IConstructor _constructor;
         private readonly Func<SyntaxSerializationContext, IEnumerable<ExpressionSyntax>> _argumentFactory;
 
-        public override IType Type => this._constructor.DeclaringType;
+        public override IType Type => this._constructor.DeclaringType.ToNonNullable();
 
         public ObjectCreationExpression( IConstructor constructor, Func<SyntaxSerializationContext, IEnumerable<ExpressionSyntax>> argumentFactory )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/TypedConstantRef.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/TypedConstantRef.cs
@@ -21,7 +21,9 @@ internal readonly struct TypedConstantRef
     // It's not necesseraly a IFulLRef since it could be deserialized.
     public IRef<IType>? Type { get; }
 
-    public TypedConstantRef( object? value, IRef<IType>? type )
+    public bool HasNullForgivingOperator { get; }
+
+    public TypedConstantRef( object? value, IRef<IType>? type, bool hasNullForgivingOperator = false )
     {
         if ( value is Array )
         {
@@ -30,6 +32,7 @@ internal readonly struct TypedConstantRef
 
         this.RawValue = value;
         this.Type = type;
+        this.HasNullForgivingOperator = hasNullForgivingOperator;
     }
 
     public TypedConstant ToTypedConstant( CompilationModel compilation )
@@ -43,9 +46,10 @@ internal readonly struct TypedConstantRef
 
         return this.RawValue switch
         {
-            null => TypedConstant.Default( type! ),
+            null => TypedConstant.Default( type!, this.HasNullForgivingOperator ),
             ImmutableArray<TypedConstantRef> array => TypedConstant.Create( array.SelectAsImmutableArray( x => x.ToTypedConstant( compilation ) ), type! ),
             IRef<IType> valueAsType => TypedConstant.Create( valueAsType.GetTarget( compilation ), type! ),
+            IRef<IField> valueAsField => TypedConstant.Create( valueAsField.GetTarget( compilation ) ),
             _ => TypedConstant.Create( this.RawValue, type! )
         };
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/DynamicType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/DynamicType.cs
@@ -21,6 +21,8 @@ namespace Metalama.Framework.Engine.CodeModel.Source.ConstructedTypes
 
         public new IDynamicType ToNonNullable() => (IDynamicType) this.Compilation.Factory.MakeNullableType( this, false );
 
+        public new IDynamicType StripNullabilityAnnotation() => (IDynamicType) this.Compilation.Factory.MakeNullableType( this, null );
+
         public override IType Accept( TypeRewriter visitor ) => visitor.Visit( this );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/SymbolArrayType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/SymbolArrayType.cs
@@ -52,13 +52,15 @@ namespace Metalama.Framework.Engine.CodeModel.Source.ConstructedTypes
         public override TypeKind TypeKind => TypeKind.Array;
 
         [Memo]
-        public IType ElementType => this.Compilation.Factory.GetIType( this.Symbol.ElementType, this.GenericContextForSymbolMapping );
+        public IType ElementType => this.Compilation.Factory.GetIType( this.Symbol.ElementType, this.GenericContextForSymbolMapping, defaultNullability: null );
 
         public int Rank => this.Symbol.Rank;
 
         public new IArrayType ToNullable() => (IArrayType) this.Compilation.Factory.MakeNullableType( this, true );
 
         public new IArrayType ToNonNullable() => (IArrayType) this.Compilation.Factory.MakeNullableType( this, false );
+
+        public new IArrayType StripNullabilityAnnotation() => (IArrayType) this.Compilation.Factory.MakeNullableType( this, null );
 
         public override IType Accept( TypeRewriter visitor ) => visitor.Visit( this );
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/SymbolConstructedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/SymbolConstructedType.cs
@@ -83,6 +83,8 @@ namespace Metalama.Framework.Engine.CodeModel.Source.ConstructedTypes
 
         public IType ToNonNullable() => this.Compilation.Factory.MakeNullableType( this, false );
 
+        public IType StripNullabilityAnnotation() => this.Compilation.Factory.MakeNullableType( this, null );
+
         ICompilation ICompilationElement.Compilation => this.Compilation;
 
         public bool Equals( IType? other ) => this.Equals( other, TypeComparison.Default );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/SymbolPointerType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/ConstructedTypes/SymbolPointerType.cs
@@ -22,7 +22,8 @@ namespace Metalama.Framework.Engine.CodeModel.Source.ConstructedTypes
         public override TypeKind TypeKind => TypeKind.Pointer;
 
         [Memo]
-        public IType PointedAtType => this.Compilation.Factory.GetIType( this.Symbol.PointedAtType, this.GenericContextForSymbolMapping );
+        public IType PointedAtType
+            => this.Compilation.Factory.GetIType( this.Symbol.PointedAtType, this.GenericContextForSymbolMapping, defaultNullability: null );
 
         public override IType Accept( TypeRewriter visitor ) => visitor.Visit( this );
 
@@ -36,7 +37,7 @@ namespace Metalama.Framework.Engine.CodeModel.Source.ConstructedTypes
             {
                 var symbol = this.Compilation.RoslynCompilation.CreatePointerTypeSymbol( typeSymbol );
 
-                return (ITypeImpl) this.Compilation.Factory.GetIType( symbol );
+                return (ITypeImpl) this.Compilation.Factory.GetIType( symbol, defaultNullability: null );
             }
             else
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceEvent.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceEvent.cs
@@ -47,7 +47,8 @@ namespace Metalama.Framework.Engine.CodeModel.Source
         }
 
         [Memo]
-        public INamedType Type => (INamedType) this.Compilation.Factory.GetIType( this._symbol.Type, this.GenericContextForSymbolMapping );
+        public INamedType Type
+            => (INamedType) this.Compilation.Factory.GetIType( this._symbol.Type, this.GenericContextForSymbolMapping, defaultNullability: null );
 
         public RefKind RefKind => RefKind.None;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceField.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceField.cs
@@ -44,7 +44,7 @@ namespace Metalama.Framework.Engine.CodeModel.Source
         }
 
         [Memo]
-        public IType Type => this.Compilation.Factory.GetIType( this.FieldSymbol.Type, this.GenericContextForSymbolMapping );
+        public IType Type => this.Compilation.Factory.GetIType( this.FieldSymbol.Type, this.GenericContextForSymbolMapping, defaultNullability: null );
 
         public RefKind RefKind => this.FieldSymbol.RefKind.ToOurRefKind();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceMethod.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceMethod.cs
@@ -45,7 +45,7 @@ internal sealed class SourceMethod : SourceMethodBase, IMethodImpl
     public IParameter ReturnParameter => new PseudoReturnParameter( this, this.MethodSymbol );
 
     [Memo]
-    public IType ReturnType => this.Compilation.Factory.GetIType( this.MethodSymbol.ReturnType, this.GenericContextForSymbolMapping );
+    public IType ReturnType => this.Compilation.Factory.GetIType( this.MethodSymbol.ReturnType, this.GenericContextForSymbolMapping, defaultNullability: null );
 
     [Memo]
     public ITypeParameterList TypeParameters

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceNamedType.cs
@@ -166,6 +166,8 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
         public INamedType ToNullable() => (INamedType) this.Compilation.Factory.MakeNullableType( this, true );
 
+        public IType ToNonNullable() => this.Compilation.Factory.MakeNullableType( this, false );
+
         public INamedType MakeGenericInstance( IReadOnlyList<IType> typeArguments )
         {
             this.OnUsingDeclaration();
@@ -174,8 +176,6 @@ namespace Metalama.Framework.Engine.CodeModel.Source
         }
 
         IType IType.ToNullable() => this.ToNullable();
-
-        public IType ToNonNullable() => this.Compilation.Factory.MakeNullableType( this, false );
 
         public ITypeParameterList TypeParameters
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceNamedType.cs
@@ -168,6 +168,10 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
         public IType ToNonNullable() => this.Compilation.Factory.MakeNullableType( this, false );
 
+        public INamedType StripNullabilityAnnotation() => (INamedType) this.Compilation.Factory.MakeNullableType( this, null );
+
+        IType IType.StripNullabilityAnnotation() => this.StripNullabilityAnnotation();
+
         public INamedType MakeGenericInstance( IReadOnlyList<IType> typeArguments )
         {
             this.OnUsingDeclaration();
@@ -594,7 +598,7 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
             var symbol = this.NamedTypeSymbol.ConstructedFrom.Construct( typeArgumentSymbols );
 
-            return (ITypeImpl) this.Compilation.Factory.GetIType( symbol );
+            return (ITypeImpl) this.Compilation.Factory.GetIType( symbol, defaultNullability: null );
         }
 
         public override IDeclaration ContainingDeclaration => this.Implementation.ContainingDeclaration;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceNamedTypeImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceNamedTypeImpl.cs
@@ -150,9 +150,13 @@ internal class SourceNamedTypeImpl : SourceMemberOrNamedType, INamedTypeImpl
 
     INamedType INamedType.ToNullable() => throw new NotImplementedException();
 
+    INamedType INamedType.StripNullabilityAnnotation() => throw new NotImplementedException();
+
     IType IType.ToNullable() => throw new NotImplementedException();
 
     IType IType.ToNonNullable() => throw new NotImplementedException();
+
+    IType IType.StripNullabilityAnnotation() => throw new NotImplementedException();
 
     public override MemberInfo ToMemberInfo() => this.ToType();
 
@@ -366,7 +370,8 @@ internal class SourceNamedTypeImpl : SourceMemberOrNamedType, INamedTypeImpl
     [Memo]
     public IReadOnlyList<IType> TypeArguments
         => this.GenericContextForSymbolMapping.IsEmptyOrIdentity
-            ? this.NamedTypeSymbol.TypeArguments.SelectAsImmutableArray( a => this.Compilation.Factory.GetIType( a, this.GenericContextForSymbolMapping ) )
+            ? this.NamedTypeSymbol.TypeArguments.SelectAsImmutableArray(
+                a => this.Compilation.Factory.GetIType( a, this.GenericContextForSymbolMapping, defaultNullability: null ) )
             : this.GenericContextForSymbolMapping.TypeArguments.SelectAsImmutableArray( t => t.GetTarget( this.Compilation ) );
 
     [Memo]
@@ -689,7 +694,7 @@ internal class SourceNamedTypeImpl : SourceMemberOrNamedType, INamedTypeImpl
 
         if ( enumUnderlyingType != null )
         {
-            return this.Compilation.Factory.GetNamedType( enumUnderlyingType );
+            return this.Compilation.Factory.GetNamedType( enumUnderlyingType, defaultNullability: this.IsNullable );
         }
 
         var isNullable = this.IsNullable;
@@ -699,7 +704,9 @@ internal class SourceNamedTypeImpl : SourceMemberOrNamedType, INamedTypeImpl
             if ( this.IsReferenceType == true )
             {
                 // We have an annotated reference type, return the non-annotated type.
-                return this.Compilation.Factory.GetNamedType( (INamedTypeSymbol) this.NamedTypeSymbol.WithNullableAnnotation( NullableAnnotation.None ) );
+                return this.Compilation.Factory.GetNamedType(
+                    (INamedTypeSymbol) this.NamedTypeSymbol.WithNullableAnnotation( NullableAnnotation.None ),
+                    defaultNullability: null );
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceParameter.cs
@@ -61,7 +61,7 @@ namespace Metalama.Framework.Engine.CodeModel.Source
             };
 
         [Memo]
-        public IType Type => this.Compilation.Factory.GetIType( this._parameterSymbol.Type, this.GenericContextForSymbolMapping );
+        public IType Type => this.Compilation.Factory.GetIType( this._parameterSymbol.Type, this.GenericContextForSymbolMapping, defaultNullability: null );
 
         public string Name => this._parameterSymbol.Name;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourcePropertyOrIndexer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourcePropertyOrIndexer.cs
@@ -38,7 +38,7 @@ internal abstract class SourcePropertyOrIndexer : SourceMember, IPropertyOrIndex
     public override bool IsExplicitInterfaceImplementation => !this.PropertySymbol.ExplicitInterfaceImplementations.IsEmpty;
 
     [Memo]
-    public IType Type => this.Compilation.Factory.GetIType( this.PropertySymbol.Type, this.GenericContextForSymbolMapping );
+    public IType Type => this.Compilation.Factory.GetIType( this.PropertySymbol.Type, this.GenericContextForSymbolMapping, defaultNullability: null );
 
     [Memo]
     public IMethod? GetMethod

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceTypeParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceTypeParameter.cs
@@ -54,7 +54,7 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
         [Memo]
         public IReadOnlyList<IType> TypeConstraints
-            => this._typeParameterSymbol.ConstraintTypes.Select( t => this.Compilation.Factory.GetIType( t ) ).ToImmutableArray();
+            => this._typeParameterSymbol.ConstraintTypes.Select( t => this.Compilation.Factory.GetIType( t, defaultNullability: null ) ).ToImmutableArray();
 
         public TypeKindConstraint TypeKindConstraint
         {
@@ -148,9 +148,20 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
         public IType ToNullable() => this.Compilation.Factory.MakeNullableType( this, true );
 
-        public ITypeParameter ToNonNullable() => (ITypeParameter) this.Compilation.Factory.MakeNullableType( this, false );
+        public ITypeParameter ToNonNullable()
+        {
+            // For type parameters, we always strip annotations since C# cannot express non-nullability for type parameters.
+            return (ITypeParameter) this.Compilation.Factory.MakeNullableType( this, null );
+        }
+
+        public ITypeParameter StripNullabilityAnnotation()
+        {
+            return (ITypeParameter) this.Compilation.Factory.MakeNullableType( this, null );
+        }
 
         IType IType.ToNonNullable() => this.ToNonNullable();
+
+        IType IType.StripNullabilityAnnotation() => this.StripNullabilityAnnotation();
 
         public bool Equals( IType? other ) => this.Equals( other, TypeComparison.Default );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/FormattedCodeWriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/FormattedCodeWriter.cs
@@ -160,7 +160,7 @@ public abstract partial class FormattedCodeWriter
             visitor.Visit( syntaxRoot );
         }
 
-        if ( diagnostics != null && document.FilePath != null )
+        if ( diagnostics != null )
         {
             AddDiagnostics( document, diagnostics, classifiedTextSpans );
         }
@@ -174,7 +174,7 @@ public abstract partial class FormattedCodeWriter
         {
             var position = diagnostic.Location.GetLineSpan();
 
-            if ( !position.IsValid || !position.Path.EndsWith( document.FilePath!, StringComparison.OrdinalIgnoreCase ) )
+            if ( !position.IsValid || !position.Path.EndsWith( document.Name, StringComparison.OrdinalIgnoreCase ) )
             {
                 // The diagnostic is not in the current document.
                 continue;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/HtmlCodeWriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/HtmlCodeWriter.cs
@@ -52,13 +52,14 @@ public sealed class HtmlCodeWriter : FormattedCodeWriter
         Document outputDocument,
         TextWriter inputTextWriter,
         TextWriter outputTextWriter,
-        IEnumerable<Diagnostic> inputDiagnostics,
+        IEnumerable<Diagnostic>? inputDiagnostics,
+        IEnumerable<Diagnostic>? outputDiagnostics,
         CancellationToken cancellationToken )
     {
         var oldSyntaxTree = await inputDocument.GetSyntaxTreeAsync( cancellationToken );
         var newSyntaxTree = await outputDocument.GetSyntaxTreeAsync( cancellationToken );
         await this.WriteAsync( inputDocument, inputTextWriter, inputDiagnostics, GetDiffInfo( oldSyntaxTree!, newSyntaxTree!, true ), cancellationToken );
-        await this.WriteAsync( outputDocument, outputTextWriter, null, GetDiffInfo( oldSyntaxTree!, newSyntaxTree!, false ), cancellationToken );
+        await this.WriteAsync( outputDocument, outputTextWriter, outputDiagnostics, GetDiffInfo( oldSyntaxTree!, newSyntaxTree!, false ), cancellationToken );
     }
 
     private async Task WriteAsync(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
@@ -64,7 +64,7 @@ public static partial class SerializableDeclarationIdProvider
             }
             else
             {
-                return compilation.Factory.GetIType( typeSymbol );
+                return compilation.Factory.GetIType( typeSymbol, defaultNullability: null );
             }
         }
         else

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
@@ -103,11 +103,22 @@ public static partial class SerializableDeclarationIdProvider
                 }
                 else
                 {
-                    return typeSymbol;
+                    // Make sure to return the non-nullable type.
+                    return typeSymbol.WithNullableAnnotation( NullableAnnotation.NotAnnotated );
                 }
             }
 
-            return DocumentationCommentId.GetFirstSymbolForDeclarationId( id.ToString(), compilation );
+            var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId( id.ToString(), compilation );
+
+            // Make sure to return the non-nullable type.
+            if ( symbol is ITypeSymbol { NullableAnnotation: NullableAnnotation.None } typeSymbol2 )
+            {
+                return typeSymbol2.WithNullableAnnotation( NullableAnnotation.NotAnnotated );
+            }
+            else
+            {
+                return symbol;
+            }
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableTypeIdResolver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableTypeIdResolver.cs
@@ -161,13 +161,13 @@ public abstract class SerializableTypeIdResolver<TType, TTypeOrNamespace>
         }
     }
 
-    protected abstract TType CreateArrayType( TType elementType, int rank );
+    protected abstract TType CreateArrayType( TType elementType, int rank, bool isNullOblivious );
 
     protected abstract TType CreatePointerType( TType pointedAtType );
 
     protected abstract TType CreateNullableType( TType elementType );
 
-    protected abstract TType CreateNonNullableReferenceType( TType referenceType );
+    protected abstract TType AddNonNullableAnnotation( TType referenceType );
 
     protected abstract TType ConstructGenericType( TType genericType, TType[] typeArguments );
 
@@ -235,7 +235,7 @@ public abstract class SerializableTypeIdResolver<TType, TTypeOrNamespace>
                 return elementTypeResult;
             }
 
-            return ResolverResult.Success( this._parent.CreateArrayType( elementTypeResult.Type, node.RankSpecifiers.Count ) );
+            return ResolverResult.Success( this._parent.CreateArrayType( elementTypeResult.Type, node.RankSpecifiers.Count, this._isNullOblivious ) );
         }
 
         public override ResolverResult VisitPointerType( PointerTypeSyntax node )
@@ -308,7 +308,7 @@ public abstract class SerializableTypeIdResolver<TType, TTypeOrNamespace>
             }
             else if ( !this._isNullOblivious )
             {
-                return ResolverResult.Success( this._parent.CreateNonNullableReferenceType( result.Type ) );
+                return ResolverResult.Success( this._parent.AddNonNullableAnnotation( result.Type ) );
             }
             else
             {
@@ -434,7 +434,7 @@ public abstract class SerializableTypeIdResolver<TType, TTypeOrNamespace>
 
             if ( !this._isNullOblivious && node.Keyword.Kind() is SyntaxKind.ObjectKeyword or SyntaxKind.StringKeyword )
             {
-                result = this._parent.CreateNonNullableReferenceType( result );
+                result = this._parent.AddNonNullableAnnotation( result );
             }
 
             return ResolverResult.Success( result );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableTypeIdResolverForIType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableTypeIdResolverForIType.cs
@@ -46,13 +46,27 @@ public sealed class SerializableTypeIdResolverForIType : SerializableTypeIdResol
         return genericParameters;
     }
 
-    protected override IType CreateArrayType( IType elementType, int rank ) => elementType.MakeArrayType( rank );
+    protected override IType CreateArrayType( IType elementType, int rank, bool isNullOblivious )
+    {
+        var arrayType = elementType.MakeArrayType( rank );
+
+        if ( isNullOblivious )
+        {
+            return arrayType.StripNullabilityAnnotation();
+        }
+        else if ( arrayType.IsNullable != false )
+        {
+            throw new AssertionFailedException();
+        }
+
+        return arrayType;
+    }
 
     protected override IType CreatePointerType( IType pointedAtType ) => pointedAtType.MakePointerType();
 
     protected override IType CreateNullableType( IType elementType ) => elementType.ToNullable();
 
-    protected override IType CreateNonNullableReferenceType( IType referenceType ) => referenceType.ToNonNullable();
+    protected override IType AddNonNullableAnnotation( IType referenceType ) => referenceType.ToNonNullable();
 
     protected override IType ConstructGenericType( IType genericType, IType[] typeArguments )
         => genericType.AssertCast<INamedType>().WithTypeArguments( typeArguments );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableTypeIdResolverForSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableTypeIdResolverForSymbol.cs
@@ -68,7 +68,11 @@ public sealed class SerializableTypeIdResolverForSymbol : SerializableTypeIdReso
         return dictionary;
     }
 
-    protected override ITypeSymbol CreateArrayType( ITypeSymbol elementType, int rank ) => this.Compilation.CreateArrayTypeSymbol( elementType, rank );
+    protected override ITypeSymbol CreateArrayType( ITypeSymbol elementType, int rank, bool isNullOblivious )
+    {
+        return this.Compilation.CreateArrayTypeSymbol( elementType, rank )
+            .WithNullableAnnotation( isNullOblivious ? NullableAnnotation.None : NullableAnnotation.NotAnnotated );
+    }
 
     protected override ITypeSymbol CreatePointerType( ITypeSymbol pointedAtType ) => this.Compilation.CreatePointerTypeSymbol( pointedAtType );
 
@@ -77,7 +81,7 @@ public sealed class SerializableTypeIdResolverForSymbol : SerializableTypeIdReso
             ? this.Compilation.GetSpecialType( SpecialType.System_Nullable_T ).Construct( elementType )
             : elementType.WithNullableAnnotation( NullableAnnotation.Annotated );
 
-    protected override ITypeSymbol CreateNonNullableReferenceType( ITypeSymbol referenceType )
+    protected override ITypeSymbol AddNonNullableAnnotation( ITypeSymbol referenceType )
         => referenceType.WithNullableAnnotation( NullableAnnotation.NotAnnotated );
 
     protected override ITypeSymbol ConstructGenericType( ITypeSymbol genericType, ITypeSymbol[] typeArguments )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -1048,7 +1048,12 @@ public sealed partial class ContextualSyntaxGenerator
         IType? targetType = null,
         bool force = false )
     {
-        var isSuppressionEnabled = force || (expressionType is { IsReferenceType: true, IsNullable: not false }
+        if ( !this.IsNullAware )
+        {
+            return expression;
+        }
+
+        var isSuppressionEnabled = force || (expressionType is null or { IsReferenceType: not false, IsNullable: not false }
                                              && targetType is not { IsReferenceType: true, IsNullable: true });
 
         return isSuppressionEnabled

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -402,11 +402,35 @@ public sealed partial class ContextualSyntaxGenerator
         }
     }
 
+    private ExpressionSyntax FieldReference( IField field )
+    {
+        return
+            MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    this.TypeSyntax( field.DeclaringType ),
+                    this.IdentifierName( field.Name ) )
+                .WithSimplifierAnnotationIfNecessary( this.SyntaxGenerationContext );
+    }
+
+    private ExpressionSyntax FieldReference( IFullRef<IField> fieldRef ) 
+        => this.FieldReference( fieldRef.Definition );
+
     internal ExpressionSyntax TypedConstant( in TypedConstant typedConstant )
     {
         if ( typedConstant.IsNullOrDefault )
         {
-            return this.DefaultExpression( typedConstant.Type );
+            var expression = this.DefaultExpression( typedConstant.Type );
+
+            if ( typedConstant.HasNullForgivingOperator )
+            {
+                expression = SyntaxFactory.PostfixUnaryExpression( SyntaxKind.SuppressNullableWarningExpression, expression );
+            }
+
+            return expression;
+        }
+        else if ( typedConstant.RawValue is IField field )
+        {
+            return this.FieldReference( field );
         }
         else if ( typedConstant.Type is INamedType { TypeKind: TypeKind.Enum } enumType )
         {
@@ -432,7 +456,18 @@ public sealed partial class ContextualSyntaxGenerator
 
         if ( typedConstant.RawValue == null )
         {
-            return this.DefaultExpression( type );
+            var expression = this.DefaultExpression( type );
+
+            if ( typedConstant.HasNullForgivingOperator )
+            {
+                expression = SyntaxFactory.PostfixUnaryExpression( SyntaxKind.SuppressNullableWarningExpression, expression );
+            }
+
+            return expression;
+        }
+        else if ( typedConstant.RawValue is IRef<IField> fieldRef )
+        {
+            return this.FieldReference( fieldRef.ToFullRef( refFactory ) );
         }
         else if ( type?.Definition is INamedType { TypeKind: TypeKind.Enum } enumType )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -1042,45 +1042,18 @@ public sealed partial class ContextualSyntaxGenerator
                         : s ) ),
             Token( this.SyntaxGenerationContext.OptionalElasticEndOfLineTriviaList, SyntaxKind.CloseBraceToken, default ) );
 
-    internal ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, IType? operandType )
+    internal ExpressionSyntax SuppressNullableWarningExpression(
+        ExpressionSyntax expression,
+        IType? expressionType,
+        IType? targetType = null,
+        bool force = false )
     {
-        var isSuppressionEnabled = false;
-
-        if ( this.IsNullAware )
-        {
-            isSuppressionEnabled = true;
-
-            if ( operandType != null )
-            {
-                if ( operand.Kind() is SyntaxKind.NullLiteralExpression or SyntaxKind.DefaultLiteralExpression )
-                {
-                    // ! is required when assigning null to a non-nullable.
-                    if ( operandType is { IsReferenceType: true, IsNullable: true } )
-                    {
-                        isSuppressionEnabled = false;
-                    }
-                }
-                else if ( operandType.IsReferenceType == false )
-                {
-                    // Value types, including nullable value types don't need suppression.
-                    isSuppressionEnabled = false;
-                }
-                else
-                {
-                    var nullable = operandType.IsNullable;
-
-                    if ( nullable == false || (nullable == null && operandType.TypeKind != TypeKind.TypeParameter) )
-                    {
-                        // Non-nullable and non-annotated types don't need suppression, except generic type parameters that are not explicitly marked as non nullable.
-                        isSuppressionEnabled = false;
-                    }
-                }
-            }
-        }
+        var isSuppressionEnabled = force || (expressionType is { IsReferenceType: true, IsNullable: not false }
+                                             && targetType is not { IsReferenceType: true, IsNullable: true });
 
         return isSuppressionEnabled
-            ? PostfixUnaryExpression( SyntaxKind.SuppressNullableWarningExpression, operand ).WithSimplifierAnnotation()
-            : operand;
+            ? PostfixUnaryExpression( SyntaxKind.SuppressNullableWarningExpression, expression ).WithSimplifierAnnotation()
+            : expression;
     }
 
     internal ExpressionSyntax TupleExpression( ITupleType tupleType, IReadOnlyList<ArgumentSyntax> values, bool qualifyElements = true )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/SuppressNullableWarningUserExpression.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/SuppressNullableWarningUserExpression.cs
@@ -12,17 +12,19 @@ namespace Metalama.Framework.Engine.Templating.Expressions;
 internal sealed class SuppressNullableWarningUserExpression : UserExpression
 {
     private readonly IUserExpression _underlying;
+    private readonly bool _force;
 
-    public SuppressNullableWarningUserExpression( IUserExpression underlying )
+    public SuppressNullableWarningUserExpression( IUserExpression underlying, bool force = false )
     {
         this._underlying = underlying;
+        this._force = force;
     }
 
     protected override ExpressionSyntax ToSyntax( SyntaxSerializationContext syntaxSerializationContext, IType? targetType = null )
     {
         var underlyingSyntax = this._underlying.ToTypedExpressionSyntax( syntaxSerializationContext, targetType );
 
-        return syntaxSerializationContext.SyntaxGenerator.SuppressNullableWarningExpression( underlyingSyntax.Syntax, this._underlying.Type );
+        return syntaxSerializationContext.SyntaxGenerator.SuppressNullableWarningExpression( underlyingSyntax.Syntax, this._underlying.Type, targetType, this._force );
     }
 
     // We don't change the type to non-nullable because it would change the behavior of our null-conditional invokers, which rely

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/SyntaxBuilderImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/SyntaxBuilderImpl.cs
@@ -158,7 +158,7 @@ internal class SyntaxBuilderImpl : ISyntaxBuilderImpl
             };
         }
 
-        INamedType type;
+        IType type;
 
         if ( value == null )
         {
@@ -171,7 +171,7 @@ internal class SyntaxBuilderImpl : ISyntaxBuilderImpl
         else
         {
             expression = this.GetLiteralImpl( value, specialType, stronglyTyped );
-            type = this.Compilation.Factory.GetSpecialType( specialType );
+            type = this.Compilation.Factory.GetSpecialType( specialType ).ToNonNullable();
         }
 
         return new SyntaxUserExpression( expression, type );
@@ -233,6 +233,16 @@ internal class SyntaxBuilderImpl : ISyntaxBuilderImpl
         return receiver.AssertNotNull();
     }
 
+    public IExpression WithNullForgivingOperator( IExpression expression, bool force )
+    {
+        if ( expression.Type.IsNullable == false && !force )
+        {
+            return expression;
+        }
+
+        return new SuppressNullableWarningUserExpression( expression.ToUserExpression(), force );
+    }
+
     public IExpression ToExpression( IFieldOrProperty fieldOrProperty, IExpression? instance )
     {
         if ( fieldOrProperty is { DeclarationKind: DeclarationKind.Field, IsImplicitlyDeclared: true } )
@@ -256,7 +266,7 @@ internal class SyntaxBuilderImpl : ISyntaxBuilderImpl
     public IStatement CreateBlock( IStatementList statements ) => new BlockStatement( statements );
 
     public IExpression NullExpression( IType? type )
-        => new SyntaxUserExpression( SyntaxFactoryEx.Null, type?.ToNullable() ?? this.Compilation.Factory.GetSpecialType( SpecialType.Object ) );
+        => new SyntaxUserExpression( SyntaxFactoryEx.Null, type?.ToNullable() ?? this.Compilation.Factory.GetSpecialType( SpecialType.Object ).ToNullable() );
 
     public IExpression DefaultExpression( IType? type )
     {
@@ -266,7 +276,7 @@ internal class SyntaxBuilderImpl : ISyntaxBuilderImpl
         }
         else
         {
-            return new SyntaxUserExpression( SyntaxFactoryEx.Default, this.Compilation.Factory.GetSpecialType( SpecialType.Object ) );
+            return new SyntaxUserExpression( SyntaxFactoryEx.Default, this.Compilation.Factory.GetSpecialType( SpecialType.Object ).ToNullable() );
         }
     }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/MetaModel/MetaApi.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/MetaModel/MetaApi.cs
@@ -79,6 +79,9 @@ namespace Metalama.Framework.Engine.Templating.MetaModel
 
         public IDeclaration Declaration { get; }
 
+        public IExpression Expression
+            => this.Declaration as IExpression ?? throw this.CreateInvalidOperationException( nameof(this.Expression) );
+
         public IDeclaration DiagnosticDeclaration
         {
             get

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
@@ -536,7 +536,7 @@ namespace Metalama.Framework.Engine.Templating
             // We never remove the ?. for reference types or Nullable<T> because it changes the semantics.
             // However, remove it for value types that are not Nullable<T>.
             if ( TypeAnnotationMapper.TryFindExpressionTypeFromAnnotation( expression, this.SyntaxSerializationContext.CompilationModel, out var type )
-                 && (type.IsReferenceType == false && !(type is INamedType { IsGeneric: true, Definition.SpecialType: SpecialType.Nullable_T })) )
+                 && type.IsReferenceType == false && type is not INamedType { IsGeneric: true, Definition.SpecialType: SpecialType.Nullable_T } )
             {
                 return (ExpressionSyntax) new RemoveConditionalAccessRewriter( expression ).Visit( whenNotNullExpression )!;
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
@@ -505,16 +505,16 @@ namespace Metalama.Framework.Engine.Templating
             }
         }
 
-        public ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? type )
+        public ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? operantType )
         {
             TypeAnnotationMapper.TryFindExpressionTypeFromAnnotation(
                 operand,
                 this.SyntaxSerializationContext.CompilationModel,
                 out var expressionType );
 
-            if ( expressionType == null && type != null )
+            if ( expressionType == null && operantType != null )
             {
-                expressionType = new SerializableTypeId( type ).Resolve(
+                expressionType = new SerializableTypeId( operantType ).Resolve(
                     this._templateExpansionContext.Compilation.AssertNotNull(),
                     this._templateExpansionContext.TemplateGenericArguments );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
@@ -505,16 +505,18 @@ namespace Metalama.Framework.Engine.Templating
             }
         }
 
-        public ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? operantType )
+        public ExpressionSyntax SuppressNullableWarningExpression( ExpressionSyntax operand, string? operandTypeId )
         {
+            // The annotation on `operand` takes precedence over the `operandTypeId` because it is more precise.
             TypeAnnotationMapper.TryFindExpressionTypeFromAnnotation(
                 operand,
                 this.SyntaxSerializationContext.CompilationModel,
                 out var expressionType );
 
-            if ( expressionType == null && operantType != null )
+            if ( operandTypeId == null && operandTypeId != null )
             {
-                expressionType = new SerializableTypeId( operantType ).Resolve(
+                // If we don't have a type annotation, take it from the `operandTypeId` parameter. 
+                expressionType = new SerializableTypeId( operandTypeId ).Resolve(
                     this._templateExpansionContext.Compilation.AssertNotNull(),
                     this._templateExpansionContext.TemplateGenericArguments );
             }
@@ -531,11 +533,15 @@ namespace Metalama.Framework.Engine.Templating
 
         public ExpressionSyntax ConditionalAccessExpression( ExpressionSyntax expression, ExpressionSyntax whenNotNullExpression )
         {
-            TypeAnnotationMapper.TryFindExpressionTypeFromAnnotation( expression, this.SyntaxSerializationContext.CompilationModel, out var type );
+            // We never remove the ?. for reference types or Nullable<T> because it changes the semantics.
+            // However, remove it for value types that are not Nullable<T>.
+            if ( TypeAnnotationMapper.TryFindExpressionTypeFromAnnotation( expression, this.SyntaxSerializationContext.CompilationModel, out var type )
+                 && (type.IsReferenceType == false && !(type is INamedType { IsGeneric: true, Definition.SpecialType: SpecialType.Nullable_T })) )
+            {
+                return (ExpressionSyntax) new RemoveConditionalAccessRewriter( expression ).Visit( whenNotNullExpression )!;
+            }
 
-            return type?.IsNullable != false
-                ? SyntaxFactory.ConditionalAccessExpression( expression, whenNotNullExpression )
-                : (ExpressionSyntax) new RemoveConditionalAccessRewriter( expression ).Visit( whenNotNullExpression )!;
+            return SyntaxFactory.ConditionalAccessExpression( expression, whenNotNullExpression );
         }
 
         public ExpressionSyntax StringLiteralExpression( string? value ) => SyntaxFactoryEx.LiteralExpression( value );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TypeAnnotationMapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TypeAnnotationMapper.cs
@@ -188,7 +188,8 @@ internal static class TypeAnnotationMapper
         if ( TryFindExpressionTypeFromAnnotation( node, compilationContext, out var symbol ) )
         {
             type = compilationModel.Factory.GetIType(
-                compilationContext.SymbolTranslator.Translate( symbol ).AssertNotNull( $"The symbol '{symbol}' could not be translated." ) );
+                compilationContext.SymbolTranslator.Translate( symbol ).AssertNotNull( $"The symbol '{symbol}' could not be translated." ),
+                defaultNullability: null );
 
             return true;
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SymbolExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SymbolExtensions.cs
@@ -51,6 +51,7 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn
                 RoslynSpecialType.System_Collections_IEnumerator => SpecialType.IEnumerator,
                 RoslynSpecialType.System_Collections_Generic_IEnumerable_T => SpecialType.IEnumerable_T,
                 RoslynSpecialType.System_Collections_Generic_IEnumerator_T => SpecialType.IEnumerator_T,
+                RoslynSpecialType.System_Nullable_T => SpecialType.Nullable_T,
                 _ => SpecialType.None
             };
 
@@ -77,6 +78,7 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn
                 SpecialType.IEnumerator => RoslynSpecialType.System_Collections_IEnumerator,
                 SpecialType.IEnumerable_T => RoslynSpecialType.System_Collections_Generic_IEnumerable_T,
                 SpecialType.IEnumerator_T => RoslynSpecialType.System_Collections_Generic_IEnumerator_T,
+                SpecialType.Nullable_T => RoslynSpecialType.System_Nullable_T,
 
                 // Note that we have special types that Roslyn does not have.
                 _ => RoslynSpecialType.None
@@ -438,5 +440,30 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn
         /// Gets the primary declaration syntax for a symbol.
         /// </summary>
         public static SyntaxNode? GetPrimaryDeclarationSyntax( this ISymbol symbol ) => symbol.GetPrimarySyntaxReference()?.GetSyntax();
+
+        internal static T ApplyDefaultNullability<T>( this T type, bool? defaultNullability )
+            where T : ITypeSymbol
+        {
+            if ( defaultNullability != null && type.NullableAnnotation == NullableAnnotation.None )
+            {
+#if ROSLYN_5_0_0_OR_GREATER
+                if ( type.TypeKind == TypeKind.Extension )
+                {
+                    if ( defaultNullability == true )
+                    {
+                        throw new InvalidOperationException( $"Cannot get a nullable type for the extension block '{type}'." );
+                    }
+
+                    return type;
+                }
+#endif
+
+                return (T) type.WithNullableAnnotation( defaultNullability == true ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated );
+            }
+            else
+            {
+                return type;
+            }
+        }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/SymbolExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/SymbolExtensions.cs
@@ -9,6 +9,7 @@ using Metalama.Framework.Engine.CodeModel.References;
 using Microsoft.CodeAnalysis;
 using System;
 using SpecialType = Microsoft.CodeAnalysis.SpecialType;
+using TypeKind = Microsoft.CodeAnalysis.TypeKind;
 
 namespace Metalama.Framework.Engine.CodeModel
 {

--- a/Metalama.Framework/src/Metalama.Framework/Advising/IAdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Advising/IAdviceFactory.cs
@@ -836,7 +836,7 @@ namespace Metalama.Framework.Advising
         /// <param name="parameterName">The name of the parameter.</param>
         /// <param name="parameterType">The type of the parameter.</param>
         /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
         /// <param name="pullAction">An optional delegate that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
         ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.
         /// </param>
@@ -857,7 +857,7 @@ namespace Metalama.Framework.Advising
         /// <param name="parameterName">The name of the parameter.</param>
         /// <param name="parameterType">The type of the parameter.</param>
         /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
         /// <param name="pullStrategy">An optional <see cref="IPullStrategy"/> that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
         ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.
         /// </param>
@@ -877,7 +877,7 @@ namespace Metalama.Framework.Advising
         /// <param name="parameterName">The name of the parameter.</param>
         /// <param name="parameterType">The type of the parameter.</param>
         /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
         /// <param name="pullAction">An optional delegate that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
         ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.
         /// </param>
@@ -898,7 +898,7 @@ namespace Metalama.Framework.Advising
         /// <param name="parameterName">The name of the parameter.</param>
         /// <param name="parameterType">The type of the parameter.</param>
         /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+        ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
         /// <param name="pullStrategy">An optional <see cref="IPullStrategy"/> that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
         ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.
         /// </param>

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
@@ -1287,6 +1287,10 @@ public static class AdviserExtensions
     /// <returns>An <see cref="IAddContractAdviceResult{T}"/> exposing the added contract.</returns>
     /// <remarks>
     /// <para>
+    /// <b>Template Access:</b> Within the template, use <c>meta.Target.Expression</c> for unified access to the target as an <see cref="IExpression"/>,
+    /// <c>meta.Target.Parameter</c> for parameter-specific access, and <c>meta.Target.ContractDirection</c> to determine whether you're validating input or output.
+    /// </para>
+    /// <para>
     /// <b>Performance Note:</b> When possible, provide all contracts to the same method from a single aspect. This approach yields better compile-time performance than using several separate aspects.
     /// </para>
     /// <para>
@@ -1295,6 +1299,7 @@ public static class AdviserExtensions
     /// </para>
     /// </remarks>
     /// <seealso cref="ContractAspect"/>
+    /// <seealso cref="IMetaTarget.Expression"/>
     /// <seealso href="@contracts"/>
     /// <seealso href="@contract-patterns"/>
     /// <seealso href="@sharing-state-with-advice"/>
@@ -1325,6 +1330,10 @@ public static class AdviserExtensions
     /// <returns>An <see cref="IAddContractAdviceResult{T}"/> exposing the added contract.</returns>
     /// <remarks>
     /// <para>
+    /// <b>Template Access:</b> Within the template, use <c>meta.Target.Expression</c> for unified access to the target as an <see cref="IExpression"/>,
+    /// <c>meta.Target.FieldOrProperty</c> for field/property-specific access, and <c>meta.Target.ContractDirection</c> to determine whether you're validating input or output.
+    /// </para>
+    /// <para>
     /// <b>Performance Note:</b> When possible, provide all contracts to the same method from a single aspect. This approach yields better compile-time performance than using several separate aspects.
     /// </para>
     /// <para>
@@ -1333,6 +1342,7 @@ public static class AdviserExtensions
     /// </para>
     /// </remarks>
     /// <seealso cref="ContractAspect"/>
+    /// <seealso cref="IMetaTarget.Expression"/>
     /// <seealso href="@contracts"/>
     /// <seealso href="@contract-patterns"/>
     /// <seealso href="@sharing-state-with-advice"/>

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
@@ -1433,7 +1433,7 @@ public static class AdviserExtensions
     /// <param name="parameterName">The name of the parameter.</param>
     /// <param name="parameterType">The type of the parameter.</param>
     /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
     /// <param name="pullAction">An optional delegate that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
     ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.</param>
     /// <param name="attributes">An optional list of custom attributes to add to the introduced parameter.</param>
@@ -1462,7 +1462,7 @@ public static class AdviserExtensions
     /// <param name="parameterName">The name of the parameter.</param>
     /// <param name="parameterType">The type of the parameter.</param>
     /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
     /// <param name="pullStrategy">An optional <see cref="IPullStrategy"/> that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
     ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.</param>
     /// <param name="attributes">An optional list of custom attributes to add to the introduced parameter.</param>
@@ -1514,7 +1514,7 @@ public static class AdviserExtensions
     /// <param name="parameterName">The name of the parameter.</param>
     /// <param name="parameterType">The type of the parameter.</param>
     /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
     /// <param name="pullAction">An optional delegate that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
     ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.</param>
     /// <param name="attributes">An optional list of custom attributes to add to the introduced parameter.</param>
@@ -1543,7 +1543,7 @@ public static class AdviserExtensions
     /// <param name="parameterName">The name of the parameter.</param>
     /// <param name="parameterType">The type of the parameter.</param>
     /// <param name="defaultValue">The default value of the parameter (required). It must be type-compatible with <paramref name="parameterType"/>.
-    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(Metalama.Framework.Code.IType)"/>.</param>
+    ///     To specify <c>default</c> as the default value, use <see cref="TypedConstant.Default(IType, bool)"/>.</param>
     /// <param name="pullStrategy">An optional <see cref="IPullStrategy"/> that returns a <see cref="PullAction"/> specifying how to pull the new parameter from other child constructors.
     ///     A <c>null</c> value is equivalent to <see cref="PullAction.None"/>, i.e. <paramref name="defaultValue"/> of the parameter will be used.</param>
     /// <param name="attributes">An optional list of custom attributes to add to the introduced parameter.</param>

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/ContractAspect.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/ContractAspect.cs
@@ -34,9 +34,9 @@ namespace Metalama.Framework.Aspects
     /// <b>Accessing Metadata:</b> In your <see cref="Validate"/> template, you can access the target context using:
     /// </para>
     /// <list type="bullet">
-    /// <item><description><c>meta.Target.Declaration</c> - Returns the target parameter, property, or field.</description></item>
+    /// <item><description><c>meta.Target.Expression</c> - Returns the target field, property, or parameter as a unified <see cref="IExpression"/>.</description></item>
     /// <item><description><c>meta.Target.FieldOrProperty</c> - Returns the target property or field (throws if applied to a parameter).</description></item>
-    /// <item><description><c>meta.Target.Parameter</c> - Returns the parameter including return value parameter (throws if applied to a field or property).</description></item>
+    /// <item><description><c>meta.Target.Parameter</c> - Returns the target parameter (throws if applied to a field or property).</description></item>
     /// <item><description><c>meta.Target.ContractDirection</c> - Returns <see cref="ContractDirection.Input"/> or <see cref="ContractDirection.Output"/> according to the data flow being validated.</description></item>
     /// </list>
     /// <para>
@@ -389,8 +389,8 @@ namespace Metalama.Framework.Aspects
         /// </para>
         /// <para>
         /// Within the template, use <c>meta.Target.ContractDirection</c> to determine whether you're validating input or output flow.
-        /// Access the target declaration through <c>meta.Target.Declaration</c>, <c>meta.Target.FieldOrProperty</c>, or
-        /// <c>meta.Target.Parameter</c> depending on the target type.
+        /// Access the target through <c>meta.Target.Expression</c> (unified access to field, property, or parameter),
+        /// or use <c>meta.Target.FieldOrProperty</c> / <c>meta.Target.Parameter</c> for specific access.
         /// </para>
         /// <para>
         /// To reject invalid values, throw an appropriate exception (typically <see cref="ArgumentException"/> for parameters,

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/IMetaTarget.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/IMetaTarget.cs
@@ -75,6 +75,21 @@ namespace Metalama.Framework.Aspects
         IDeclaration Declaration { get; }
 
         /// <summary>
+        /// Gets the target field, property, or parameter as a unified <see cref="IExpression"/>,
+        /// or throws an exception if the declaration does not implement <see cref="IExpression"/>.
+        /// </summary>
+        /// <remarks>
+        /// This property is useful when authoring contract templates because it provides unified access to <see cref="IField"/>, <see cref="IProperty"/>, and <see cref="IParameter"/>
+        /// as an <see cref="IExpression"/>.
+        /// </remarks>
+        /// <seealso cref="Field"/>
+        /// <seealso cref="FieldOrProperty"/>
+        /// <seealso cref="Parameter"/>
+        /// <seealso cref="IExpression"/>
+        /// <seealso href="@templates"/>
+        IExpression Expression { get; }
+
+        /// <summary>
         /// Gets the target member (method, constructor, field, property or event, but not a nested type), or
         /// throws an exception if the advice does not target a member.
         /// </summary>

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/ISyntaxBuilderImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/ISyntaxBuilderImpl.cs
@@ -74,5 +74,6 @@ internal interface ISyntaxBuilderImpl
 
     IExpression ReceiverExpression( IDeclaration declaration );
 
+    /// <inheritdoc cref="ExpressionFactory.WithNullForgivingOperator"/>
     IExpression WithNullForgivingOperator( IExpression expression, bool force );
 }

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/ISyntaxBuilderImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/ISyntaxBuilderImpl.cs
@@ -73,4 +73,6 @@ internal interface ISyntaxBuilderImpl
     bool TryConvertExpressionToTypedConstant( string expression, [NotNullWhen( true )] out TypedConstant? typedConstant );
 
     IExpression ReceiverExpression( IDeclaration declaration );
+
+    IExpression WithNullForgivingOperator( IExpression expression, bool force );
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/INamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/INamedType.cs
@@ -228,6 +228,7 @@ namespace Metalama.Framework.Code
         /// <inheritdoc cref="IDeclaration.ToRef"/>
         new IRef<INamedType> ToRef();
 
+        /// <inheritdoc cref="IType.ToNullable"/>
         new INamedType ToNullable();
 
         // Note that ToNonNullable, when called with Nullable<T>, can return an ITypeParameter and therefore cannot be cast to INamedType.

--- a/Metalama.Framework/src/Metalama.Framework/Code/INamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/INamedType.cs
@@ -231,6 +231,9 @@ namespace Metalama.Framework.Code
         /// <inheritdoc cref="IType.ToNullable"/>
         new INamedType ToNullable();
 
+        /// <inheritdoc cref="IType.StripNullabilityAnnotation"/>
+        new INamedType StripNullabilityAnnotation();
+
         // Note that ToNonNullable, when called with Nullable<T>, can return an ITypeParameter and therefore cannot be cast to INamedType.
 
         /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework/Code/IType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/IType.cs
@@ -146,7 +146,7 @@ namespace Metalama.Framework.Code
         /// If the current type is a <see cref="Nullable{T}"/>, i.e. a nullable value type, returns the underlying type.
         /// </summary>
         /// <remarks>
-        /// Note that for non-value type type parameters, this method strips the nullable annotation, if any,
+        /// Note that for non-value type parameters, this method strips the nullable annotation, if any,
         /// which means it returns a type whose <see cref="IType.IsNullable"/> property returns <see langword="null" />.
         /// This is because C# has no way to express non-nullability for type parameters.
         /// </remarks>

--- a/Metalama.Framework/src/Metalama.Framework/Code/IType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/IType.cs
@@ -139,6 +139,13 @@ namespace Metalama.Framework.Code
         /// Creates a nullable type from the current <see cref="IType"/>. If the current type is already nullable, returns the current type.
         /// If the type is a value type, returns a <see cref="Nullable{T}"/> of this type.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For a value type <c>T</c>, this method returns <see cref="Nullable{T}"/>.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="ToNonNullable"/>
+        /// <seealso cref="StripNullabilityAnnotation"/>
         IType ToNullable();
 
         /// <summary>
@@ -146,10 +153,34 @@ namespace Metalama.Framework.Code
         /// If the current type is a <see cref="Nullable{T}"/>, i.e. a nullable value type, returns the underlying type.
         /// </summary>
         /// <remarks>
-        /// Note that for non-value type parameters, this method strips the nullable annotation, if any,
-        /// which means it returns a type whose <see cref="IType.IsNullable"/> property returns <see langword="null" />.
-        /// This is because C# has no way to express non-nullability for type parameters.
+        /// <para>
+        /// For type parameters without a <c>class</c> or <c>struct</c> constraint, this method always strips the nullable annotation
+        /// because C# has no way to express non-nullability for such type parameters. To unconditionally strip nullability annotations for all types,
+        /// use <see cref="StripNullabilityAnnotation"/> instead.
+        /// </para>
+        /// <para>
+        /// For nullable value types, i.e. <see cref="Nullable{T}"/>, this method returns the underlying type <c>T</c>.
+        /// </para>
         /// </remarks>
+        /// <seealso cref="ToNullable"/>
+        /// <seealso cref="StripNullabilityAnnotation"/>
         IType ToNonNullable();
+
+        /// <summary>
+        /// Strips the nullability annotation from the current type, returning an unannotated version.
+        /// </summary>
+        /// <returns>
+        /// A type whose <see cref="IsNullable"/> property is <see langword="null"/>, meaning the type has no nullability annotation.
+        /// If the current type is a <see cref="Nullable{T}"/>, returns the underlying value type.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// Unlike <see cref="ToNonNullable"/>, which marks reference types as non-nullable (returning a type with <see cref="IsNullable"/>
+        /// set to <see langword="false"/>), this method returns an unannotated type (with <see cref="IsNullable"/> set to <see langword="null"/>).
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="ToNullable"/>
+        /// <seealso cref="ToNonNullable"/>
+        IType StripNullabilityAnnotation();
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/ITypeParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/ITypeParameter.cs
@@ -101,6 +101,9 @@ namespace Metalama.Framework.Code
         /// <inheritdoc cref="IType.ToNonNullable"/>
         new ITypeParameter ToNonNullable();
 
+        /// <inheritdoc cref="IType.StripNullabilityAnnotation"/>
+        new ITypeParameter StripNullabilityAnnotation();
+
         // Note that ToNullable, when called with T : struct, can return the INamedType Nullable<T> and therefore cannot be cast to an ITypeParameter.
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/ITypeParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/ITypeParameter.cs
@@ -98,6 +98,7 @@ namespace Metalama.Framework.Code
 
         TypeParameterKind TypeParameterKind { get; }
 
+        /// <inheritdoc cref="IType.ToNonNullable"/>
         new ITypeParameter ToNonNullable();
 
         // Note that ToNullable, when called with T : struct, can return the INamedType Nullable<T> and therefore cannot be cast to an ITypeParameter.

--- a/Metalama.Framework/src/Metalama.Framework/Code/SpecialType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/SpecialType.cs
@@ -174,6 +174,8 @@ namespace Metalama.Framework.Code
         /// </summary>
         ValueTuple,
 
+        Nullable_T,
+
         // Must be last.
 
         /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework/Code/SyntaxBuilders/ExpressionFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/SyntaxBuilders/ExpressionFactory.cs
@@ -297,6 +297,28 @@ public static class ExpressionFactory
     public static IExpression WithNullability( this IExpression expression, bool isNullable )
         => expression.WithType( isNullable ? expression.Type.ToNullable() : expression.Type.ToNonNullable() );
 
+    /// <summary>
+    /// Returns an expression with the null-forgiving operator (<c>!</c>) applied, suppressing nullable warnings.
+    /// </summary>
+    /// <param name="expression">The expression to which the null-forgiving operator should be applied.</param>
+    /// <param name="force">
+    /// When <see langword="false"/> (the default), the operator is only added if the expression is nullable.
+    /// When <see langword="true"/>, the operator is always added regardless of the expression's nullability.
+    /// </param>
+    /// <returns>
+    /// An expression with the null-forgiving operator applied, or the original expression if the operator is not needed
+    /// and <paramref name="force"/> is <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The null-forgiving operator tells the compiler that an expression is not null, even if the compiler's
+    /// static analysis cannot determine this. Use this method when you know an expression will not be null
+    /// at run time but the compiler cannot verify this.
+    /// </para>
+    /// <para>
+    /// The operator is never added to value types (except <see cref="Nullable{T}"/>) since they cannot be null by definition.
+    /// </para>
+    /// </remarks>
     public static IExpression WithNullForgivingOperator( this IExpression expression, bool force = false )
         => SyntaxBuilder.CurrentImplementation.WithNullForgivingOperator( expression, force );
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/SyntaxBuilders/ExpressionFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/SyntaxBuilders/ExpressionFactory.cs
@@ -296,4 +296,7 @@ public static class ExpressionFactory
     /// </summary>
     public static IExpression WithNullability( this IExpression expression, bool isNullable )
         => expression.WithType( isNullable ? expression.Type.ToNullable() : expression.Type.ToNonNullable() );
+
+    public static IExpression WithNullForgivingOperator( this IExpression expression, bool force = false )
+        => SyntaxBuilder.CurrentImplementation.WithNullForgivingOperator( expression, force );
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/TypedConstant.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/TypedConstant.cs
@@ -43,6 +43,12 @@ namespace Metalama.Framework.Code
         public bool IsInitialized => this._type != null;
 
         /// <summary>
+        /// Gets a value indicating whether the null-forgiving operator (<c>!</c>) should be appended when this <see cref="TypedConstant"/>
+        /// is rendered to code. Only applicable when <see cref="IsNullOrDefault"/> is <c>true</c>.
+        /// </summary>
+        public bool HasNullForgivingOperator { get; }
+
+        /// <summary>
         /// Gets the type of the value. This is important if the type is an enum, because in this case, if the enum type is not compile-time,
         /// <see cref="Value"/> is set to the underlying integer value.
         /// </summary>
@@ -124,8 +130,11 @@ namespace Metalama.Framework.Code
         /// </summary>
         /// <param name="value">The value (even <c>null</c>).</param>
         /// <param name="type">The type of the value.</param>
-        private TypedConstant( object? value, IType type ) : this()
+        /// <param name="hasNullForgivingOperator"></param>
+        private TypedConstant( object? value, IType type, bool hasNullForgivingOperator = false ) : this()
         {
+            this.HasNullForgivingOperator = hasNullForgivingOperator;
+
             if ( value != null )
             {
                 var valueType = value.GetType();
@@ -305,9 +314,29 @@ namespace Metalama.Framework.Code
 
         private static Type FixRuntimeType( Type type ) => type is not ICompileTimeType && typeof(Type).IsAssignableFrom( type ) ? typeof(Type) : type;
 
-        public static TypedConstant Default( IType type ) => new( null, type );
+        /// <summary>
+        /// Creates a <see cref="TypedConstant"/> representing the default value for the specified type.
+        /// When rendered to code, this produces <c>default(T)</c> or <c>default(T)!</c> if <paramref name="hasNullForgivingOperator"/> is <c>true</c>.
+        /// </summary>
+        /// <param name="type">The type for which to create a default value.</param>
+        /// <param name="hasNullForgivingOperator">
+        /// If <c>true</c>, the null-forgiving operator (<c>!</c>) will be appended to the rendered expression.
+        /// </param>
+        /// <returns>A <see cref="TypedConstant"/> representing <c>default(T)</c> or <c>default(T)!</c>.</returns>
+        /// <seealso cref="HasNullForgivingOperator"/>
+        public static TypedConstant Default( IType type, bool hasNullForgivingOperator = false ) => new( null, type, hasNullForgivingOperator );
 
-        public static TypedConstant Default( Type type ) => new( null, GetIType( type ) );
+        /// <summary>
+        /// Creates a <see cref="TypedConstant"/> representing the default value for the specified type.
+        /// When rendered to code, this produces <c>default(T)</c> or <c>default(T)!</c> if <paramref name="hasNullForgivingOperator"/> is <c>true</c>.
+        /// </summary>
+        /// <param name="type">The reflection <see cref="Type"/> for which to create a default value.</param>
+        /// <param name="hasNullForgivingOperator">
+        /// If <c>true</c>, the null-forgiving operator (<c>!</c>) will be appended to the rendered expression.
+        /// </param>
+        /// <returns>A <see cref="TypedConstant"/> representing <c>default(T)</c> or <c>default(T)!</c>.</returns>
+        /// <seealso cref="HasNullForgivingOperator"/>
+        public static TypedConstant Default( Type type, bool hasNullForgivingOperator = false ) => new( null, GetIType( type ), hasNullForgivingOperator );
 
         private static Type GetValueType( object? value )
             => value switch
@@ -347,6 +376,23 @@ namespace Metalama.Framework.Code
         }
 
         public static TypedConstant CreateUnchecked( object? value, IType type ) => new( value, type );
+
+        /// <summary>
+        /// Creates a <see cref="TypedConstant"/> that references a constant field. When rendered to code,
+        /// this produces a reference to the field (e.g., <c>MyClass.MyConstField</c>) instead of the literal value.
+        /// </summary>
+        /// <param name="field">A constant field, i.e., <see cref="IField.ConstantValue"/> must not be <c>null</c>.</param>
+        /// <returns>A <see cref="TypedConstant"/> representing the field reference.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="field"/> is not a constant field.</exception>
+        public static TypedConstant Create( IField field )
+        {
+            if ( field.ConstantValue == null )
+            {
+                throw new ArgumentException( $"The field '{field}' must be a const field.", nameof(field) );
+            }
+
+            return new TypedConstant( field, field.Type );
+        }
 
         internal static TypedConstant UnwrapOrCreate( object? value, IType type )
             => value is TypedConstant typedConstant ? typedConstant : new TypedConstant( value, type );
@@ -420,7 +466,9 @@ namespace Metalama.Framework.Code
             {
                 return this._value switch
                 {
+                    null => Default( this.Type.ForCompilation( compilation ), this.HasNullForgivingOperator ),
                     IType type => Create( type.ForCompilation( compilation ), this.Type.ForCompilation( compilation ) ),
+                    IField field => Create( field.ForCompilation( compilation ) ),
                     ImmutableArray<TypedConstant> array => Create(
                         array.Select( i => i.ForCompilation( compilation ) ).ToImmutableArray(),
                         this.Type.ForCompilation( compilation ) ),
@@ -483,6 +531,9 @@ namespace Metalama.Framework.Code
                 case IType type:
                     return other._value is IType otherType && type.Equals( otherType );
 
+                case IField field:
+                    return other._value is IField otherField && field.Equals( otherField );
+
                 default:
                     return this._value.Equals( other._value );
             }
@@ -514,6 +565,9 @@ namespace Metalama.Framework.Code
 
                 case IType type:
                     return type.GetHashCode();
+
+                case IField field:
+                    return field.GetHashCode();
 
                 default:
                     return this._value.GetHashCode();

--- a/Metalama.Framework/src/Metalama.Framework/Code/Types/IArrayType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/Types/IArrayType.cs
@@ -32,8 +32,10 @@ namespace Metalama.Framework.Code.Types
         /// </summary>
         int Rank { get; }
 
+        /// <inheritdoc cref="IType.ToNullable"/>
         new IArrayType ToNullable();
 
+        /// <inheritdoc cref="IType.ToNonNullable"/>
         new IArrayType ToNonNullable();
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/Types/IArrayType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/Types/IArrayType.cs
@@ -37,5 +37,8 @@ namespace Metalama.Framework.Code.Types
 
         /// <inheritdoc cref="IType.ToNonNullable"/>
         new IArrayType ToNonNullable();
+
+        /// <inheritdoc cref="IType.StripNullabilityAnnotation"/>
+        new IArrayType StripNullabilityAnnotation();
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/Types/IDynamicType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/Types/IDynamicType.cs
@@ -27,5 +27,8 @@ namespace Metalama.Framework.Code.Types
 
         /// <inheritdoc cref="IType.ToNonNullable"/>
         new IDynamicType ToNonNullable();
+
+        /// <inheritdoc cref="IType.StripNullabilityAnnotation"/>
+        new IDynamicType StripNullabilityAnnotation();
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/Types/IDynamicType.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/Types/IDynamicType.cs
@@ -22,8 +22,10 @@ namespace Metalama.Framework.Code.Types
     /// <seealso href="@type-system"/>
     public interface IDynamicType : IType
     {
+        /// <inheritdoc cref="IType.ToNullable"/>
         new IDynamicType ToNullable();
 
+        /// <inheritdoc cref="IType.ToNonNullable"/>
         new IDynamicType ToNonNullable();
     }
 }

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/AspectTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/AspectTestRunner.cs
@@ -538,11 +538,12 @@ internal class AspectTestRunner : BaseTestRunner
         {
             var aspectTestResult = (AspectTestResult) testResult;
 
-            this.RunDiffToolIfDifferent(
+            this.CompareFiles(
                 aspectTestResult.ExpectedProgramOutputText!,
                 aspectTestResult.ExpectedProgramOutputPath!,
                 aspectTestResult.ActualProgramOutputText!,
-                aspectTestResult.ActualProgramOutputPath! );
+                aspectTestResult.ActualProgramOutputPath!,
+                testInput.Options );
         }
 
 #if DEBUG

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/AspectTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/AspectTestRunner.cs
@@ -230,7 +230,7 @@ internal class AspectTestRunner : BaseTestRunner
             var peStream = new MemoryStream();
             var emitResult = resultCompilation.Emit( peStream );
 
-            testResult.OutputCompilationDiagnostics.Report( emitResult.Diagnostics.Where( d => d.Severity == DiagnosticSeverity.Error ) );
+            testResult.OutputCompilationDiagnostics.Report( emitResult.Diagnostics );
 
             if ( !emitResult.Success )
             {
@@ -255,7 +255,7 @@ internal class AspectTestRunner : BaseTestRunner
         }
         else
         {
-            testResult.OutputCompilationDiagnostics.Report( resultCompilation.GetDiagnostics().Where( d => d.Severity == DiagnosticSeverity.Error ) );
+            testResult.OutputCompilationDiagnostics.Report( resultCompilation.GetDiagnostics() );
         }
 
         return true;

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
@@ -667,11 +667,12 @@ internal abstract partial class BaseTestRunner
                 continue;
             }
 
-            hasDifference |= this.RunDiffToolIfDifferent(
+            hasDifference |= this.CompareFiles(
                 syntaxTree.ExpectedTransformedCodeText!,
                 syntaxTree.ExpectedTransformedCodePath!,
                 syntaxTree.ActualTransformedNormalizedCodeText!,
-                syntaxTree.ActualTransformedCodePath! );
+                syntaxTree.ActualTransformedCodePath!,
+                testInput.Options );
 
             actuallyWrittenFiles.Add( syntaxTree.ExpectedTransformedCodePath! );
         }
@@ -706,9 +707,12 @@ internal abstract partial class BaseTestRunner
         }
     }
 
-    protected bool RunDiffToolIfDifferent( string expectedText, string expectedPath, string actualText, string actualPath )
+    protected bool CompareFiles( string expectedText, string expectedPath, string actualText, string actualPath, TestOptions testOptions )
+        => this.CompareFiles( expectedText, expectedPath, actualText, actualPath, testOptions.SkipDiffTool == true );
+
+    protected bool CompareFiles( string expectedText, string expectedPath, string actualText, string actualPath, bool skipDiffTool = false )
     {
-        var useDiff = this._testRunnerOptions.LaunchDiffTool && !DiffRunner.Disabled;
+        var useDiff = this._testRunnerOptions.LaunchDiffTool && !DiffRunner.Disabled && !skipDiffTool;
 
         if ( expectedText != actualText )
         {
@@ -869,7 +873,7 @@ internal abstract partial class BaseTestRunner
             outputDiagnostics =
                 testResult.OutputCompilationDiagnostics
                     .Concat( testResult.PipelineDiagnostics )
-                    .Where( d => d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree.AssertNotNull().FilePath )
+                    .Where( d =>d.Location is { IsInSource: true, SourceTree: not null } && d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree?.FilePath )
                     .Where( testResult.ShouldDiagnosticBeReported )
                     .ToList();
         }

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
@@ -873,7 +873,9 @@ internal abstract partial class BaseTestRunner
             outputDiagnostics =
                 testResult.OutputCompilationDiagnostics
                     .Concat( testResult.PipelineDiagnostics )
-                    .Where( d =>d.Location is { IsInSource: true, SourceTree: not null } && d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree?.FilePath )
+                    .Where(
+                        d => d.Location is { IsInSource: true, SourceTree: not null }
+                             && d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree?.FilePath )
                     .Where( testResult.ShouldDiagnosticBeReported )
                     .ToList();
         }

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
@@ -633,7 +633,7 @@ internal abstract partial class BaseTestRunner
                 logger.WriteLine( "=====================" );
 
                 // Write all diagnostics to the logger.
-                foreach ( var diagnostic in testResult.Diagnostics )
+                foreach ( var diagnostic in testResult.AllDiagnostics )
                 {
                     logger.WriteLine( diagnostic.ToString() );
                 }
@@ -821,12 +821,13 @@ internal abstract partial class BaseTestRunner
         string htmlDirectory,
         HtmlCodeWriter htmlCodeWriter,
         bool writeDiff,
-        ImmutableArray<ScopedSuppression> suppressions,
+        ImmutableArray<ScopedSuppression> designTimeSuppressions,
         CancellationToken cancellationToken )
     {
         StreamWriter? inputTextWriter = null;
         StreamWriter? outputTextWriter = null;
         List<Diagnostic>? inputDiagnostics = null;
+        List<Diagnostic>? outputDiagnostics = null;
 
         if ( testResult.TestInput!.Options.WriteInputHtml == true && testSyntaxTree.InputDocument != null )
         {
@@ -838,31 +839,14 @@ internal abstract partial class BaseTestRunner
 
             inputTextWriter = new StreamWriter( this._fileSystem.Open( testSyntaxTree.HtmlInputPath, FileMode.Create ) );
 
-            // Add diagnostics to the input tree.
-            inputDiagnostics = new List<Diagnostic>();
-
-            inputDiagnostics.AddRange(
-                testResult.Diagnostics.Where( d => d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree.AssertNotNull().FilePath ) );
-
-            var semanticModel = compilationWithDesignTimeTrees.AssertNotNull().GetSemanticModel( testSyntaxTree.InputSyntaxTree.AssertNotNull() );
-
-            foreach ( var diagnostic in semanticModel.GetDiagnostics().Where( d => !testResult.TestInput.ShouldIgnoreDiagnostic( d.Id ) ) )
-            {
-                // Check if any suppression applies to this diagnostic.
-                if ( suppressions.Any(
-                        s => s.Suppression.Definition.SuppressedDiagnosticId == diagnostic.Id
-                             && s.GetScopeSymbolOrNull( compilationWithDesignTimeTrees.GetCompilationContext() )
-                                 .DeclaringSyntaxReferences.Any(
-                                     r =>
-                                         r.SyntaxTree == diagnostic.Location.SourceTree &&
-                                         r.Span.Contains( diagnostic.Location.SourceSpan ) ) ) )
-                {
-                    return;
-                }
-
-                // Add the diagnostic.
-                inputDiagnostics.Add( diagnostic );
-            }
+            // We must render the input buffer including all design-time syntax trees and suppressions
+            // because it needs to look like what the user sees in the IDE.
+            inputDiagnostics =
+                compilationWithDesignTimeTrees.GetDiagnostics()
+                    .Concat( testResult.PipelineDiagnostics )
+                    .Where( d => d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree.AssertNotNull().FilePath )
+                    .Where( d => testResult.ShouldDiagnosticBeReported( d, designTimeSuppressions ) )
+                    .ToList();
         }
 
         if ( testResult.TestInput.Options.WriteOutputHtml == true && testResult.OutputProject != null )
@@ -881,6 +865,13 @@ internal abstract partial class BaseTestRunner
             this.Logger?.WriteLine( "HTML of output: " + testSyntaxTree.HtmlOutputPath );
 
             outputTextWriter = new StreamWriter( this._fileSystem.Open( testSyntaxTree.HtmlOutputPath, FileMode.Create ) );
+
+            outputDiagnostics =
+                testResult.OutputCompilationDiagnostics
+                    .Concat( testResult.PipelineDiagnostics )
+                    .Where( d => d.Location.SourceTree?.FilePath == testSyntaxTree.InputSyntaxTree.AssertNotNull().FilePath )
+                    .Where( testResult.ShouldDiagnosticBeReported )
+                    .ToList();
         }
 
         if ( writeDiff && inputTextWriter != null && outputTextWriter != null && testSyntaxTree.InputDocument != null )
@@ -893,7 +884,8 @@ internal abstract partial class BaseTestRunner
                     testSyntaxTree.OutputDocument.AssertNotNull(),
                     inputTextWriter,
                     outputTextWriter,
-                    inputDiagnostics!,
+                    inputDiagnostics,
+                    outputDiagnostics,
                     cancellationToken );
             }
         }
@@ -918,7 +910,8 @@ internal abstract partial class BaseTestRunner
                     await htmlCodeWriter.WriteAsync(
                         testSyntaxTree.OutputDocument.AssertNotNull(),
                         outputTextWriter,
-                        cancellationToken: cancellationToken );
+                        outputDiagnostics,
+                        cancellationToken );
                 }
             }
         }

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/DesignTimeTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/DesignTimeTestRunner.cs
@@ -55,7 +55,7 @@ namespace Metalama.Testing.AspectTesting
                                 .Select( ( x, i ) => x.GeneratedSyntaxTree.WithFilePath( $"{i}.cs" ) ) );
 
                     testResult.OutputCompilation = outputCompilation;
-                    testResult.OutputCompilationDiagnostics.Report( outputCompilation.GetDiagnostics().Where( d => d.Severity == DiagnosticSeverity.Error ) );
+                    testResult.OutputCompilationDiagnostics.Report( outputCompilation.GetDiagnostics() );
 
                     await testResult.SetOutputCompilationAsync( outputCompilation );
                 }

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestOptions.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestOptions.cs
@@ -56,7 +56,7 @@ public class TestOptions
     /// <summary>
     /// Gets or sets a value indicating whether the diagnostics of the compilation of the transformed target code should be included in the test result.
     /// This is useful when diagnostic suppression is being tested.
-    /// To enable this option in a test, add this comment to your test file: <c>// @ReportOutputWarnings</c>. 
+    /// To enable this option in a test, add this comment to your test file: <c>// @ReportOutputWarnings</c>.
     /// </summary>
     public bool? ReportOutputWarnings { get; set; }
 

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestOptions.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestOptions.cs
@@ -54,13 +54,6 @@ public class TestOptions
     public bool IsSkipped => this.SkipReason != null;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the diagnostics of the compilation of the transformed target code should be included in the test result.
-    /// This is useful when diagnostic suppression is being tested.
-    /// To enable this option in a test, add this comment to your test file: <c>// @ReportOutputWarnings</c>.
-    /// </summary>
-    public bool? ReportOutputWarnings { get; set; }
-
-    /// <summary>
     /// Gets or sets a value indicating whether the output file must be compiled into a binary (e.g. emitted).
     /// To enable this option in a test, add this comment to your test file: <c>// @OutputCompilationDisabled</c>.
     /// </summary>
@@ -164,7 +157,7 @@ public class TestOptions
     public bool? NullabilityDisabled { get; set; }
 
     /// <summary>
-    /// Gets a list of warnings that are not reported even if <see cref="ReportOutputWarnings"/> is set to <c>true</c>.
+    /// Gets a list of warnings that are not reported.
     /// To add an item into this collection from a test, add this comment to your test file: <c>// @IgnoredDiagnostic(id)</c>.
     /// </summary>
     public List<string> IgnoredDiagnostics { get; } = new();
@@ -375,9 +368,15 @@ public class TestOptions
 
     /// <summary>
     /// Gets or sets the seed for the random number generator. The default value is random when <see cref="Repeat"/> is <c>1</c>, or <c>0</c>
-    /// otherwise. To change this option in a test, add this comment to your test file: <c>// @RandomSeed(int)</c>. 
+    /// otherwise. To change this option in a test, add this comment to your test file: <c>// @RandomSeed(int)</c>.
     /// </summary>
     public int? RandomSeed { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the diff tool should be prevented from opening when test output differs from expected.
+    /// The default value is <c>false</c>. To enable this option in a test, add this comment to your test file: <c>// @SkipDiffTool</c>.
+    /// </summary>
+    public bool? SkipDiffTool { get; set; }
 
     internal void SetFullPaths( string directory )
     {
@@ -394,8 +393,6 @@ public class TestOptions
     internal virtual void ApplyBaseOptions( TestDirectoryOptions baseOptions )
     {
         this.SkipReason ??= baseOptions.SkipReason;
-
-        this.ReportOutputWarnings ??= baseOptions.ReportOutputWarnings;
 
         this.OutputCompilationDisabled ??= baseOptions.OutputCompilationDisabled;
 
@@ -481,6 +478,8 @@ public class TestOptions
         this.Repeat ??= baseOptions.Repeat;
 
         this.RandomSeed ??= baseOptions.RandomSeed;
+
+        this.SkipDiffTool ??= baseOptions.SkipDiffTool;
     }
 
     public IReadOnlyList<string> InvalidSourceOptions => this._invalidSourceOptions;
@@ -510,11 +509,6 @@ public class TestOptions
 
             switch ( optionName )
             {
-                case "ReportOutputWarnings":
-                    this.ReportOutputWarnings = true;
-
-                    break;
-
                 case "OutputCompilationDisabled":
                     this.OutputCompilationDisabled = true;
 
@@ -807,6 +801,11 @@ public class TestOptions
 
                 case "RandomSeed":
                     this.RandomSeed = int.Parse( optionArg, CultureInfo.InvariantCulture );
+
+                    break;
+
+                case "SkipDiffTool":
+                    this.SkipDiffTool = true;
 
                     break;
 

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestResult.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestResult.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CompileTime;
 using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Compiler;
 using Metalama.Framework.Engine.Formatting;
 using Metalama.Framework.Engine.Utilities;
 using Metalama.Testing.UnitTesting;
@@ -23,6 +24,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Metalama.Testing.AspectTesting;
+
+internal enum DiagnosticOrigin { InputCompilation, OutputCompilation, Pipeline };
 
 /// <summary>
 /// Represents the result of a test run.
@@ -46,48 +49,67 @@ internal class TestResult : IDisposable
 
     public IDiagnosticBag PipelineDiagnostics { get; } = new DiagnosticBag();
 
-    // We don't add the CompileTimeCompilationDiagnostics to Diagnostics because they are already in PipelineDiagnostics.
-    public IEnumerable<Diagnostic> Diagnostics
+    public bool ShouldDiagnosticBeReported( Diagnostic diagnostic ) => this.ShouldDiagnosticBeReported( diagnostic, this.DiagnosticSuppressions );
+
+    public bool ShouldDiagnosticBeReported( Diagnostic diagnostic, IEnumerable<ScopedSuppression> suppressions )
     {
-        get
+        // When IncludeAllSeverities is set, report all diagnostics regardless of severity.
+        if ( this.TestInput?.Options.IncludeAllSeverities != true )
         {
             var minimalSeverity = this.TestInput?.Options.ReportOutputWarnings == true ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error;
 
-            var allDiagnostics = this.OutputCompilationDiagnostics.Where( d => d.Severity >= minimalSeverity )
-                .Concat( this.PipelineDiagnostics )
-                .Concat( this.InputCompilationDiagnostics );
-
-            return allDiagnostics.Where( MustBeReported );
-
-            bool MustBeReported( Diagnostic d )
+            if ( diagnostic.Severity < minimalSeverity )
             {
-                if ( d.Id == "CS1701" )
-                {
-                    // Ignore warning CS1701: Assuming assembly reference "Assembly Name #1" matches "Assembly Name #2", you may need to supply runtime policy.
-                    // This warning is ignored by MSBuild anyway.
-                    return false;
-                }
-
-                if ( this.TestInput?.ShouldIgnoreDiagnostic( d.Id ) == true )
-                {
-                    return false;
-                }
-
-                foreach ( var suppression in this.DiagnosticSuppressions )
-                {
-                    if ( suppression.Matches( d, this.InputCompilation!, filter => filter() ) )
-                    {
-                        return false;
-                    }
-
-                    if ( suppression.Matches( d, this.OutputCompilation!, filter => filter() ) )
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+                return false;
             }
+        }
+
+        if ( diagnostic.Id == "CS1701" )
+        {
+            // Ignore warning CS1701: Assuming assembly reference "Assembly Name #1" matches "Assembly Name #2", you may need to supply runtime policy.
+            // This warning is ignored by MSBuild anyway.
+            return false;
+        }
+
+        if ( this.TestInput?.ShouldIgnoreDiagnostic( diagnostic.Id ) == true )
+        {
+            return false;
+        }
+
+        foreach ( var suppression in suppressions )
+        {
+            if ( suppression.Matches( diagnostic, this.InputCompilation!, filter => filter() ) )
+            {
+                return false;
+            }
+
+            if ( suppression.Matches( diagnostic, this.OutputCompilation!, filter => filter() ) )
+            {
+                return false;
+            }
+        }
+
+        // Warnings in introduced code (see annotation) are always ignored.
+        if ( diagnostic.Severity < DiagnosticSeverity.Error && this.IsInGeneratedCode( diagnostic ) )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    // We don't add the CompileTimeCompilationDiagnostics to Diagnostics because they are already in PipelineDiagnostics.
+    public IEnumerable<(Diagnostic Diagnostic, DiagnosticOrigin Origin)> AllDiagnostics
+    {
+        get
+        {
+            var allDiagnostics = this.OutputCompilationDiagnostics
+                .Select( d => (d, DiagnosticOrigin.OutputCompilation) )
+                .Concat( this.PipelineDiagnostics.Select( d => (d, DiagnosticOrigin.Pipeline) ) )
+                .Concat( this.InputCompilationDiagnostics.Select( d => (d, DiagnosticOrigin.InputCompilation) ) )
+                .Where( d => this.ShouldDiagnosticBeReported( d.Item1 ) );
+
+            return allDiagnostics;
         }
     }
 
@@ -335,6 +357,37 @@ internal class TestResult : IDisposable
         return default;
     }
 
+    private bool IsInGeneratedCode( Diagnostic diagnostic )
+    {
+        var syntaxTree = diagnostic.Location.SourceTree;
+
+        if ( syntaxTree == null )
+        {
+            return false;
+        }
+
+        var root = syntaxTree.GetRoot();
+        var node = root.FindNode( diagnostic.Location.SourceSpan, getInnermostNodeForTie: true );
+
+        // Walk up the tree looking for annotations.
+        for ( var n = node; n != null; n = n.Parent )
+        {
+            // If we hit a source code annotation, we're not in generated code.
+            if ( n.HasAnnotation( FormattingAnnotations.SourceCodeAnnotation ) )
+            {
+                return false;
+            }
+
+            // If we hit a generated code annotation, we're in generated code.
+            if ( n.HasAnnotations( MetalamaCompilerAnnotations.GeneratedCodeAnnotationKind ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Gets the content of the <c>.t.cs</c> file, i.e. the output transformed code with comments
     /// for diagnostics.
@@ -384,9 +437,9 @@ internal class TestResult : IDisposable
         // Assign diagnostics to syntax trees.
         var diagnosticsBySyntaxTree = new Dictionary<TestSyntaxTree, List<Diagnostic>>();
 
-        foreach ( var diagnostic in this.Diagnostics )
+        foreach ( var diagnostic in this.AllDiagnostics )
         {
-            var diagnosticsSourceFilePath = diagnostic.Location.SourceTree?.FilePath;
+            var diagnosticsSourceFilePath = diagnostic.Diagnostic.Location.SourceTree?.FilePath;
 
             if ( diagnosticsSourceFilePath != null && outputTreesByFilePath.TryGetValue( diagnosticsSourceFilePath, out var diagnosticSourceSyntaxTree ) )
             {
@@ -396,7 +449,7 @@ internal class TestResult : IDisposable
                     diagnosticsBySyntaxTree.Add( diagnosticSourceSyntaxTree, diagnostics );
                 }
 
-                diagnostics.Add( diagnostic );
+                diagnostics.Add( diagnostic.Diagnostic );
             }
             else if ( primaryOutputTree != null )
             {
@@ -406,7 +459,7 @@ internal class TestResult : IDisposable
                     diagnosticsBySyntaxTree.Add( primaryOutputTree, diagnostics );
                 }
 
-                diagnostics.Add( diagnostic );
+                diagnostics.Add( diagnostic.Diagnostic );
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestResult.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/TestResult.cs
@@ -54,14 +54,11 @@ internal class TestResult : IDisposable
     public bool ShouldDiagnosticBeReported( Diagnostic diagnostic, IEnumerable<ScopedSuppression> suppressions )
     {
         // When IncludeAllSeverities is set, report all diagnostics regardless of severity.
-        if ( this.TestInput?.Options.IncludeAllSeverities != true )
-        {
-            var minimalSeverity = this.TestInput?.Options.ReportOutputWarnings == true ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error;
+        var minimalSeverity = this.TestInput?.Options.IncludeAllSeverities == true ? DiagnosticSeverity.Hidden : DiagnosticSeverity.Warning;
 
-            if ( diagnostic.Severity < minimalSeverity )
-            {
-                return false;
-            }
+        if ( diagnostic.Severity < minimalSeverity )
+        {
+            return false;
         }
 
         if ( diagnostic.Id == "CS1701" )
@@ -90,7 +87,7 @@ internal class TestResult : IDisposable
         }
 
         // Warnings in introduced code (see annotation) are always ignored.
-        if ( diagnostic.Severity < DiagnosticSeverity.Error && this.IsInGeneratedCode( diagnostic ) )
+        if ( diagnostic.Severity < DiagnosticSeverity.Error && IsInGeneratedCode( diagnostic ) )
         {
             return false;
         }
@@ -357,7 +354,7 @@ internal class TestResult : IDisposable
         return default;
     }
 
-    private bool IsInGeneratedCode( Diagnostic diagnostic )
+    private static bool IsInGeneratedCode( Diagnostic diagnostic )
     {
         var syntaxTree = diagnostic.Location.SourceTree;
 

--- a/Metalama.Framework/src/tests/Metalama.AspectWorkbench/ViewModels/MainViewModel.cs
+++ b/Metalama.Framework/src/tests/Metalama.AspectWorkbench/ViewModels/MainViewModel.cs
@@ -222,7 +222,7 @@ namespace Metalama.AspectWorkbench.ViewModels
                         // Display the annotated syntax tree.
                         this.ColoredSourceCodeDocument = await syntaxColorizer.WriteSyntaxColoringAsync(
                             testResult.SyntaxTrees.First().InputDocument,
-                            diagnostics: testResult.Diagnostics );
+                            diagnostics: testResult.AllDiagnostics.Select( d => d.Diagnostic ) );
                     }
 
                     var transformedTemplateSyntax = testSyntaxTree.OutputCompileTimeSyntaxRoot;
@@ -337,14 +337,14 @@ namespace Metalama.AspectWorkbench.ViewModels
                     }
                 }
 
-                var errors = testResult.Diagnostics;
+                var errors = testResult.AllDiagnostics;
 
                 errorsDocument.Blocks.AddRange(
                     errors.Select(
                         e => new Paragraph(
                             new Run( e.ToString() )
                             {
-                                Foreground = e.Severity switch
+                                Foreground = e.Diagnostic.Severity switch
                                 {
                                     DiagnosticSeverity.Error => Brushes.Red,
                                     DiagnosticSeverity.Warning => Brushes.Chocolate,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Runners/HighlightingTestRunner.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Runners/HighlightingTestRunner.cs
@@ -174,7 +174,7 @@ namespace Metalama.Framework.Tests.AspectTests.Runners
             var htmlPath = actualHtmlPath;
             var actualHighlightedSource = TestOutputNormalizer.NormalizeEndOfLines( File.ReadAllText( htmlPath ) );
 
-            var hasDifference = this.RunDiffToolIfDifferent( expectedHighlightedSource, expectedHtmlPath, actualHighlightedSource, htmlPath );
+            var hasDifference = this.CompareFiles( expectedHighlightedSource, expectedHtmlPath, actualHighlightedSource, htmlPath );
 
             if ( hasDifference )
             {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Runners/HighlightingTestRunner.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Runners/HighlightingTestRunner.cs
@@ -115,7 +115,7 @@ namespace Metalama.Framework.Tests.AspectTests.Runners
             Assert.NotNull( testInput.ProjectDirectory );
             Assert.NotNull( testInput.RelativePath );
 
-            foreach ( var diagnostic in testResult.Diagnostics )
+            foreach ( var diagnostic in testResult.AllDiagnostics )
             {
                 this.Logger?.WriteLine( diagnostic.ToString() );
             }
@@ -162,7 +162,10 @@ namespace Metalama.Framework.Tests.AspectTests.Runners
         {
             this.Logger?.WriteLine( "Actual HTML: " + actualHtmlPath );
 
-            Assert.True( File.Exists( expectedHtmlPath ), $"The expected HTML file '{expectedHtmlPath}' does not exist." );
+            if ( !File.Exists( expectedHtmlPath ) )
+            {
+                File.WriteAllText( expectedHtmlPath, "TODO: Replace this file with the expected/accepted HTML." );
+            }
 
             this.Logger?.WriteLine( "Expected HTML: " + expectedHtmlPath );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Runners/HighlightingTestRunner.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Runners/HighlightingTestRunner.cs
@@ -138,7 +138,7 @@ namespace Metalama.Framework.Tests.AspectTests.Runners
                         Path.GetDirectoryName( sourceAbsolutePath )!,
                         Path.GetFileNameWithoutExtension( sourceAbsolutePath ) + FileExtensions.InputHtml );
 
-                    this.CompareHtmlFiles( syntaxTree.HtmlInputPath!, expectedInputHtmlPath );
+                    this.CompareHtmlFiles( syntaxTree.HtmlInputPath!, expectedInputHtmlPath, testInput.Options );
                 }
             }
 
@@ -153,12 +153,12 @@ namespace Metalama.Framework.Tests.AspectTests.Runners
                         Path.GetDirectoryName( testInput.FullPath )!,
                         syntaxTree.ShortName + extension );
 
-                    this.CompareHtmlFiles( syntaxTree.HtmlOutputPath.AssertNotNull(), expectedOutputHtmlPath );
+                    this.CompareHtmlFiles( syntaxTree.HtmlOutputPath.AssertNotNull(), expectedOutputHtmlPath, testInput.Options );
                 }
             }
         }
 
-        private void CompareHtmlFiles( string actualHtmlPath, string expectedHtmlPath )
+        private void CompareHtmlFiles( string actualHtmlPath, string expectedHtmlPath, TestOptions testOptions )
         {
             this.Logger?.WriteLine( "Actual HTML: " + actualHtmlPath );
 
@@ -174,7 +174,7 @@ namespace Metalama.Framework.Tests.AspectTests.Runners
             var htmlPath = actualHtmlPath;
             var actualHighlightedSource = TestOutputNormalizer.NormalizeEndOfLines( File.ReadAllText( htmlPath ) );
 
-            var hasDifference = this.CompareFiles( expectedHighlightedSource, expectedHtmlPath, actualHighlightedSource, htmlPath );
+            var hasDifference = this.CompareFiles( expectedHighlightedSource, expectedHtmlPath, actualHighlightedSource, htmlPath, testOptions );
 
             if ( hasDifference )
             {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_FieldReference.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_FieldReference.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System.Linq;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.AppendParameter.TypedConstant_FieldReference;
+
+public class AddParameterWithFieldReference : ConstructorAspect
+{
+    public override void BuildAspect( IAspectBuilder<IConstructor> builder )
+    {
+        base.BuildAspect( builder );
+
+        // Get the const field from the target type
+        var constField = builder.Target.DeclaringType.Fields.Single( f => f.Name == "DefaultValue" );
+
+        // Create a TypedConstant that references the const field
+        builder.IntroduceParameter(
+            "arg1",
+            typeof(int),
+            TypedConstant.Create( constField ) );
+    }
+}
+
+// <target>
+internal class TargetCode
+{
+    public const int DefaultValue = 42;
+
+    [AddParameterWithFieldReference]
+    private TargetCode( string name ) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_FieldReference.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_FieldReference.t.cs
@@ -1,0 +1,8 @@
+internal class TargetCode
+{
+  public const int DefaultValue = 42;
+  [AddParameterWithFieldReference]
+  private TargetCode(string name, global::System.Int32 arg1 = global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.AppendParameter.TypedConstant_FieldReference.TargetCode.DefaultValue)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_NullForgivingOperator.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_NullForgivingOperator.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.AppendParameter.TypedConstant_NullForgivingOperator;
+
+public class AddParameterWithNullForgiving : ConstructorAspect
+{
+    public override void BuildAspect( IAspectBuilder<IConstructor> builder )
+    {
+        base.BuildAspect( builder );
+
+        // Non-nullable string parameter with null-forgiving operator on default value.
+        // Should generate: string arg1 = default(string)!
+        builder.IntroduceParameter(
+            "arg1",
+            typeof(string),
+            TypedConstant.Default( typeof(string), hasNullForgivingOperator: true ) );
+
+        // Non-nullable string parameter without null-forgiving operator.
+        // Should generate: string arg2 = default(string)
+        builder.IntroduceParameter(
+            "arg2",
+            typeof(string),
+            TypedConstant.Default( typeof(string), hasNullForgivingOperator: false ) );
+    }
+}
+
+// <target>
+internal class TargetCode
+{
+    [AddParameterWithNullForgiving]
+    private TargetCode( int i ) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_NullForgivingOperator.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/TypedConstant_NullForgivingOperator.t.cs
@@ -1,0 +1,7 @@
+internal class TargetCode
+{
+  [AddParameterWithNullForgiving]
+  private TargetCode(int i, global::System.String arg1 = default(global::System.String)!, global::System.String arg2 = default(global::System.String))
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug30448.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug30448.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 
 #pragma warning disable CS8618, CS8602
 
@@ -14,7 +13,7 @@ internal class TrimAttribute : ContractAspect
 {
     public override void Validate( dynamic? value )
     {
-        if ( ((IHasType) meta.Target.Declaration).Type.IsNullable == true )
+        if ( meta.Target.Expression.Type.IsNullable == true )
         {
             value = value?.Trim();
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug30448.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug30448.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
 
 #pragma warning disable CS8618, CS8602
 
@@ -13,7 +14,14 @@ internal class TrimAttribute : ContractAspect
 {
     public override void Validate( dynamic? value )
     {
-        value = value?.Trim();
+        if ( ((IHasType) meta.Target.Declaration).Type.IsNullable == true )
+        {
+            value = value?.Trim();
+        }
+        else
+        {
+            value = value.Trim();
+        }
     }
 }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Property_IntroducedInterface.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Property_IntroducedInterface.t.cs
@@ -8,7 +8,7 @@ internal record Target : global::Metalama.Framework.Tests.AspectTests.Tests.Aspe
     {
       global::System.String? returnValue;
       global::System.Console.WriteLine("Introduced.");
-      returnValue = default(global::System.String? )!;
+      returnValue = default(global::System.String? );
       if (returnValue == null)
       {
         throw new global::System.ArgumentNullException("Metalama.Framework.Tests.AspectTests.Tests.Aspects.Contracts.Property_IntroducedInterface.I.M");

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/Covariant.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/Covariant.0.i.cs
@@ -14,7 +14,7 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covarian
     {
       get
       {
-        return default(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covariant.B? )!;
+        return default(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covariant.B? );
       }
     }
     public virtual global::System.String NonCovariantProperty

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/Covariant.1.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/Covariant.1.i.cs
@@ -10,7 +10,7 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covarian
     {
       get
       {
-        return default(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covariant.D? )!;
+        return default(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covariant.D? );
       }
     }
     public override global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.DesignTime.Covariant.D? this[global::System.Int32 index]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/ExtensionMethods/Conditional_Statement.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/ExtensionMethods/Conditional_Statement.t.cs
@@ -8,7 +8,7 @@ private object Method()
   if (numbers is { } numbers_1)
     if (global::System.Linq.LinqExtensions.ToReadOnlyList(numbers_1)is { } iReadOnlyList)
       global::System.Linq.LinqExtensions.ToReadOnlyList(iReadOnlyList);
-  if (global::System.Linq.LinqExtensions.ToReadOnlyList(numbers)is { } iReadOnlyList_1)
+  if (global::System.Linq.LinqExtensions.ToReadOnlyList(numbers!)is { } iReadOnlyList_1)
     global::System.Linq.LinqExtensions.ToReadOnlyList(iReadOnlyList_1);
   if (numbers is { } numbers_2)
     global::System.Linq.LinqExtensions.ToReadOnlyList(global::System.Linq.LinqExtensions.ToReadOnlyList(numbers_2));

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicMetaParameterExclamationMark.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicMetaParameterExclamationMark.cs
@@ -33,47 +33,49 @@ internal class TargetCode
         [Aspect]
         private void NullableReferenceType( string? s ) { }
 
+        // t1 has no nullability annotation and we cannot detect if ! is redundant
+        // without more complex analysis.
         [Aspect]
-        private void Generic<T>( T t ) { }
+        private void Generic<T>( T t1 ) { }
 
         [Aspect]
-        private void NullableGeneric<T>( T? t ) { }
+        private void NullableGeneric<T>( T? t2 ) { }
 
         [Aspect]
-        private void NotNullGeneric<T>( T t ) where T : notnull { }
+        private void NotNullGeneric<T>( T t3 ) where T : notnull { }
 
         [Aspect]
-        private void NullableNotNullGeneric<T>( T? t ) where T : notnull { }
+        private void NullableNotNullGeneric<T>( T? t4 ) where T : notnull { }
 
         [Aspect]
-        private void ValueTypeGeneric<T>( T t ) where T : struct { }
+        private void ValueTypeGeneric<T>( T t5 ) where T : struct { }
 
         [Aspect]
-        private void NullableValueTypeGeneric<T>( T? t ) where T : struct { }
+        private void NullableValueTypeGeneric<T>( T? t6 ) where T : struct { }
 
         [Aspect]
-        private void ReferenceTypeGeneric<T>( T t ) where T : class { }
+        private void ReferenceTypeGeneric<T>( T t7 ) where T : class { }
 
         [Aspect]
-        private void NullableReferenceTypeGeneric<T>( T? t ) where T : class { }
+        private void NullableReferenceTypeGeneric<T>( T? t8 ) where T : class { }
 
         [Aspect]
-        private void ReferenceTypeNullableGeneric<T>( T t ) where T : class? { }
+        private void ReferenceTypeNullableGeneric<T>( T t9 ) where T : class? { }
 
         [Aspect]
-        private void NullableReferenceTypeNullableGeneric<T>( T? t ) where T : class? { }
+        private void NullableReferenceTypeNullableGeneric<T>( T? t10 ) where T : class? { }
 
         [Aspect]
-        private void SpecificReferenceTypeGeneric<T>( T t ) where T : IComparable { }
+        private void SpecificReferenceTypeGeneric<T>( T t11 ) where T : IComparable { }
 
         [Aspect]
-        private void SpecificNullableReferenceTypeGeneric<T>( T? t ) where T : IComparable { }
+        private void SpecificNullableReferenceTypeGeneric<T>( T? t12 ) where T : IComparable { }
 
         [Aspect]
-        private void SpecificReferenceTypeNullableGeneric<T>( T t ) where T : IComparable? { }
+        private void SpecificReferenceTypeNullableGeneric<T>( T t13 ) where T : IComparable? { }
 
         [Aspect]
-        private void SpecificNullableReferenceTypeNullableGeneric<T>( T? t ) where T : IComparable? { }
+        private void SpecificNullableReferenceTypeNullableGeneric<T>( T? t14 ) where T : IComparable? { }
     }
 
 #nullable disable
@@ -90,18 +92,18 @@ internal class TargetCode
         private void ReferenceType( string s ) { }
 
         [Aspect]
-        private void Generic<T>( T t ) { }
+        private void Generic<T>( T t15 ) { }
 
         [Aspect]
-        private void ValueTypeGeneric<T>( T t ) where T : struct { }
+        private void ValueTypeGeneric<T>( T t16 ) where T : struct { }
 
         [Aspect]
-        private void NullableValueTypeGeneric<T>( T? t ) where T : struct { }
+        private void NullableValueTypeGeneric<T>( T? t17 ) where T : struct { }
 
         [Aspect]
-        private void ReferenceTypeGeneric<T>( T t ) where T : class { }
+        private void ReferenceTypeGeneric<T>( T t18 ) where T : class { }
 
         [Aspect]
-        private void SpecificReferenceTypeGeneric<T>( T t ) where T : IComparable { }
+        private void SpecificReferenceTypeGeneric<T>( T t19 ) where T : IComparable { }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicMetaParameterExclamationMark.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicMetaParameterExclamationMark.t.cs
@@ -26,100 +26,102 @@ internal class TargetCode
       s!.ToString();
       return;
     }
+    // t1 has no nullability annotation and we cannot detect if ! is redundant
+    // without more complex analysis.
     [Aspect]
-    private void Generic<T>(T t)
+    private void Generic<T>(T t1)
     {
-      t!.ToString();
+      t1!.ToString();
       return;
     }
     [Aspect]
-    private void NullableGeneric<T>(T? t)
+    private void NullableGeneric<T>(T? t2)
     {
-      t!.ToString();
+      t2!.ToString();
       return;
     }
     [Aspect]
-    private void NotNullGeneric<T>(T t)
+    private void NotNullGeneric<T>(T t3)
       where T : notnull
     {
-      t.ToString();
+      t3.ToString();
       return;
     }
     [Aspect]
-    private void NullableNotNullGeneric<T>(T? t)
+    private void NullableNotNullGeneric<T>(T? t4)
       where T : notnull
     {
-      t!.ToString();
+      t4!.ToString();
       return;
     }
     [Aspect]
-    private void ValueTypeGeneric<T>(T t)
+    private void ValueTypeGeneric<T>(T t5)
       where T : struct
     {
-      t.ToString();
+      t5.ToString();
       return;
     }
     [Aspect]
-    private void NullableValueTypeGeneric<T>(T? t)
+    private void NullableValueTypeGeneric<T>(T? t6)
       where T : struct
     {
-      t.ToString();
+      t6.ToString();
       return;
     }
     [Aspect]
-    private void ReferenceTypeGeneric<T>(T t)
+    private void ReferenceTypeGeneric<T>(T t7)
       where T : class
     {
-      t.ToString();
+      t7.ToString();
       return;
     }
     [Aspect]
-    private void NullableReferenceTypeGeneric<T>(T? t)
+    private void NullableReferenceTypeGeneric<T>(T? t8)
       where T : class
     {
-      t!.ToString();
+      t8!.ToString();
       return;
     }
     [Aspect]
-    private void ReferenceTypeNullableGeneric<T>(T t)
+    private void ReferenceTypeNullableGeneric<T>(T t9)
       where T : class?
     {
-      t!.ToString();
+      t9!.ToString();
       return;
     }
     [Aspect]
-    private void NullableReferenceTypeNullableGeneric<T>(T? t)
+    private void NullableReferenceTypeNullableGeneric<T>(T? t10)
       where T : class?
     {
-      t!.ToString();
+      t10!.ToString();
       return;
     }
     [Aspect]
-    private void SpecificReferenceTypeGeneric<T>(T t)
+    private void SpecificReferenceTypeGeneric<T>(T t11)
       where T : IComparable
     {
-      t.ToString();
+      t11.ToString();
       return;
     }
     [Aspect]
-    private void SpecificNullableReferenceTypeGeneric<T>(T? t)
+    private void SpecificNullableReferenceTypeGeneric<T>(T? t12)
       where T : IComparable
     {
-      t!.ToString();
+      t12!.ToString();
       return;
     }
     [Aspect]
-    private void SpecificReferenceTypeNullableGeneric<T>(T t)
+    private void SpecificReferenceTypeNullableGeneric<T>(T t13)
       where T : IComparable?
     {
-      t!.ToString();
+      t13!.ToString();
       return;
     }
     [Aspect]
-    private void SpecificNullableReferenceTypeNullableGeneric<T>(T? t)
+    private void SpecificNullableReferenceTypeNullableGeneric<T>(T? t14)
       where T : IComparable?
     {
-      t!.ToString();
+      t14!.ToString();
       return;
     }
   }
@@ -145,37 +147,37 @@ internal class TargetCode
       return;
     }
     [Aspect]
-    private void Generic<T>(T t)
+    private void Generic<T>(T t15)
     {
-      t.ToString();
+      t15.ToString();
       return;
     }
     [Aspect]
-    private void ValueTypeGeneric<T>(T t)
+    private void ValueTypeGeneric<T>(T t16)
       where T : struct
     {
-      t.ToString();
+      t16.ToString();
       return;
     }
     [Aspect]
-    private void NullableValueTypeGeneric<T>(T? t)
+    private void NullableValueTypeGeneric<T>(T? t17)
       where T : struct
     {
-      t.ToString();
+      t17.ToString();
       return;
     }
     [Aspect]
-    private void ReferenceTypeGeneric<T>(T t)
+    private void ReferenceTypeGeneric<T>(T t18)
       where T : class
     {
-      t.ToString();
+      t18.ToString();
       return;
     }
     [Aspect]
-    private void SpecificReferenceTypeGeneric<T>(T t)
+    private void SpecificReferenceTypeGeneric<T>(T t19)
       where T : IComparable
     {
-      t.ToString();
+      t19.ToString();
       return;
     }
   }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicMetaParameterQuestionMark.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicMetaParameterQuestionMark.t.cs
@@ -17,7 +17,7 @@ internal class TargetCode
     [Aspect]
     private void ReferenceType(string s)
     {
-      s.ToString();
+      s?.ToString();
       return;
     }
     [Aspect]
@@ -42,7 +42,7 @@ internal class TargetCode
     private void NotNullGeneric<T>(T t)
       where T : notnull
     {
-      t.ToString();
+      t?.ToString();
       return;
     }
     [Aspect]
@@ -70,7 +70,7 @@ internal class TargetCode
     private void ReferenceTypeGeneric<T>(T t)
       where T : class
     {
-      t.ToString();
+      t?.ToString();
       return;
     }
     [Aspect]
@@ -98,7 +98,7 @@ internal class TargetCode
     private void SpecificReferenceTypeGeneric<T>(T t)
       where T : IComparable
     {
-      t.ToString();
+      t?.ToString();
       return;
     }
     [Aspect]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterContract.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterContract.cs
@@ -14,7 +14,9 @@ internal class Aspect : ContractAspect
 {
     public override void Validate( dynamic? value )
     {
+        meta.InsertComment( "value?.ToString()" );
         value?.ToString();
+        meta.InsertComment( "value!.ToString()" );
         value!.ToString();
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterContract.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterContract.t.cs
@@ -12,7 +12,9 @@ internal class TargetCode
       }
       set
       {
+        // value?.ToString()
         value?.ToString();
+        // value!.ToString()
         value!.ToString();
         this._field = value;
       }
@@ -27,7 +29,9 @@ internal class TargetCode
       }
       set
       {
+        // value?.ToString()
         value?.ToString();
+        // value!.ToString()
         value!.ToString();
         this._property = value;
       }
@@ -39,7 +43,9 @@ internal class TargetCode
       {
         global::System.String? returnValue;
         returnValue = null;
+        // value?.ToString()
         returnValue?.ToString();
+        // value!.ToString()
         returnValue!.ToString();
         return returnValue;
       }
@@ -47,11 +53,15 @@ internal class TargetCode
     [return: Aspect]
     private string? Method([Aspect] string? arg)
     {
+      // value?.ToString()
       arg?.ToString();
+      // value!.ToString()
       arg!.ToString();
       global::System.String? returnValue;
       returnValue = arg;
+      // value?.ToString()
       returnValue?.ToString();
+      // value!.ToString()
       returnValue!.ToString();
       return returnValue;
     }
@@ -68,7 +78,9 @@ internal class TargetCode
       }
       set
       {
-        value.ToString();
+        // value?.ToString()
+        value?.ToString();
+        // value!.ToString()
         value.ToString();
         this._field = value;
       }
@@ -83,7 +95,9 @@ internal class TargetCode
       }
       set
       {
-        value.ToString();
+        // value?.ToString()
+        value?.ToString();
+        // value!.ToString()
         value.ToString();
         this._property = value;
       }
@@ -95,7 +109,9 @@ internal class TargetCode
       {
         global::System.String returnValue;
         returnValue = null !;
-        returnValue.ToString();
+        // value?.ToString()
+        returnValue?.ToString();
+        // value!.ToString()
         returnValue.ToString();
         return returnValue;
       }
@@ -103,11 +119,15 @@ internal class TargetCode
     [return: Aspect]
     private string Method([Aspect] string arg)
     {
-      arg.ToString();
+      // value?.ToString()
+      arg?.ToString();
+      // value!.ToString()
       arg.ToString();
       global::System.String returnValue;
       returnValue = arg;
-      returnValue.ToString();
+      // value?.ToString()
+      returnValue?.ToString();
+      // value!.ToString()
       returnValue.ToString();
       return returnValue;
     }
@@ -125,7 +145,9 @@ internal class TargetCode
       }
       set
       {
+        // value?.ToString()
         value?.ToString();
+        // value!.ToString()
         value.ToString();
         this._field = value;
       }
@@ -140,7 +162,9 @@ internal class TargetCode
       }
       set
       {
+        // value?.ToString()
         value?.ToString();
+        // value!.ToString()
         value.ToString();
         this._property = value;
       }
@@ -152,7 +176,9 @@ internal class TargetCode
       {
         global::System.String returnValue;
         returnValue = null;
+        // value?.ToString()
         returnValue?.ToString();
+        // value!.ToString()
         returnValue.ToString();
         return returnValue;
       }
@@ -160,11 +186,15 @@ internal class TargetCode
     [return: Aspect]
     private string Method([Aspect] string arg)
     {
+      // value?.ToString()
       arg?.ToString();
+      // value!.ToString()
       arg.ToString();
       global::System.String returnValue;
       returnValue = arg;
+      // value?.ToString()
       returnValue?.ToString();
+      // value!.ToString()
       returnValue.ToString();
       return returnValue;
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterIntroduction.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterIntroduction.cs
@@ -9,7 +9,6 @@
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
-using System.Linq;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Nullable.DynamicParameterIntroduction;
 
@@ -20,32 +19,41 @@ internal class Aspect : TypeAspect
         var objectType = TypeFactory.GetType( typeof(object) );
 
         builder.IntroduceMethod(
-            nameof(Template),
+            nameof(this.Template),
             buildMethod: methodBuilder =>
             {
                 methodBuilder.Name = "Nullable";
-                methodBuilder.Parameters.Single().Type = objectType.ToNullable();
+                methodBuilder.Parameters[0].Name = "nullableArg1";
+                methodBuilder.Parameters[0].Type = objectType.ToNullable();
+                methodBuilder.Parameters[1].Name = "nullableArg2";
+                methodBuilder.Parameters[1].Type = objectType.ToNullable();
             } );
 
         builder.IntroduceMethod(
-            nameof(Template),
+            nameof(this.Template),
             buildMethod: methodBuilder =>
             {
                 methodBuilder.Name = "NonNullable";
-                methodBuilder.Parameters.Single().Type = objectType.ToNonNullable();
+                methodBuilder.Parameters[0].Name = "nonNullableArg1";
+                methodBuilder.Parameters[0].Type = objectType.ToNonNullable();
+                methodBuilder.Parameters[1].Name = "nonNullableArg2";
+                methodBuilder.Parameters[1].Type = objectType.ToNonNullable();
             } );
 
         builder.IntroduceMethod(
-            nameof(Template),
+            nameof(this.Template),
             buildMethod: methodBuilder =>
             {
                 methodBuilder.Name = "Default";
-                methodBuilder.Parameters.Single().Type = objectType;
+                methodBuilder.Parameters[0].Name = "defaultArg1";
+                methodBuilder.Parameters[0].Type = objectType;
+                methodBuilder.Parameters[1].Name = "defaultArg2";
+                methodBuilder.Parameters[1].Type = objectType;
             } );
     }
 
     [Template]
-    private string Template( dynamic? arg ) => arg?.ToString() + arg!.ToString();
+    private string Template( dynamic? arg1, dynamic? arg2 ) => arg1?.ToString() + arg2!.ToString();
 }
 
 // <target>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterIntroduction.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterIntroduction.t.cs
@@ -7,7 +7,7 @@ internal class TargetCode
   }
   private global::System.String NonNullable(global::System.Object nonNullableArg1, global::System.Object nonNullableArg2)
   {
-    return (global::System.String)(nonNullableArg1.ToString() + nonNullableArg2.ToString());
+    return (global::System.String)(nonNullableArg1?.ToString() + nonNullableArg2.ToString());
   }
   private global::System.String Nullable(global::System.Object? nullableArg1, global::System.Object? nullableArg2)
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterIntroduction.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterIntroduction.t.cs
@@ -1,16 +1,16 @@
 [Aspect]
 internal class TargetCode
 {
-  private global::System.String Default(global::System.Object arg)
+  private global::System.String Default(global::System.Object defaultArg1, global::System.Object defaultArg2)
   {
-    return (global::System.String)(arg?.ToString() + arg.ToString());
+    return (global::System.String)(defaultArg1?.ToString() + defaultArg2.ToString());
   }
-  private global::System.String NonNullable(global::System.Object arg)
+  private global::System.String NonNullable(global::System.Object nonNullableArg1, global::System.Object nonNullableArg2)
   {
-    return (global::System.String)(arg.ToString() + arg.ToString());
+    return (global::System.String)(nonNullableArg1.ToString() + nonNullableArg2.ToString());
   }
-  private global::System.String Nullable(global::System.Object? arg)
+  private global::System.String Nullable(global::System.Object? nullableArg1, global::System.Object? nullableArg2)
   {
-    return (global::System.String)(arg?.ToString() + arg!.ToString());
+    return (global::System.String)(nullableArg1?.ToString() + nullableArg2!.ToString());
   }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterQuestionMarkTypes.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterQuestionMarkTypes.t.cs
@@ -15,7 +15,7 @@ internal class TargetCode
     [Aspect]
     private void ReferenceType(string arg)
     {
-      arg.ToString();
+      arg?.ToString();
     }
     [Aspect]
     private void NullableReferenceType(string? arg)
@@ -36,7 +36,7 @@ internal class TargetCode
     private void NotNullGeneric<T>(T arg)
       where T : notnull
     {
-      arg.ToString();
+      arg?.ToString();
     }
     [Aspect]
     private void NullableNotNullGeneric<T>(T? arg)
@@ -60,7 +60,7 @@ internal class TargetCode
     private void ReferenceTypeGeneric<T>(T arg)
       where T : class
     {
-      arg.ToString();
+      arg?.ToString();
     }
     [Aspect]
     private void NullableReferenceTypeGeneric<T>(T? arg)
@@ -84,7 +84,7 @@ internal class TargetCode
     private void SpecificReferenceTypeGeneric<T>(T arg)
       where T : IComparable
     {
-      arg.ToString();
+      arg?.ToString();
     }
     [Aspect]
     private void SpecificNullableReferenceTypeGeneric<T>(T? arg)

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterSyntax.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterSyntax.cs
@@ -15,19 +15,20 @@ internal class Aspect : MethodAspect
 {
     public override void BuildAspect( IAspectBuilder<IMethod> builder )
     {
-        builder.Override( nameof(Template) );
+        builder.Override( nameof(this.Template) );
     }
 
     [Template]
     private void Template( dynamic? arg )
     {
+        meta.InsertComment( "?" );
         var s = arg?.Nullable?.ToString();
         s = arg?.NonNullable?.ToString();
+        var i = arg?[0]?[1];
 
+        meta.InsertComment( "!" );
         s = arg!.Nullable!.ToString();
         s = arg!.NonNullable!.ToString();
-
-        var i = arg?[0]?[1];
         i = arg![0]![1];
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterSyntax.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Nullable/DynamicParameterSyntax.t.cs
@@ -4,22 +4,24 @@ internal class TargetCode
   {
     [Aspect]
     private void ReferenceType(Foo arg)
-    {
-      var s = arg.Nullable?.ToString();
-      s = arg.NonNullable?.ToString();
+    { // ?
+      var s = arg?.Nullable?.ToString();
+      s = arg?.NonNullable?.ToString();
+      var i = arg?[0]?[1];
+      // !
       s = arg.Nullable!.ToString();
       s = arg.NonNullable!.ToString();
-      var i = arg[0]?[1];
       i = arg[0]![1];
     }
     [Aspect]
     private void NullableReferenceType(Foo? arg)
-    {
+    { // ?
       var s = arg?.Nullable?.ToString();
       s = arg?.NonNullable?.ToString();
+      var i = arg?[0]?[1];
+      // !
       s = arg!.Nullable!.ToString();
       s = arg!.NonNullable!.ToString();
-      var i = arg?[0]?[1];
       i = arg![0]![1];
     }
   }
@@ -28,12 +30,13 @@ internal class TargetCode
   {
     [Aspect]
     private void ReferenceType(Foo arg)
-    {
+    { // ?
       var s = arg?.Nullable?.ToString();
       s = arg?.NonNullable?.ToString();
+      var i = arg?[0]?[1];
+      // !
       s = arg.Nullable.ToString();
       s = arg.NonNullable.ToString();
-      var i = arg?[0]?[1];
       i = arg[0][1];
     }
   }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/Method.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/Method.t.cs
@@ -1,3 +1,4 @@
+// Warning CS0219 on `y`: `The variable 'y' is assigned but its value is never used`
 internal class TargetClass
 {
   [SuppressWarning]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/NestedScopes.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/NestedScopes.cs
@@ -6,6 +6,10 @@
 // @ClearIgnoredDiagnostics
 # endif
 
+#if !TESTRUNNER // Disable the warning in the main build, not during tests. (1)
+#pragma warning disable CS0219
+#endif
+
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 using Metalama.Framework.Diagnostics;
@@ -21,9 +25,6 @@ namespace Metalama.Framework.Tests.AspectTests.Aspects.Suppressions.NestedScopes
         [Template]
         public dynamic? Override()
         {
-#if !TESTRUNNER // Disable the warning in the main build, not during tests. (1)
-#pragma warning disable CS0219
-#endif
             var a = 0;
 
             return meta.Proceed();
@@ -31,7 +32,7 @@ namespace Metalama.Framework.Tests.AspectTests.Aspects.Suppressions.NestedScopes
 
         public override void BuildAspect( IAspectBuilder<IMethod> builder )
         {
-            builder.Override( nameof(Override) );
+            builder.Override( nameof(this.Override) );
             builder.Diagnostics.Suppress( _suppression, builder.Target );
         }
     }
@@ -43,6 +44,8 @@ namespace Metalama.Framework.Tests.AspectTests.Aspects.Suppressions.NestedScopes
         private void M2( string m )
         {
 #pragma warning disable CS0219
+
+            // CS0219 not expected.
             var b = 0;
 #pragma warning restore CS0219
 
@@ -50,12 +53,15 @@ namespace Metalama.Framework.Tests.AspectTests.Aspects.Suppressions.NestedScopes
 #pragma warning disable CS0219
 #endif
 
+            // CS0219 not expected.
             var c = 0;
         }
 
         private void M1( string m )
         {
 #pragma warning disable CS0219
+
+            // CS0219 not expected.
             var d = 0;
 #pragma warning restore CS0219
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/NestedScopes.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/NestedScopes.t.cs
@@ -1,4 +1,5 @@
 // Warning CS0219  on `a`: `The variable 'a' is assigned but its value is never used`
+// Warning CS0219 on `e`: `The variable 'e' is assigned but its value is never used`
 internal class TargetClass
 {
   [SuppressWarning]
@@ -6,14 +7,17 @@ internal class TargetClass
   {
     var a = 0;
 #pragma warning disable CS0219
+    // CS0219 not expected.
     var b = 0;
 #pragma warning restore CS0219
+    // CS0219 not expected.
     var c = 0;
     return;
   }
   private void M1(string m)
   {
 #pragma warning disable CS0219
+    // CS0219 not expected.
     var d = 0;
 #pragma warning restore CS0219
     // CS0219 expected

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/OverrideMethod.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/OverrideMethod.cs
@@ -27,14 +27,18 @@ namespace Metalama.Framework.Tests.AspectTests.Aspects.Suppressions.OverrideMeth
         [Template]
         public dynamic? Override()
         {
+            meta.InsertComment( "CS0219 NOT expected because diagnostics from generated code should be suppressed." );
+#pragma warning disable CS0219 // This is to suppress the warning from the input compilation.
             var a = 0;
-
+#if TESTRUNNER
+            #pragma warning restore CS0219
+#endif
             return meta.Proceed();
         }
 
         public override void BuildAspect( IAspectBuilder<IMethod> builder )
         {
-            builder.Override( nameof(Override) );
+            builder.Override( nameof(this.Override) );
             builder.Diagnostics.Suppress( _suppression, builder.Target );
         }
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/OverrideMethod.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Suppressions/OverrideMethod.t.cs
@@ -1,9 +1,10 @@
-// Warning CS0219  on `a`: `The variable 'a' is assigned but its value is never used`
+// Warning CS0219 on `y`: `The variable 'y' is assigned but its value is never used`
 internal class TargetClass
 {
   [SuppressWarning]
   private void M2(string m)
   {
+    // CS0219 NOT expected because diagnostics from generated code should be suppressed.
     var a = 0;
     var x = 0;
     return;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/SyntaxBuilders/NullForgivingOperator.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/SyntaxBuilders/NullForgivingOperator.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code.SyntaxBuilders;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.SyntaxBuilders.NullForgivingOperator;
+
+public class Aspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        meta.InsertComment( "Test with nullable expression - should add !" ); 
+        var nullableString = (object?) ExpressionFactory.Parse( "GetNullableString()" ).WithNullability( true ).WithNullForgivingOperator().Value;
+
+        meta.InsertComment( "Test with null literal - should add !" );
+        var nullLiteral = (object?) ExpressionFactory.Null().WithNullForgivingOperator().Value;
+
+        meta.InsertComment( "Test with default expression - should add !");
+        var defaultExpr = (object?) ExpressionFactory.Default<string>().WithNullForgivingOperator().Value;
+
+        meta.InsertComment( "Test with force=true on non-nullable - should add !" );
+        var forced = (object?) ExpressionFactory.Literal( "hello" ).WithNullForgivingOperator( force: true ).Value;
+        
+        meta.InsertComment( "Test with non-nullable - should NOT add !" );
+        var nonNullable = (object?) ExpressionFactory.Literal( "hello" ).WithNullForgivingOperator( ).Value;
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+internal class C
+{
+    [Aspect]
+    private int M() => 0;
+
+    private static string? GetNullableString() => null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/SyntaxBuilders/NullForgivingOperator.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/SyntaxBuilders/NullForgivingOperator.t.cs
@@ -1,0 +1,20 @@
+internal class C
+{
+  [Aspect]
+  private int M()
+  {
+    // Test with nullable expression - should add !
+    var nullableString = (object? )GetNullableString()!;
+    // Test with null literal - should add !
+    var nullLiteral = (object? )null !;
+    // Test with default expression - should add !
+    var defaultExpr = (object? )default(global::System.String)!;
+    // Test with force=true on non-nullable - should add !
+    var forced = (object? )"hello"!;
+    // Test with non-nullable - should NOT add !
+    var nonNullable = (object? )"hello";
+    return 0;
+  }
+
+  private static string? GetNullableString() => null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.Aspect.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.Aspect.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Formatting.Output.SuppressionWithFilter;
+
+public class SuppressFilteredAttribute : TypeAspect
+{
+    private static readonly SuppressionDefinition _suppression = new("CS0414");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        // This suppression matches CS0414 but only for fields named "_initialized"
+        builder.Diagnostics.Suppress(
+            _suppression.WithFilter(
+                diag => diag.Arguments.Any(arg => arg is string name && name == "C._initialized")),
+            builder.Target);
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.Aspect.t.cs.html
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.Aspect.t.cs.html
@@ -1,0 +1,95 @@
+
+<html>
+    <head>
+        <style>
+            .cr-CompileTime,
+            .cr-Conflict,
+            .cr-TemplateKeyword,
+            .cr-Dynamic,
+            .cr-CompileTimeVariable,
+            .cr-GeneratedCode
+            {
+                background-color: rgba(50,50,90,0.1);
+            }
+
+            .cr-NeutralTrivia
+            {
+                background-color: rgba(0,255,0,0.1);
+            }
+
+            .cr-TemplateKeyword
+            {
+                color: rgb(250, 0, 250) !important;
+                font-weight: bold;
+            }
+
+            .cr-Dynamic
+            {
+                text-decoration: underline;
+            }
+
+            .cr-CompileTimeVariable
+            {
+                font-style: italic;
+            }
+
+            .diag-Warning
+            {
+                text-decoration: underline 1px wavy orange;
+            }
+
+            .diag-Error
+            {
+                text-decoration: underline 1px wavy red;
+            }
+
+         .diff-Imaginary {
+                display: block;
+                background-image: repeating-linear-gradient( -45deg, gray, gray 2px, transparent 2px, transparent 8px );
+            }
+
+
+            .legend 
+            {
+                margin-top: 100px;
+            }
+        </style>
+    </head>
+    <body><pre><code class="nohighlight"><span class='line-number'>1</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Aspects</span><span class="cs-punctuation">;</span>
+<span class='line-number'>2</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Code</span><span class="cs-punctuation">;</span>
+<span class='line-number'>3</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Diagnostics</span><span class="cs-punctuation">;</span>
+<span class='line-number'>4</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">System</span><span class="cs-operator">.</span><span class="cs-namespace-name">Linq</span><span class="cs-punctuation">;</span>
+<span class='line-number'>5</span>
+<span class='line-number'>6</span><span class="cs-keyword">namespace</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">AspectTests</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">Formatting</span><span class="cs-operator">.</span><span class="cs-namespace-name">Output</span><span class="cs-operator">.</span><span class="cs-namespace-name">SuppressionWithFilter</span><span class="cs-punctuation">;</span>
+<span class='line-number'>7</span>
+<span class='line-number'>8</span>
+<span class='line-number' data-member='SuppressFilteredAttribute'>9</span><span class="cs-preprocessor-keyword">#pragma</span> <span class="cs-preprocessor-keyword">warning</span> <span class="cs-preprocessor-keyword">disable</span> <span class="cs-identifier">CS0067</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS8618</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS0162</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS0169</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS0414</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CA1822</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CA1823</span><span class="cs-punctuation">,</span> <span class="cs-identifier">IDE0051</span><span class="cs-punctuation">,</span> <span class="cs-identifier">IDE0052</span>
+<span class='line-number' data-member='SuppressFilteredAttribute'>10</span>
+<span class='line-number' data-member='SuppressFilteredAttribute'>11</span><span class="cr-CompileTime cs-keyword">public</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">class</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">SuppressFilteredAttribute</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">:</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">TypeAspect</span>
+<span class='line-number' data-member='SuppressFilteredAttribute'>12</span><span class="cr-CompileTime cs-punctuation">{</span>
+<span class='line-number' data-member='SuppressFilteredAttribute._suppression'>13</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">private</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">static</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">readonly</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">SuppressionDefinition</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-field-name cs-static-symbol">_suppression</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-operator">=</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">new</span><span class="cr-CompileTime cs-punctuation">(</span><span class="cr-CompileTime cs-string">"CS0414"</span><span class="cr-CompileTime cs-punctuation">);</span>
+<span class='line-number' data-member='SuppressFilteredAttribute._suppression'>14</span>
+<span class='line-number' data-member='SuppressFilteredAttribute.BuildAspect'>15</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">public</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">override</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">void</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-method-name">BuildAspect</span><span class="cr-CompileTime cs-punctuation">(</span><span class="cr-CompileTime cs-interface-name">IAspectBuilder</span><span class="cr-CompileTime cs-punctuation">&lt;</span><span class="cr-CompileTime cs-interface-name">INamedType</span><span class="cr-CompileTime cs-punctuation">&gt;</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-parameter-name">builder</span><span class="cr-CompileTime cs-punctuation">)</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-operator">=&gt;</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword cs-control">throw</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">new</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-namespace-name">System</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-CompileTime cs-class-name">NotSupportedException</span><span class="cr-CompileTime cs-punctuation">(</span><span class="cr-CompileTime cs-string">"Compile-time-only code cannot be called at run-time."</span><span class="cr-CompileTime cs-punctuation">);</span>
+<span class='line-number' data-member='SuppressFilteredAttribute'>16</span><span class="cr-CompileTime cs-punctuation">}</span>
+<span class='line-number' data-member='SuppressFilteredAttribute'>17</span>
+<span class='line-number'>18</span><span class="cs-preprocessor-keyword">#pragma</span> <span class="cs-preprocessor-keyword">warning</span> <span class="cs-preprocessor-keyword">restore</span> <span class="cs-identifier">CS0067</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS8618</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS0162</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS0169</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CS0414</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CA1822</span><span class="cs-punctuation">,</span> <span class="cs-identifier">CA1823</span><span class="cs-punctuation">,</span> <span class="cs-identifier">IDE0051</span><span class="cs-punctuation">,</span> <span class="cs-identifier">IDE0052</span>
+<span class='line-number'>19</span>
+<span class='line-number'>20</span>
+<span class='line-number'>21</span>
+</code></pre>
+       <p class='legend'>Legend:</p>
+       <pre>
+<span class='cr-Default'>Default</span>
+<span class='cr-RunTime'>RunTime</span>
+<span class='cr-CompileTime'>CompileTime</span>
+<span class='cr-Dynamic'>Dynamic</span>
+<span class='cr-CompileTimeVariable'>CompileTimeVariable</span>
+<span class='cr-TemplateKeyword'>TemplateKeyword</span>
+<span class='cr-Conflict'>Conflict</span>
+<span class='cr-Excluded'>Excluded</span>
+<span class='cr-GeneratedCode'>GeneratedCode</span>
+<span class='cr-SourceCode'>SourceCode</span>
+<span class='cr-NeutralTrivia'>NeutralTrivia</span>
+       </pre>
+   </body>
+</html>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @ClearIgnoredDiagnostics
+#endif
+
+#if !TESTRUNNER // Disable the warning in the main build, not during tests.
+#pragma warning disable CS0414
+#endif
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Formatting.Output.SuppressionWithFilter;
+
+[SuppressFiltered]
+public class C
+{
+    // This field triggers CS0414 (assigned but never used).
+    // The suppression filter only matches "_initialized", so _other should still warn.
+    private int _initialized = 1;
+    private int _other = 2;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.t.cs.html
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/Output/SuppressionWithFilter.t.cs.html
@@ -1,0 +1,87 @@
+
+<html>
+    <head>
+        <style>
+            .cr-CompileTime,
+            .cr-Conflict,
+            .cr-TemplateKeyword,
+            .cr-Dynamic,
+            .cr-CompileTimeVariable,
+            .cr-GeneratedCode
+            {
+                background-color: rgba(50,50,90,0.1);
+            }
+
+            .cr-NeutralTrivia
+            {
+                background-color: rgba(0,255,0,0.1);
+            }
+
+            .cr-TemplateKeyword
+            {
+                color: rgb(250, 0, 250) !important;
+                font-weight: bold;
+            }
+
+            .cr-Dynamic
+            {
+                text-decoration: underline;
+            }
+
+            .cr-CompileTimeVariable
+            {
+                font-style: italic;
+            }
+
+            .diag-Warning
+            {
+                text-decoration: underline 1px wavy orange;
+            }
+
+            .diag-Error
+            {
+                text-decoration: underline 1px wavy red;
+            }
+
+         .diff-Imaginary {
+                display: block;
+                background-image: repeating-linear-gradient( -45deg, gray, gray 2px, transparent 2px, transparent 8px );
+            }
+
+
+            .legend 
+            {
+                margin-top: 100px;
+            }
+        </style>
+    </head>
+    <body><pre><code class="nohighlight"><span class='line-number'>1</span><span class="cs-keyword">namespace</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">AspectTests</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">Formatting</span><span class="cs-operator">.</span><span class="cs-namespace-name">Output</span><span class="cs-operator">.</span><span class="cs-namespace-name">SuppressionWithFilter</span><span class="cs-punctuation">;</span>
+<span class='line-number'>2</span>
+<span class='line-number' data-member='C'>3</span><span class="cs-punctuation">[</span><span class="cs-class-name">SuppressFiltered</span><span class="cs-punctuation">]</span>
+<span class='line-number' data-member='C'>4</span><span class="cs-keyword">public</span> <span class="cs-keyword">class</span> <span class="cs-class-name">C</span>
+<span class='line-number' data-member='C'>5</span><span class="cs-punctuation">{</span>
+<span class='line-number' data-member='C._initialized'>6</span>    <span class="cs-comment">// This field triggers CS0414 (assigned but never used).</span>
+<span class='line-number' data-member='C._initialized'>7</span>    <span class="cs-comment">// The suppression filter only matches "_initialized", so _other should still warn.</span>
+<span class='line-number' data-member='C._initialized'>8</span>    <span class="cs-keyword">private</span> <span class="cs-keyword">int</span> <span class="cs-field-name">_initialized</span> <span class="cs-operator">=</span> <span class="cs-number">1</span><span class="cs-punctuation">;</span>
+<span class="diagLines">    <span class="diagLine-Warning">Warning CS0414: The field 'C._other' is assigned but its value is never used</span>
+    
+</span><span class='line-number' data-member='C._other'>9</span>    <span class="cs-keyword">private</span> <span class="cs-keyword">int</span> <span class="cs-field-name diag-Warning" title="Warning CS0414: The field 'C._other' is assigned but its value is never used">_other</span> <span class="cs-operator">=</span> <span class="cs-number">2</span><span class="cs-punctuation">;</span>
+<span class='line-number' data-member='C'>10</span><span class="cs-punctuation">}</span>
+<span class='line-number'>11</span>
+</code></pre>
+       <p class='legend'>Legend:</p>
+       <pre>
+<span class='cr-Default'>Default</span>
+<span class='cr-RunTime'>RunTime</span>
+<span class='cr-CompileTime'>CompileTime</span>
+<span class='cr-Dynamic'>Dynamic</span>
+<span class='cr-CompileTimeVariable'>CompileTimeVariable</span>
+<span class='cr-TemplateKeyword'>TemplateKeyword</span>
+<span class='cr-Conflict'>Conflict</span>
+<span class='cr-Excluded'>Excluded</span>
+<span class='cr-GeneratedCode'>GeneratedCode</span>
+<span class='cr-SourceCode'>SourceCode</span>
+<span class='cr-NeutralTrivia'>NeutralTrivia</span>
+       </pre>
+   </body>
+</html>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/metalamaTests.json
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/metalamaTests.json
@@ -2,7 +2,28 @@
  "ReportErrorMessage": true,
  "FormatOutput": false,
  "ReportOutputWarnings": true,
- "IgnoredDiagnostics" : [ "CS8603", "CS0219", "CS0067", "CS8602", "CS8600", "CS8604", "CS0649", "CS8767", "CS0169", "CS8765", "CS8625", "CS8424", "CS8425" ],
+ // IgnoredDiagnostics: Warnings suppressed during aspect testing to focus on aspect behavior rather than general code quality.
+ "IgnoredDiagnostics" : [
+    "CS0067",  // Event is never used
+    "CS0162",  // Unreachable code detected
+    "CS0169",  // Field is never used
+    "CS0219",  // Variable is assigned but its value is never used
+    "CS0414",  // Field is assigned but its value is never used
+    "CS0420",  // A reference to a volatile field will not be treated as volatile
+    "CS0626",  // Method, operator, or accessor is marked external and has no attributes on it
+    "CS0649",  // Field is never assigned to (will always have default value)
+    "CS0659",  // Class overrides Object.Equals but does not override Object.GetHashCode
+    "CS8424",  // Iterator specifying non-nullable return type but code block returns null values
+    "CS8425",  // Async-iterator does not have the proper return type
+    "CS8600",  // Converting null literal or possible null value to non-nullable type
+    "CS8602",  // Dereference of a possibly null reference
+    "CS8603",  // Possible null reference return
+    "CS8604",  // Possible null reference argument
+    "CS8625",  // Cannot convert null literal to non-nullable reference type
+    "CS8631",  // Nullability of type argument doesn't match constraint type
+    "CS8765",  // Nullability of type of parameter doesn't match overridden member
+    "CS8767"   // Nullability of reference types in parameter doesn't match implicitly implemented member
+ ],
  "MainMethod": "TestMain",
  "CheckMemoryLeaks": true,
  "IgnoreUserProfileLicenses": true,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/FormatSensitiveTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/FormatSensitiveTests.cs
@@ -75,7 +75,7 @@ public string Prop132
 {
     get
     {
-        return (global::System.String)this._prop132.ToUpper();
+        return (global::System.String)this._prop132?.ToUpper();
     }
 
     set

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelTests.cs
@@ -1286,9 +1286,10 @@ public class PublicClass
         using var testContext = this.CreateTestContext();
 
         var compilation = testContext.CreateCompilationModel( "" );
-        var objectType = compilation.Factory.GetNamedTypeByReflectionType( typeof(object) );
-        Assert.Same( objectType, objectType.UnderlyingType );
-        var nonNullableObjectType = (INamedType) objectType.ToNonNullable();
+        var nonNullableObjectType = compilation.Factory.GetNamedTypeByReflectionType( typeof(object) );
+        var objectType = nonNullableObjectType.StripNullabilityAnnotation();
+        Assert.Same( objectType, nonNullableObjectType.UnderlyingType );
+
         Assert.False( nonNullableObjectType.IsNullable );
         Assert.Same( objectType, nonNullableObjectType.UnderlyingType );
         var nullableObjectType = objectType.ToNullable();

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelTests.cs
@@ -1287,7 +1287,6 @@ public class PublicClass
 
         var compilation = testContext.CreateCompilationModel( "" );
         var objectType = compilation.Factory.GetNamedTypeByReflectionType( typeof(object) );
-        Assert.Null( objectType.IsNullable );
         Assert.Same( objectType, objectType.UnderlyingType );
         var nonNullableObjectType = (INamedType) objectType.ToNonNullable();
         Assert.False( nonNullableObjectType.IsNullable );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/ExpressionFactoryTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/ExpressionFactoryTests.cs
@@ -51,7 +51,7 @@ public sealed class ExpressionFactoryTests : UnitTestClass
         Assert.Equal( "null", expression.Syntax );
 
         // The expression should be untyped (target typed) but the Metalama model does not allow for it.
-        Assert.Equal( "object", expression.Type.AssertNotNull().ToString() );
+        Assert.Equal( "object?", expression.Type.AssertNotNull().ToString() );
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public sealed class ExpressionFactoryTests : UnitTestClass
         Assert.Equal( "default", expression.Syntax );
 
         // The expression should be untyped (target typed) but the Metalama model does not allow for it.
-        Assert.Equal( "object", expression.Type.AssertNotNull().ToString() );
+        Assert.Equal( "object?", expression.Type.AssertNotNull().ToString() );
     }
 
     [Fact]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/TestFramework/AspectTestRunnerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/TestFramework/AspectTestRunnerTests.cs
@@ -157,6 +157,9 @@ public class Program
             var testRunner = new AspectTestRunner( serviceProvider, directory, testProjectReferences, testOutputHelper );
             var testInput = new TestInput.Factory( serviceProvider ).FromFile( testProjectProperties, testDirectoryOptionsReader, "Test.cs" );
             var testContextOptions = testInput.Options.ApplyToTestContextOptions( new TestContextOptions() );
+            testInput.Options.SkipDiffTool = true;
+            testInput.Options.IgnoredDiagnostics.Add( "CS8602" );
+            testInput.Options.IgnoredDiagnostics.Add( "CS8600" );
 
             // A task that will be started by the test.
             var insideTestTask = new Task( () => { } );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -117,7 +117,7 @@ class C<T>
 
         if ( symbol != null )
         {
-            Roundtrip( compilation, symbol );
+            Roundtrip( compilation, symbol, symbol is not ITypeSymbol );
         }
     }
 
@@ -136,7 +136,7 @@ class C<T>
         }
         else
         {
-            Assert.Equal( symbol, symbolRoundtrip, SymbolEqualityComparer.Default );
+            Assert.Equal( symbol, symbolRoundtrip, SymbolEqualityComparer.IncludeNullability );
         }
 
         // Also test a Ref roundtrip.

--- a/Metalama.Framework/src/tests/Standalone/TestWeaver/TestWeaver.UnitTests/Class.cs
+++ b/Metalama.Framework/src/tests/Standalone/TestWeaver/TestWeaver.UnitTests/Class.cs
@@ -32,7 +32,7 @@ namespace Metalama.Open.Virtuosity.TestApp
         // Transformed (should not be sealed).
         public sealed override string ToString()
         {
-            return null;
+            return null!;
         }
 
         // Not transformed.

--- a/Metalama.Framework/src/tests/Standalone/TestWeaver/TestWeaver.UnitTests/Class.t.cs
+++ b/Metalama.Framework/src/tests/Standalone/TestWeaver/TestWeaver.UnitTests/Class.t.cs
@@ -30,7 +30,7 @@ namespace Metalama.Open.Virtuosity.TestApp
     // Transformed (should not be sealed).
     public override string ToString()
     {
-      return null;
+      return null!;
     }
     // Not transformed.
     public override int GetHashCode()

--- a/Metalama.Framework/src/tests/Standalone/TestWeaverSimple/TestWeaver.UnitTests/Class.cs
+++ b/Metalama.Framework/src/tests/Standalone/TestWeaverSimple/TestWeaver.UnitTests/Class.cs
@@ -32,7 +32,7 @@ namespace Metalama.Open.Virtuosity.TestApp
         // Transformed (should not be sealed).
         public sealed override string ToString()
         {
-            return null;
+            return null!;
         }
 
         // Not transformed.

--- a/Metalama.Framework/src/tests/Standalone/TestWeaverSimple/TestWeaver.UnitTests/Class.t.cs
+++ b/Metalama.Framework/src/tests/Standalone/TestWeaverSimple/TestWeaver.UnitTests/Class.t.cs
@@ -30,7 +30,7 @@ namespace Metalama.Open.Virtuosity.TestApp
     // Transformed (should not be sealed).
     public override string ToString()
     {
-      return null;
+      return null!;
     }
     // Not transformed.
     public override int GetHashCode()

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Wpf.AspectTests/_TrimAttribute.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Wpf.AspectTests/_TrimAttribute.cs
@@ -31,6 +31,13 @@ public sealed class TrimAttribute : ContractAspect
     public override void Validate( dynamic? value )
     {
         // ReSharper disable once RedundantAssignment
-        value = value?.Trim();
+        if ( meta.Target.Expression.Type.IsNullable == true )
+        {
+            value = value?.Trim();
+        }
+        else
+        {
+            value = value!.Trim();
+        }
     }
 }

--- a/Metalama.Patterns/src/tests/metalamaTests.json
+++ b/Metalama.Patterns/src/tests/metalamaTests.json
@@ -1,3 +1,4 @@
 {
-  "FormatOutput": true
+    "FormatOutput": true,
+    "IgnoredDiagnostics": ["CS0067"]
 }

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,9 @@
+# Development Notes
+
+This file contains notes about ongoing work, breaking changes, and important decisions.
+
+## Breaking Changes
+
+### Elvis operator `?.` in templates
+
+Processing of elvis `?.` in templates has been fixed - this is a breaking change.


### PR DESCRIPTION
## Summary

- Fix empty HTML output when test has filtered suppressions
- Add `IType.StripNullabilityAnnotation()` method to strip nullability annotations without marking as non-nullable
- Add `IMetaTarget.Expression` property providing unified access to fields, properties, and parameters as `IExpression`
- Add `TypedConstant.Create(IField)` to reference const fields instead of literal values
- Add `TypedConstant.Default(IType, bool)` overload with null-forgiving operator support
- Add `HasNullForgivingOperator` property to `TypedConstant`
- Report warnings by default in test framework
- The elvis operator `?.` in templates is no longer simplified out for non-nullable reference types

## Breaking Changes

The elvis operator `?.` in templates is no longer simplified out for non-nullable reference types. It is only simplified for non-nullable value types.

## Issues Fixed

- Fixes #1226 - Test framework: WriteInputHtml produces empty file for some tests
- Fixes #1232 - Enhance nullability handling in type system API