### PR TITLE
Remove TransitiveProjectFabric from ServiceLocator

### DIFF
--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/_Fabric.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/_Fabric.cs
@@ -2,11 +2,12 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Extensions.DependencyInjection;
 using Metalama.Framework.Fabrics;
 
-namespace Metalama.Extensions.DependencyInjection.ServiceLocator;
+namespace Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests;
 
-internal class Fabric : TransitiveProjectFabric
+internal class Fabric : ProjectFabric
 {
     public override void AmendProject( IProjectAmender amender )
     {

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/metalamaTests.json
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests/metalamaTests.json
@@ -1,3 +1,4 @@
 {
-  "FormatOutput": true
+  "FormatOutput": true,
+  "IncludedFiles": [ "_Fabric.cs" ]
 }


### PR DESCRIPTION
## Summary
- ServiceLocator no longer self-registers via TransitiveProjectFabric
- Tests now explicitly register the framework via an included `_Fabric.cs`

Fixes #1238