### PR TITLE
Support building compile-time projects with msbuild.exe (#1247)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
@@ -70,6 +70,7 @@ internal sealed class CompileTimeAssemblyLocator
     private readonly int _restoreTimeout;
     private readonly ImmutableArray<string> _targetFrameworks;
     private readonly string? _sdkVersion;
+    private readonly string? _msBuildBinPath;
 
     /// <summary>
     /// This compilation is used by the <see cref="SymbolClassifier"/> to determine if an API is available
@@ -105,6 +106,7 @@ internal sealed class CompileTimeAssemblyLocator
     {
         this._logger = serviceProvider.GetLoggerFactory().GetLogger( nameof(CompileTimeAssemblyLocator) );
         this._sdkVersion = serviceProvider.GetRequiredService<IProjectOptions>().SdkVersion;
+        this._msBuildBinPath = serviceProvider.GetRequiredService<IProjectOptions>().MSBuildBinPath;
 
         this._dotNetTool = new DotNetTool( serviceProvider.Global );
 
@@ -163,6 +165,12 @@ internal sealed class CompileTimeAssemblyLocator
         {
             var nugetConfigContent = File.ReadAllText( nugetConfigFile );
             hashBuilder.Update( nugetConfigContent );
+        }
+
+        // Include optional salt for cache invalidation (useful for testing).
+        if ( !string.IsNullOrEmpty( projectOptions.AssemblyLocatorSalt ) )
+        {
+            hashBuilder.Update( projectOptions.AssemblyLocatorSalt );
         }
 
         var projectHash = hashBuilder.Digest().ToString( "x", CultureInfo.InvariantCulture );
@@ -520,20 +528,30 @@ internal sealed class CompileTimeAssemblyLocator
                 File.WriteAllText( nuGetConfigPath, nugetConfig );
             }
 
-            // We may consider executing msbuild.exe instead of dotnet.exe when the build itself runs using msbuild.exe.
-            // This way we wouldn't need to require a .NET SDK to be installed. Also, it seems that Rider requires the full path.
-            var arguments = $"build -bl:msbuild_{Guid.NewGuid():N}.binlog";
-
             this._logger.Trace?.Log( $"Building with restore timeout {this._restoreTimeout}." );
 
-            // Remove configuration environment variable to avoid having different output directory than Debug.
-            // Build scripts may rely on env var to set the configuration in MSBuild.
-            // Case insensitive comparison needed because MSBuild is case insensitive.
-            this._dotNetTool.Execute(
-                arguments,
-                this._cacheDirectory,
-                this._restoreTimeout,
-                envVar => !StringComparer.OrdinalIgnoreCase.Equals( envVar.Key, "configuration" ) );
+            // When NETCoreSdkVersion is not available (e.g., old-style .NET Framework projects built with msbuild.exe),
+            // use msbuild.exe directly instead of dotnet.exe.
+            if ( string.IsNullOrEmpty( this._sdkVersion ) && !string.IsNullOrEmpty( this._msBuildBinPath ) )
+            {
+                var msBuildTool = new MSBuildTool( this._msBuildBinPath );
+                var arguments = $"\"{projectFilePath}\" /t:Restore;Build /bl:msbuild_{Guid.NewGuid():N}.binlog";
+
+                msBuildTool.Execute( arguments, this._cacheDirectory, this._restoreTimeout );
+            }
+            else
+            {
+                // Remove configuration environment variable to avoid having different output directory than Debug.
+                // Build scripts may rely on env var to set the configuration in MSBuild.
+                // Case insensitive comparison needed because MSBuild is case insensitive.
+                var arguments = $"build -bl:msbuild_{Guid.NewGuid():N}.binlog";
+
+                this._dotNetTool.Execute(
+                    arguments,
+                    this._cacheDirectory,
+                    this._restoreTimeout,
+                    envVar => !StringComparer.OrdinalIgnoreCase.Equals( envVar.Key, "configuration" ) );
+            }
 
             var assemblies = File.ReadAllLines( assembliesListPath );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
@@ -122,6 +122,10 @@ public class DefaultProjectOptions : IProjectOptions
 
     public virtual string? SdkVersion => null;
 
+    public virtual string? MSBuildBinPath => null;
+
+    public virtual string? AssemblyLocatorSalt => null;
+
     // IProjectOptions is currently not used as a dictionary key, so we can throw here.
     public sealed override int GetHashCode() => throw new NotImplementedException();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
@@ -214,4 +214,18 @@ public interface IProjectOptions : IProjectService, IEquatable<IProjectOptions>
     LanguageVersion LanguageVersion { get; }
 
     string? SdkVersion { get; }
+
+    /// <summary>
+    /// Gets the path to the MSBuild bin directory. This is used to locate msbuild.exe
+    /// when building compile-time projects in environments where the .NET SDK is not available
+    /// (e.g., old-style .NET Framework projects built with msbuild.exe).
+    /// </summary>
+    string? MSBuildBinPath { get; }
+
+    /// <summary>
+    /// Gets a salt value used to invalidate the AssemblyLocator cache.
+    /// When set to a non-null value, this salt is incorporated into the cache hash,
+    /// allowing tests to force cache misses without manually clearing the cache directory.
+    /// </summary>
+    string? AssemblyLocatorSalt { get; }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
@@ -224,8 +224,9 @@ public interface IProjectOptions : IProjectService, IEquatable<IProjectOptions>
 
     /// <summary>
     /// Gets a salt value used to invalidate the AssemblyLocator cache.
-    /// When set to a non-null value, this salt is incorporated into the cache hash,
-    /// allowing tests to force cache misses without manually clearing the cache directory.
+    /// This property is primarily intended for testing scenarios where it is necessary to force cache invalidation
+    /// without manually clearing cache directories. When set to a non-null value, this salt is incorporated into the cache hash,
+    /// allowing tests to force cache misses. This property is not intended for use in production environments.
     /// </summary>
     string? AssemblyLocatorSalt { get; }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
@@ -175,6 +175,12 @@ public partial class MSBuildProjectOptions : DefaultProjectOptions
     private string? GetSdkVersionCore() => this.GetStringOption( MSBuildPropertyNames.NETCoreSdkVersion );
 
     [Memo]
+    public override string? MSBuildBinPath => this.GetStringOption( MSBuildPropertyNames.MSBuildBinPath );
+
+    [Memo]
+    public override string? AssemblyLocatorSalt => this.GetStringOption( MSBuildPropertyNames.MetalamaAssemblyLocatorSalt );
+
+    [Memo]
     public override ImmutableArray<string> SourceGeneratorAttributes => this.GetListOption( MSBuildPropertyNames.MetalamaSourceGeneratorAttributes );
 
     public override bool AvoidLockingExtensionAssemblies => this.GetBooleanOption( MSBuildPropertyNames.MetalamaAvoidLockingExtensionAssemblies );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
@@ -51,6 +51,8 @@ public static class MSBuildPropertyNames
     public const string MetalamaDesignTimeExtensionAssemblies = nameof(MetalamaDesignTimeExtensionAssemblies);
     public const string MetalamaAvoidLockingExtensionAssemblies = nameof(MetalamaAvoidLockingExtensionAssemblies);
     public const string NETCoreSdkVersion = nameof(NETCoreSdkVersion);
+    public const string MSBuildBinPath = nameof(MSBuildBinPath);
+    public const string MetalamaAssemblyLocatorSalt = nameof(MetalamaAssemblyLocatorSalt);
 
     public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
         MetalamaBuildTouchFile,
@@ -88,5 +90,7 @@ public static class MSBuildPropertyNames
         MetalamaExtensionAssemblies,
         MetalamaDesignTimeExtensionAssemblies,
         MetalamaAvoidLockingExtensionAssemblies,
-        NETCoreSdkVersion );
+        NETCoreSdkVersion,
+        MSBuildBinPath,
+        MetalamaAssemblyLocatorSalt );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
@@ -108,6 +108,10 @@ public abstract class ProjectOptionsWrapper : IProjectOptions
 
     public string? SdkVersion => this.Wrapped.SdkVersion;
 
