### PR TITLE
Fix #1231: InvalidCastException with nullable type parameters in typeof

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Contracts/AspectExplorer/IAspectDatabaseService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Contracts/AspectExplorer/IAspectDatabaseService.cs
@@ -22,7 +22,7 @@ public interface IAspectDatabaseService : ICompilerService
     Task GetAspectInstancesAsync(
         Compilation compilation,
         INamedTypeSymbol aspectClass,
-        IEnumerable<AspectExplorerAspectInstance>[] result,
+        IEnumerable<AspectExplorerAspectInstance>?[] result,
         CancellationToken cancellationToken );
 
     event Action<string> AspectClassesChanged;
@@ -37,6 +37,6 @@ public interface IAspectDatabaseService2 : IAspectDatabaseService
     Task GetAspectInstancesAsync(
         Compilation compilation,
         INamedTypeSymbol aspectClass,
-        IEnumerable<IAspectExplorerAspectInstance>[] result,
+        IEnumerable<IAspectExplorerAspectInstance>?[] result,
         CancellationToken cancellationToken );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
@@ -213,7 +213,7 @@ internal sealed class AspectDatabase : IGlobalService
                                         : null,
                                     transformedDeclaration.GetPrimarySyntaxTree()?.FilePath );
                             } )
-                        .ToArray() ) );
+                        .ToImmutableArray() ) );
 
         static string GetSerializableIdForOriginalDeclaration( IDeclaration declaration )
         {
@@ -239,7 +239,6 @@ internal sealed class AspectDatabase : IGlobalService
             };
         }
 
-#pragma warning disable IDE0300 // Don't use collection literal, since <>z__ReadOnlyArray`1 can't be deserialized here.
         var predecessorAspectInstances = aspectInstances
             .Where( aspectInstance => aspectInstance.Predecessors.Any( predecessor => GetPredecessorFullName( predecessor.Instance ) == aspectClassFullName ) )
             .Select(
@@ -250,7 +249,6 @@ internal sealed class AspectDatabase : IGlobalService
                             GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
                             $"Add the '{aspectInstance.AspectClass}' aspect to '{aspectInstance.TargetDeclaration}'." )
                     ] ) );
-#pragma warning restore IDE0300
 
         return transformationAspectInstances.Concat( predecessorAspectInstances ).ToArray();
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
@@ -193,27 +193,25 @@ internal sealed class AspectDatabase : IGlobalService
 
         var transformationAspectInstances = aspectInstances
             .Where( aspectInstance => aspectInstance.AspectClass.FullName == aspectClassFullName )