+    public string? MSBuildBinPath => this.Wrapped.MSBuildBinPath;
+
+    public string? AssemblyLocatorSalt => this.Wrapped.AssemblyLocatorSalt;
+
     public sealed override int GetHashCode() => throw new NotImplementedException();
 
     public sealed override bool Equals( object? obj ) => this.Equals( obj as IProjectOptions );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/LanguageVersionProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/LanguageVersionProvider.cs
@@ -87,12 +87,25 @@ internal class LanguageVersionProvider : ILanguageVersionProvider
         }
 
         // Find Roslyn assembly in the MSBuild bin path to determine the version.
+        // The Roslyn folder can be in the bin path itself (e.g., ...\Bin\Roslyn) or in the parent directory
+        // when using the amd64 subfolder (e.g., ...\Bin\amd64 -> ...\Bin\Roslyn).
         var roslynDllPath = Path.Combine( msBuildBinPath, "Roslyn", "Microsoft.CodeAnalysis.CSharp.dll" );
 
         if ( !File.Exists( roslynDllPath ) )
         {
+            // Try parent directory (for amd64 subfolder case).
+            var parentPath = Path.GetDirectoryName( msBuildBinPath );
+
+            if ( parentPath != null )
+            {
+                roslynDllPath = Path.Combine( parentPath, "Roslyn", "Microsoft.CodeAnalysis.CSharp.dll" );
+            }
+        }
+
+        if ( !File.Exists( roslynDllPath ) )
+        {
             throw new InvalidOperationException(
-                $"Cannot determine the compile-time language version: could not find '{roslynDllPath}'." );
+                $"Cannot determine the compile-time language version: could not find Roslyn in '{msBuildBinPath}' or its parent directory." );
         }
 
         var roslynVersion = AssemblyName.GetAssemblyName( roslynDllPath ).Version;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/LanguageVersionProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/LanguageVersionProvider.cs