-            .Select(
-                aspectInstance => new AspectDatabaseAspectInstance(
-                    GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
-                    aspectInstance.Advice
-                        .SelectMany( advice => advice.Transformations )
-                        .Where( transformation => transformation.ShouldBeDisplayed() )
-                        .Select(
-                            transformation =>
-                            {
-                                var transformedDeclaration = transformation.IntroducedDeclaration ?? transformation.TargetDeclaration;
+            .Select( aspectInstance => new AspectDatabaseAspectInstance(
+                         GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
+                         aspectInstance.Advice
+                             .SelectMany( advice => advice.Transformations )
+                             .Where( transformation => transformation.ShouldBeDisplayed() )
+                             .Select( transformation =>
+                             {
+                                 var transformedDeclaration = transformation.IntroducedDeclaration ?? transformation.TargetDeclaration;
 
-                                // ReSharper disable once RedundantSuppressNullableWarningExpression
-                                return new AspectDatabaseAspectTransformation(
-                                    GetSerializableIdForOriginalDeclaration( transformation.TargetDeclaration ),
-                                    transformation.ToString()!,
-                                    transformedDeclaration.GetClosestNamedType() is { } transformedType
-                                        ? GetSerializableIdForOriginalDeclaration( transformedType )
-                                        : null,
-                                    transformedDeclaration.GetPrimarySyntaxTree()?.FilePath );
-                            } )
-                        .ToImmutableArray() ) );
+                                 // ReSharper disable once RedundantSuppressNullableWarningExpression
+                                 return new AspectDatabaseAspectTransformation(
+                                     GetSerializableIdForOriginalDeclaration( transformation.TargetDeclaration ),
+                                     transformation.ToString()!,
+                                     transformedDeclaration.GetClosestNamedType() is { } transformedType
+                                         ? GetSerializableIdForOriginalDeclaration( transformedType )
+                                         : null,
+                                     transformedDeclaration.GetPrimarySyntaxTree()?.FilePath );
+                             } )
+                             .ToImmutableArray() ) );
 
         static string GetSerializableIdForOriginalDeclaration( IDeclaration declaration )
         {
@@ -241,14 +239,12 @@ internal sealed class AspectDatabase : IGlobalService
 
         var predecessorAspectInstances = aspectInstances
             .Where( aspectInstance => aspectInstance.Predecessors.Any( predecessor => GetPredecessorFullName( predecessor.Instance ) == aspectClassFullName ) )
-            .Select(
-                aspectInstance => new AspectDatabaseAspectInstance(
-                    GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
-                    [
-                        new AspectDatabaseAspectTransformation(
-                            GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
-                            $"Add the '{aspectInstance.AspectClass}' aspect to '{aspectInstance.TargetDeclaration}'." )
-                    ] ) );
+            .Select( aspectInstance => new AspectDatabaseAspectInstance(
+                         GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
+                         ImmutableArray.Create(
+                             new AspectDatabaseAspectTransformation(
+                                 GetSerializableIdForOriginalDeclaration( aspectInstance.TargetDeclaration ),
+                                 $"Add the '{aspectInstance.AspectClass}' aspect to '{aspectInstance.TargetDeclaration}'." ) ) ) );
 
         return transformationAspectInstances.Concat( predecessorAspectInstances ).ToArray();
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabaseAspectInstance.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabaseAspectInstance.cs
@@ -2,13 +2,17 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Newtonsoft.Json;
+using System.Collections.Immutable;
+
 namespace Metalama.Framework.DesignTime.AspectExplorer;
 
+[JsonObject]
 internal sealed class AspectDatabaseAspectInstance(
     string targetDeclarationId,
-    IEnumerable<AspectDatabaseAspectTransformation> transformations )
+    ImmutableArray<AspectDatabaseAspectTransformation> transformations )
 {
     public string TargetDeclarationId { get; } = targetDeclarationId;
 
-    public IEnumerable<AspectDatabaseAspectTransformation> Transformations { get; } = transformations;
+    public ImmutableArray<AspectDatabaseAspectTransformation> Transformations { get; } = transformations;
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/AspectExplorer/AspectDatabaseService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/AspectExplorer/AspectDatabaseService.cs
@@ -15,11 +15,11 @@ using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.DesignTime.VisualStudio.AspectExplorer;
 
-internal sealed class AspectDatabase : IAspectDatabaseService2, IDisposable
+internal sealed class AspectDatabaseService : IAspectDatabaseService2, IDisposable
 {
     private readonly ServiceHubRpcService _serviceHub;
 
-    public AspectDatabase( GlobalServiceProvider serviceProvider )
+    public AspectDatabaseService( GlobalServiceProvider serviceProvider )
     {
         this._serviceHub = serviceProvider.GetRequiredService<IServiceHubRpcServiceProvider>().ServiceHub;
 
@@ -91,21 +91,23 @@ internal sealed class AspectDatabase : IAspectDatabaseService2, IDisposable
     public async Task GetAspectInstancesAsync(
         Compilation compilation,
         INamedTypeSymbol aspectClass,
-        IEnumerable<AspectExplorerAspectInstance>[] result,
+        IEnumerable<AspectExplorerAspectInstance>?[] result,
         CancellationToken cancellationToken )
     {
-        var version2Result = new IEnumerable<IAspectExplorerAspectInstance>[1];
+        var version2Result = new IEnumerable<IAspectExplorerAspectInstance>?[1];
 
         await this.GetAspectInstancesAsync( compilation, aspectClass, version2Result, cancellationToken );
 
-        result[0] = version2Result[0].Select( ToVersion1 ).ToArray();
+        // Be strict with nulls in the debug build and tolerant in the release build.
+        version2Result.AssertNotNull();
+        result[0] = version2Result[0]?.Select( ToVersion1 ).ToArray() ?? [];
     }
 #pragma warning restore CS0612
 
     public async Task GetAspectInstancesAsync(
         Compilation compilation,
         INamedTypeSymbol aspectClass,
-        IEnumerable<IAspectExplorerAspectInstance>[] result,
+        IEnumerable<IAspectExplorerAspectInstance>?[] result,
         CancellationToken cancellationToken )
     {
         var projectKey = compilation.GetProjectKey();
@@ -126,6 +128,8 @@ internal sealed class AspectDatabase : IAspectDatabaseService2, IDisposable
             cancellationToken );
 
         result[0] = GetAspectInstances().ToArray();
+
+        return;
 
         IEnumerable<IAspectExplorerAspectInstance> GetAspectInstances()
         {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/Services/VsUserProcessCompilerServiceProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/Services/VsUserProcessCompilerServiceProvider.cs
@@ -31,7 +31,7 @@ namespace Metalama.Framework.DesignTime.VisualStudio.Services
                 nameof(ICompileTimeEditingStatusService) => new CompileTimeEditingStatusService( this.ServiceProvider ),
                 nameof(ICodeLensService) => new CodeLensService( this.ServiceProvider ),
                 nameof(IServiceHubLocator) => new ServiceHubLocator( this.ServiceProvider ),
-                nameof(IAspectDatabaseService) => new AspectDatabase( this.ServiceProvider ),
+                nameof(IAspectDatabaseService) => new AspectDatabaseService( this.ServiceProvider ),
 
                 // When components implement several services, we ask for the primary interface so we ensure there 
                 // is a single instance of the component.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildItemNames.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildItemNames.cs
@@ -17,7 +17,13 @@ public static class MSBuildItemNames
 
     public const string MetalamaSourceGeneratorAttribute = nameof(MetalamaSourceGeneratorAttribute);
 
+    /// <summary>
+    /// List of compile-time extension assemblies. Passed through the <see cref="MSBuildPropertyNames.MetalamaExtensionAssemblies"/> property.
+    /// </summary>
     public const string MetalamaExtensionAssembly = nameof(MetalamaExtensionAssembly);
 
-    public const string MetalamaDesignTimeExtensionAssembly = nameof(MetalamaExtensionAssembly);
+    /// <summary>
+    /// List of design-time extension assemblies. Passed through the <see cref="MSBuildPropertyNames.MetalamaDesignTimeExtensionAssemblies"/> property.
+    /// </summary>
+    public const string MetalamaDesignTimeExtensionAssembly = nameof(MetalamaDesignTimeExtensionAssembly);
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.RemoveReferenceNullableAnnotationsRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.RemoveReferenceNullableAnnotationsRewriter.cs
@@ -116,9 +116,14 @@ namespace Metalama.Framework.Engine.SyntaxGeneration
                     // Skip the annotation.
                     return this.Visit( node.ElementType );
                 }
+                else if ( this._type is ITypeParameterSymbol )
+                {
+                    // For unconstrained type parameters, strip the nullable annotation.
+                    return this.Visit( node.ElementType );
+                }
                 else
                 {
-                    // Keep it.
+                    // Keep it - this is Nullable<T> for a value type.
                     var type = (INamedTypeSymbol) this._type;
 
                     using ( this.WithType( type.TypeArguments.Single() ) )
@@ -224,9 +229,14 @@ namespace Metalama.Framework.Engine.SyntaxGeneration
                     // Skip the annotation.
                     return this.Visit( node.ElementType );
                 }
+                else if ( this._type is ITypeParameter )
+                {
+                    // For unconstrained type parameters, strip the nullable annotation.
+                    return this.Visit( node.ElementType );
+                }
                 else
                 {
-                    // Keep it.
+                    // Keep it - this is Nullable<T> for a value type.
                     var type = (INamedType) this._type;
 
                     using ( this.WithType( type.TypeArguments.Single() ) )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.cs
@@ -2,8 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Metalama.Framework.Aspects;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231;
+
+public class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Return type: {meta.Target.Method.ReturnType.ToType()}" );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class MyClass<T>
+{
+    [Log]
+    public List<T?> GetValues()
+    {
+        return new List<T?>();
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.t.cs
@@ -1,0 +1,9 @@
+public class MyClass<T>
+{
+  [Log]
+  public List<T?> GetValues()
+  {
+    global::System.Console.WriteLine($"Return type: {typeof(global::System.Collections.Generic.List<T>)}");
+    return new List<T?>();
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Array.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Array.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Array;
+
+public class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Return type: {meta.Target.Method.ReturnType.ToType()}" );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class MyClass<T>
+{
+    [Log]
+    public T?[] GetValues()
+    {
+        return new T?[0];
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Array.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Array.t.cs
@@ -1,0 +1,9 @@
+public class MyClass<T>
+{
+  [Log]
+  public T? [] GetValues()
+  {
+    global::System.Console.WriteLine($"Return type: {typeof(T[])}");
+    return new T? [0];
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Direct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Direct.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Direct;
+
+public class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Return type: {meta.Target.Method.ReturnType.ToType()}" );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class MyClass<T>
+{
+    [Log]
+    public T? GetValue()
+    {
+        return default;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Direct.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Direct.t.cs
@@ -1,0 +1,9 @@
+public class MyClass<T>
+{
+  [Log]
+  public T? GetValue()
+  {
+    global::System.Console.WriteLine($"Return type: {typeof(T)}");
+    return default;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Introduced.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Introduced.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Introduced;
+
+public class IntroduceMethodAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Use the target type's own type parameter
+        var typeParameter = builder.Target.TypeParameters[0];
+        var nullableTypeParameter = typeParameter.ToNullable();
+        var listType = ( (INamedType) TypeFactory.GetType( typeof(List<>) ) ).WithTypeArguments( nullableTypeParameter );
+
+        builder.IntroduceMethod(
+            nameof(GetValues),
+            buildMethod: methodBuilder =>
+            {
+                methodBuilder.ReturnType = listType;
+            } );
+    }
+
+    [Template]
+    public dynamic? GetValues()
+    {
+        Console.WriteLine( $"Return type: {meta.Target.Method.ReturnType.ToType()}" );
+
+        return default;
+    }
+}
+
+// <target>
+[IntroduceMethodAspect]
+internal class TargetCode<T> { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Introduced.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Introduced.cs
@@ -2,8 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Metalama.Framework.Advising;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Introduced.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Introduced.t.cs
@@ -1,0 +1,9 @@
+[IntroduceMethodAspect]
+internal class TargetCode<T>
+{
+  public global::System.Collections.Generic.List<T?> GetValues()
+  {
+    global::System.Console.WriteLine($"Return type: {typeof(global::System.Collections.Generic.List<T>)}");
+    return default;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Nested.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Nested.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Nested;
+
+public class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Return type: {meta.Target.Method.ReturnType.ToType()}" );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class MyClass<T>
+{
+    [Log]
+    public Dictionary<string, List<T?>> GetValues()
+    {
+        return new Dictionary<string, List<T?>>();
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Nested.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Nested.t.cs
@@ -1,0 +1,9 @@
+public class MyClass<T>
+{
+  [Log]
+  public Dictionary<string, List<T?>> GetValues()
+  {
+    global::System.Console.WriteLine($"Return type: {typeof(global::System.Collections.Generic.Dictionary<global::System.String, global::System.Collections.Generic.List<T>>)}");
+    return new Dictionary<string, List<T?>>();
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Tuple.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Tuple.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Tuple;
+
+public class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Return type: {meta.Target.Method.ReturnType.ToType()}" );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class MyClass<T>
+{
+    [Log]
+    public (T?, string) GetValues()
+    {
+        return (default, "test");
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Tuple.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Tuple.t.cs
@@ -1,0 +1,9 @@
+public class MyClass<T>
+{
+  [Log]
+  public (T?, string) GetValues()
+  {
+    global::System.Console.WriteLine($"Return type: {typeof((T, global::System.String))}");
+    return (default, "test");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/DistributedDesignTimeTestContext.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/DistributedDesignTimeTestContext.cs
@@ -112,9 +112,9 @@ public sealed class DistributedDesignTimeTestContext : TestContext
 
     public GlobalServiceProvider UserProcessServiceProvider { get; private set; }
 
-    public ServiceHubServerEndpoint ServiceHubServerEndpoint => this._userProcessServiceHubEndpoint ?? throw new InvalidOperationException();
+    public ServiceHubServerEndpoint UserProcessServiceHubEndpoint => this._userProcessServiceHubEndpoint ?? throw new InvalidOperationException();
 
-    public RpcServiceProviderServerEndpoint RpcServiceProviderEndpoint => this._analysisProcessEndpoint ?? throw new InvalidOperationException();
+    public RpcServiceProviderServerEndpoint AnalysisProcessEndpoint => this._analysisProcessEndpoint ?? throw new InvalidOperationException();
 
     public TestDesignTimeAspectPipelineFactory PipelineFactory => this._pipelineFactory ?? throw new InvalidOperationException();
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/CompileTimeErrorNotificationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/CompileTimeErrorNotificationTests.cs
@@ -50,12 +50,12 @@ public sealed class CompileTimeErrorNotificationTests : DistributedDesignTimeTes
             "project",
             new Dictionary<string, string> { ["code.cs"] = codeWithError } );
 
-        await testContext.RpcServiceProviderEndpoint.RegisterProjectAsync( projectKey, testContext.CancellationToken );
+        await testContext.AnalysisProcessEndpoint.RegisterProjectAsync( projectKey, testContext.CancellationToken );
 
         // Register a synchronization point.
         var hasCompilerErrorData = new TaskCompletionSource<bool>();
 
-        testContext.ServiceHubServerEndpoint.ServiceHub.Endpoints.Single().EventReceived += eventData =>
+        testContext.UserProcessServiceHubEndpoint.ServiceHub.Endpoints.Single().EventReceived += eventData =>
         {
             if ( eventData is CompileTimeErrorsChangedEventData )
             {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/AspectDatabaseDistributedTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/AspectDatabaseDistributedTests.cs
@@ -2,13 +2,14 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.DesignTime.Contracts.CodeLens;
-using Metalama.Framework.DesignTime.VisualStudio.CodeLens;
+using Metalama.Framework.DesignTime.Contracts.AspectExplorer;
+using Metalama.Framework.DesignTime.VisualStudio.AspectExplorer;
 using Metalama.Framework.Engine.Pipeline.DesignTime;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Services;
 using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,13 +18,16 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.EndToEnd;
 
 #pragma warning disable VSTHRD200
 
-public sealed class CodeLensTests : DistributedDesignTimeTestBase
+public sealed class AspectDatabaseDistributedTests : DistributedDesignTimeTestBase
 {
-    public CodeLensTests( ITestOutputHelper? testOutputHelper ) : base( testOutputHelper ) { }
+    public AspectDatabaseDistributedTests( ITestOutputHelper? testOutputHelper ) : base( testOutputHelper ) { }
 
     [Fact]
     public async Task EndToEnd()
     {
+        // This test reproduces https://github.com/metalama/Metalama/issues/1183, which is linked to the serialization
+        // in presence of successors.
+
         var analysisProcessServices = new ServiceProviderBuilder<IGlobalService>();
 
         // Initialize the components.
@@ -34,16 +38,25 @@ public sealed class CodeLensTests : DistributedDesignTimeTestBase
         const string code = """
                             using Metalama.Framework.Advising;
                             using Metalama.Framework.Aspects; 
-                            using Metalama.Framework.Advising;
                             using Metalama.Framework.Code;
 
-                            class TheAspect : TypeAspect
+                            [assembly: AspectOrder( AspectOrderDirection.CompileTime, typeof( Aspect1 ), typeof( Aspect2 ) )]
+
+                            class Aspect1 : TypeAspect
+                            {
+                                public override void BuildAspect(IAspectBuilder<INamedType> builder)
+                                {
+                                    builder.RequireAspect<Aspect2>();
+                                }
+                            }
+
+                            class Aspect2 : TypeAspect
                             {
                                [Introduce]
                                void IntroducedMethod(){}
                             }
 
-                            [TheAspect]
+                            [Aspect1]
                             class TheClass {}
                             """;
 
@@ -55,25 +68,25 @@ public sealed class CodeLensTests : DistributedDesignTimeTestBase
         // We need to run the pipeline because code lens does not run it on its own.
         var project = testContext.WorkspaceProvider.GetProject( "project" );
         var pipeline = testContext.PipelineFactory.GetOrCreatePipeline( project )!;
-        await pipeline.ExecuteAsync( (await project.GetCompilationAsync())!, AsyncExecutionContext.Get() );
+        var pipelineResult = await pipeline.ExecuteAsync( (await project.GetCompilationAsync())!, AsyncExecutionContext.Get() );
+        Assert.True( pipelineResult.IsSuccessful );
 
-        // Test the CodeLens service.
-        var theClassSymbol = compilation.GetTypeByMetadataName( "TheClass" )!;
+        var aspectDatabaseService = new AspectDatabaseService( testContext.UserProcessServiceProvider );
 
-        var codeLensService = new CodeLensService( testContext.UserProcessServiceProvider );
+        var aspectClasses = (await aspectDatabaseService.GetAspectClassesAsync( compilation, testContext.CancellationToken ))
+            .OrderBy( x => x.Name )
+            .ToArray();
 
-        var summary = new ICodeLensSummary[1];
-        await codeLensService.GetCodeLensSummaryAsync( compilation, theClassSymbol, summary );
+        Assert.Equal( 2, aspectClasses.Length );
 
-        Assert.NotNull( summary[0] );
-        Assert.Equal( "1 aspect", summary[0].Description );
+        var aspectInstances1 = new IEnumerable<IAspectExplorerAspectInstance>[1];
+        await aspectDatabaseService.GetAspectInstancesAsync( compilation, aspectClasses[0], aspectInstances1, testContext.CancellationToken );
 
-        var details = new ICodeLensDetails[1];
-        await codeLensService.GetCodeLensDetailsAsync( compilation, theClassSymbol, details );
+        Assert.Equal( 2, aspectInstances1[0].Count() );
 
-        Assert.NotNull( details[0] );
-        var table = (ICodeLensDetailsTable) details[0];
-        Assert.Single( table.Entries );
-        Assert.NotNull( table.Entries[0].Fields[0] );
+        var aspectInstances2 = new IEnumerable<IAspectExplorerAspectInstance>[1];
+        await aspectDatabaseService.GetAspectInstancesAsync( compilation, aspectClasses[1], aspectInstances2, testContext.CancellationToken );
+
+        Assert.Single( aspectInstances2[0] );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/NotificationIntegrationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/NotificationIntegrationTests.cs
@@ -29,7 +29,7 @@ public sealed class NotificationIntegrationTests : DistributedDesignTimeTestBase
         // Start the notification listener.
         var notificationListenerEndpoint = new CodeLensProcessClientEndpoint(
             testContext.ServiceProvider.Underlying,
-            testContext.ServiceHubServerEndpoint.PipeName );
+            testContext.UserProcessServiceHubEndpoint.PipeName );
 
         // We need to make sure that the notification listener listens before we run the pipeline,
         // otherwise the notification will be missed.

--- a/eng/AutoUpdatedVersions.props
+++ b/eng/AutoUpdatedVersions.props
@@ -2,7 +2,7 @@
 <Project>
 
     <PropertyGroup>
-        <MetalamaCompilerVersion>2025.1.10</MetalamaCompilerVersion>
-    <MetalamaReleaseVersion>2025.1.16</MetalamaReleaseVersion><MetalamaReleaseMainVersion>2025.1.16</MetalamaReleaseMainVersion></PropertyGroup>
+        <MetalamaCompilerVersion>2025.1.11</MetalamaCompilerVersion>
+    <MetalamaReleaseVersion>2025.1.17</MetalamaReleaseVersion><MetalamaReleaseMainVersion>2025.1.17</MetalamaReleaseMainVersion></PropertyGroup>
 
 </Project>

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>2025.1.16</MainVersion>
+        <MainVersion>2025.1.17</MainVersion>
         <PackageVersionSuffix></PackageVersionSuffix>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Fixes #1231: `InvalidCastException` when using `meta.Target.Method.ReturnType.ToType()` on methods returning generic types with nullable unconstrained type parameters (e.g., `List<T?>`)
- The bug was in `RemoveReferenceNullableAnnotationsRewriterForSymbol.VisitNullableType()` which assumed `T?` was always `Nullable<T>` (a value type) when `IsReferenceType` was false, but for unconstrained type parameters it's actually an `ITypeParameterSymbol`

--Claude