@@ -6,6 +6,8 @@ using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Services;
 using Microsoft.CodeAnalysis.CSharp;
 using System;
+using System.IO;
+using System.Reflection;
 
 namespace Metalama.Framework.Engine.Utilities;
 
@@ -28,13 +30,21 @@ internal class LanguageVersionProvider : ILanguageVersionProvider
 
     private LanguageVersion GetCompileTimeLanguageVersionCore()
     {
-        if ( this._projectOptions.SdkVersion == null )
+        // NETCoreSdkVersion can be null (property not defined) or empty (old-style .NET Framework projects
+        // built with msbuild.exe where Microsoft.NETCoreSdk.BundledVersions.props is not imported).
+        if ( string.IsNullOrEmpty( this._projectOptions.SdkVersion ) )
         {
-            throw new InvalidOperationException(
-                $"Cannot get the .NET SDK version: the {nameof(MSBuildPropertyNames.NETCoreSdkVersion)} MSBuild property is not defined for project '{this._projectOptions.ProjectName}'." );
+            // When building with msbuild.exe from Visual Studio (no .NET SDK), we use the project's
+            // language version constrained by what the MSBuild's bundled Roslyn version supports.
+            return this.GetLanguageVersionFromMSBuild();
         }
 
-        var mainVersion = this._projectOptions.SdkVersion.Split( '-' )[0];
+        return this.GetLanguageVersionFromDotNetSdk();
+    }
+
+    private LanguageVersion GetLanguageVersionFromDotNetSdk()
+    {
+        var mainVersion = this._projectOptions.SdkVersion!.Split( '-' )[0];
 
         if ( !Version.TryParse( mainVersion, out var version ) )
         {
@@ -62,6 +72,48 @@ internal class LanguageVersionProvider : ILanguageVersionProvider
         else
         {
             return sdkSupportedVersion;
+        }
+    }
+
+    private LanguageVersion GetLanguageVersionFromMSBuild()
+    {
+        var msBuildBinPath = this._projectOptions.MSBuildBinPath;
+
+        if ( string.IsNullOrEmpty( msBuildBinPath ) )
+        {
+            throw new InvalidOperationException(
+                $"Cannot determine the compile-time language version: neither {nameof(MSBuildPropertyNames.NETCoreSdkVersion)} nor " +
+                $"{nameof(MSBuildPropertyNames.MSBuildBinPath)} is defined for project '{this._projectOptions.ProjectName}'." );
+        }
+
+        // Find Roslyn assembly in the MSBuild bin path to determine the version.
+        var roslynDllPath = Path.Combine( msBuildBinPath, "Roslyn", "Microsoft.CodeAnalysis.CSharp.dll" );
+
+        if ( !File.Exists( roslynDllPath ) )
+        {
+            throw new InvalidOperationException(
+                $"Cannot determine the compile-time language version: could not find '{roslynDllPath}'." );
+        }
+
+        var roslynVersion = AssemblyName.GetAssemblyName( roslynDllPath ).Version;
+
+        if ( roslynVersion == null )
+        {
+            throw new InvalidOperationException(
+                $"Cannot determine the compile-time language version: could not read assembly version from '{roslynDllPath}'." );
+        }
+
+        var msBuildSupportedVersion = SupportedCSharpVersions.GetMaxLanguageVersion( roslynVersion );
+
+        var projectVersion = this._projectOptions.LanguageVersion;
+
+        if ( msBuildSupportedVersion >= projectVersion )
+        {
+            return projectVersion;
+        }
+        else
+        {
+            return msBuildSupportedVersion;
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Metalama.Framework.Engine.Utilities;
+
+/// <summary>
+/// Executes MSBuild.exe from Visual Studio or Build Tools.
+/// Used when building compile-time projects in environments where the .NET SDK is not available
+/// (e.g., old-style .NET Framework projects built with msbuild.exe).
+/// </summary>
+[PublicAPI]
+public sealed class MSBuildTool
+{
+    private readonly string _msBuildExePath;
+
+    public MSBuildTool( string msBuildBinPath )
+    {
+        this._msBuildExePath = Path.Combine( msBuildBinPath, "MSBuild.exe" );
+
+        if ( !File.Exists( this._msBuildExePath ) )
+        {
+            throw new InvalidOperationException(
+                $"Cannot find MSBuild.exe at '{this._msBuildExePath}'. The MSBuildBinPath property value '{msBuildBinPath}' is invalid." );
+        }
+    }
+
+    public void Execute(
+        string arguments,
+        string? workingDirectory = null,
+        int timeout = 30_000,
+        Func<KeyValuePair<string, string?>, bool>? environmentVariableFilter = null )
+    {
+        var startInfo = new ProcessStartInfo( this._msBuildExePath, arguments )
+        {
+            WorkingDirectory = workingDirectory ?? Environment.CurrentDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        // Remove configuration environment variable to avoid having different output directory than Debug.
+        // Build scripts may rely on env var to set the configuration in MSBuild.
+        // Case insensitive comparison needed because MSBuild is case insensitive.
+        foreach ( var key in startInfo.Environment.Keys.Where( k => k.Equals( "Configuration", StringComparison.OrdinalIgnoreCase ) ).ToArray() )
+        {
+            startInfo.Environment.Remove( key );
+        }
+
+        if ( environmentVariableFilter != null )
+        {
+            foreach ( var envVar in startInfo.Environment.ToArray() )
+            {
+                if ( !environmentVariableFilter( envVar ) )
+                {
+                    startInfo.Environment.Remove( envVar.Key );
+                }
+            }
+        }
+
+        var process = new Process { StartInfo = startInfo };
+
+        var lines = new List<string>();
+
+        void OnProcessDataReceived( object sender, DataReceivedEventArgs e )
+        {
+            lines.Add( e.Data ?? "" );
+        }
+
+        process.OutputDataReceived += OnProcessDataReceived;
+        process.ErrorDataReceived += OnProcessDataReceived;
+
+        process.Start();
+        process.BeginErrorReadLine();
+        process.BeginOutputReadLine();
+
+        if ( !process.WaitForExit( timeout ) )
+        {
+            try
+            {
+                process.Kill();
+            }
+            catch
+            {
+                // ignored
+            }
+
+            throw new AssertionFailedException( $"The process '{this._msBuildExePath} {arguments}' did not complete in {timeout / 1000f} s." );
+        }
+
+        if ( process.ExitCode != 0 )
+        {
+            throw new InvalidOperationException(
+                $"Error calling `\"{this._msBuildExePath}\" {arguments}` in `{startInfo.WorkingDirectory}` returned {process.ExitCode}. Process output:"
+                + Environment.NewLine + Environment.NewLine + string.Join( Environment.NewLine, lines ) );
+        }
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
@@ -47,10 +47,13 @@ public sealed class MSBuildTool
             RedirectStandardError = true
         };
 
-        // Remove configuration environment variable to avoid having different output directory than Debug.
-        // Build scripts may rely on env var to set the configuration in MSBuild.
-        // Case insensitive comparison needed because MSBuild is case insensitive.
-        foreach ( var key in startInfo.Environment.Keys.Where( k => k.Equals( "Configuration", StringComparison.OrdinalIgnoreCase ) ).ToArray() )
+        // Remove environment variables that can interfere with MSBuild execution.
+        // These variables may point to .NET SDK paths that conflict with Visual Studio's MSBuild.
+        var variablesToRemove = new[] { "DOTNET_ROOT_X64", "MSBUILD_EXE_PATH", "MSBuildSDKsPath", "Configuration" };
+
+        foreach ( var key in startInfo.Environment.Keys
+                     .Where( k => variablesToRemove.Any( v => k.Equals( v, StringComparison.OrdinalIgnoreCase ) ) )
+                     .ToArray() )
         {
             startInfo.Environment.Remove( key );
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
@@ -69,7 +69,7 @@ public sealed class MSBuildTool
             }
         }
 
-        var process = new Process { StartInfo = startInfo };
+        using var process = new Process { StartInfo = startInfo };
 
         var lines = new List<string>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SupportedCSharpVersions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SupportedCSharpVersions.cs
@@ -95,4 +95,19 @@ public static class SupportedCSharpVersions
             RoslynApiVersion.V5_0_0 => new Version( 5, 0, 0 ),
             _ => throw new AssertionFailedException( $"Unexpected Roslyn version {roslynApiVersion}." )
         };
+
+    /// <summary>
+    /// Gets the maximum C# language version supported by a given Roslyn version.
+    /// </summary>
+    internal static LanguageVersion GetMaxLanguageVersion( Version roslynVersion )
+        => (roslynVersion.Major, roslynVersion.Minor) switch
+        {
+            (>= 5, _) => AllLanguageVersions.CSharp14,
+            (4, >= 12) => AllLanguageVersions.CSharp13,
+            (4, >= 8) => AllLanguageVersions.CSharp12,
+            (4, >= 4) => AllLanguageVersions.CSharp11,
+            (4, _) => AllLanguageVersions.CSharp10,
+            (3, _) => LanguageVersion.CSharp9,
+            _ => throw new PlatformNotSupportedException( $"Unsupported Roslyn version: {roslynVersion}." )
+        };
 }

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
@@ -37,6 +37,8 @@
         <CompilerVisibleProperty Include="MetalamaAvoidLockingExtensionAssemblies"/>
         <CompilerVisibleProperty Include="LangVersion"/>
         <CompilerVisibleProperty Include="NETCoreSdkVersion"/>
+        <CompilerVisibleProperty Include="MSBuildBinPath"/>
+        <CompilerVisibleProperty Include="MetalamaAssemblyLocatorSalt"/>
     </ItemGroup>
 
     <!-- More properties are already exported by Metalama.Compiler and don't need to be exported a second time. -->

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Array.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Array.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Array;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Direct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Direct.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Direct;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Nested.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Nested.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Nested;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Tuple.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1231_Tuple.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1231_Tuple;
 

--- a/Metalama.Framework/src/tests/Standalone/Issue31024/Issue31024.proj
+++ b/Metalama.Framework/src/tests/Standalone/Issue31024/Issue31024.proj
@@ -3,17 +3,21 @@
     <!-- Imports Directory.Build.props of the upper directory. We must do this explicitly because this project has no SDK. -->
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(`Directory.Build.props`, `$(MSBuildThisFileDirectory)../`))')" />
 
+    <!-- Generate a unique salt to force cache invalidation on each test run -->
+    <PropertyGroup>
+        <TestSalt>$([System.Guid]::NewGuid())</TestSalt>
+    </PropertyGroup>
 
   <Target Name="Build">
 
-      <Error Text="This test requires Visual Studio or Visual Studio Build Tools to be installed." Condition="'$(MSBuildExePath)'==''" /> 
+      <Error Text="This test requires Visual Studio or Visual Studio Build Tools to be installed." Condition="'$(MSBuildExePath)'==''" />
 
       <!-- The library must be built with `dotnet build`, which is supposed to be the current process. -->
       <Exec Command="dotnet build $(MSBuildThisFileDirectory)NetCoreBuildLibrary/ClassLibrary1.csproj /t:rebuild"/>
 
-      <!-- The app must be built with `msbuild` -->
+      <!-- The app must be built with `msbuild` with a unique salt to bypass cache -->
       <Exec Command="dotnet restore" WorkingDirectory="$(MSBuildThisFileDirectory)NetFrameworkBuildApp"/>
-      <Exec Command="$(MSBuildExePath) $(MSBuildThisFileDirectory)NetFrameworkBuildApp/ConsoleApp1.csproj  /t:rebuild" EnvironmentVariables="DOTNET_ROOT_X64=;MSBUILD_EXE_PATH=;MSBuildSDKsPath="/>
+      <Exec Command="$(MSBuildExePath) $(MSBuildThisFileDirectory)NetFrameworkBuildApp/ConsoleApp1.csproj /t:rebuild /p:MetalamaAssemblyLocatorSalt=$(TestSalt)" EnvironmentVariables="DOTNET_ROOT_X64=;MSBUILD_EXE_PATH=;MSBuildSDKsPath="/>
   </Target>
 
 </Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue31024/Issue31024.sln
+++ b/Metalama.Framework/src/tests/Standalone/Issue31024/Issue31024.sln
@@ -1,0 +1,38 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NetCoreBuildLibrary", "NetCoreBuildLibrary", "{4A992B29-6BBC-BCC4-9E0B-4C961904C3FE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NetFrameworkBuildApp", "NetFrameworkBuildApp", "{B3080963-D9A2-711F-7E73-EEBCED5AC2AF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "NetCoreBuildLibrary\ClassLibrary1.csproj", "{6D0CD48B-92C9-B532-0740-7CC05DD8EDEE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "NetFrameworkBuildApp\ConsoleApp1.csproj", "{7A83826B-D2DC-7469-1B3D-120DE6EBC90D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6D0CD48B-92C9-B532-0740-7CC05DD8EDEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D0CD48B-92C9-B532-0740-7CC05DD8EDEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D0CD48B-92C9-B532-0740-7CC05DD8EDEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D0CD48B-92C9-B532-0740-7CC05DD8EDEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A83826B-D2DC-7469-1B3D-120DE6EBC90D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A83826B-D2DC-7469-1B3D-120DE6EBC90D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A83826B-D2DC-7469-1B3D-120DE6EBC90D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A83826B-D2DC-7469-1B3D-120DE6EBC90D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6D0CD48B-92C9-B532-0740-7CC05DD8EDEE} = {4A992B29-6BBC-BCC4-9E0B-4C961904C3FE}
+		{7A83826B-D2DC-7469-1B3D-120DE6EBC90D} = {B3080963-D9A2-711F-7E73-EEBCED5AC2AF}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5BC79CAC-0271-4E18-AD9E-0A18D817A0DE}
+	EndGlobalSection
+EndGlobal

--- a/Metalama.Framework/src/tests/Standalone/Issue31024/NetFrameworkBuildApp/ConsoleApp1.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue31024/NetFrameworkBuildApp/ConsoleApp1.csproj
@@ -13,6 +13,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <RuntimeIdentifier>win</RuntimeIdentifier>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Metalama.Framework/src/tests/Standalone/Issue31024/NetFrameworkBuildApp/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue31024/NetFrameworkBuildApp/Program.cs
@@ -1,19 +1,28 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
 using ClassLibrary1;
+using Metalama.Framework.Aspects;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ConsoleApp1
 {
+    // This aspect is defined directly in the .NET Framework project to force compile-time compilation,
+    // which exercises the NETCoreSdkVersion code path in LanguageVersionProvider.
+    public class LogAttribute : OverrideMethodAspect
+    {
+        public override dynamic? OverrideMethod()
+        {
+            Console.WriteLine( $"Entering {meta.Target.Method.Name}" );
+            return meta.Proceed();
+        }
+    }
+
     internal class Program : IInterface
     {
-        static void Main(string[] args)
+        [Log]
+        static void Main( string[] args )
         {
             Console.WriteLine( "Hello, world." );
         }

--- a/Metalama.Framework/src/tests/Standalone/Issue31024/NetFrameworkBuildApp/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue31024/NetFrameworkBuildApp/Program.cs
@@ -9,7 +9,8 @@ using System;
 namespace ConsoleApp1
 {
     // This aspect is defined directly in the .NET Framework project to force compile-time compilation,
-    // which exercises the NETCoreSdkVersion code path in LanguageVersionProvider.
+    // which exercises the GetLanguageVersionFromMSBuild() code path in LanguageVersionProvider
+    // (i.e., when NETCoreSdkVersion is empty or not available).
     public class LogAttribute : OverrideMethodAspect
     {
         public override dynamic? OverrideMethod()


### PR DESCRIPTION
## Summary
- When `NETCoreSdkVersion` is empty (old-style .NET Framework projects built with msbuild.exe instead of `dotnet build`), use `MSBuildBinPath` to locate and invoke msbuild.exe directly for compile-time project builds
- Added `MSBuildTool` class (similar to existing `DotNetTool`) to execute msbuild.exe
- Added `GetLanguageVersionFromMSBuild()` to determine C# language version from the Roslyn assembly bundled with MSBuild
- Added `MetalamaAssemblyLocatorSalt` property for cache invalidation in tests

## Issues Fixed
- #1247 - AssertionFailedException: Cannot parse the .NET SDK version '' when building old-style .NET Framework projects with msbuild.exe
- #1248 - MetalamaAssemblyLocatorSalt MSBuild property for cache invalidation