### PR TITLE
Escape C# keyword names with @ prefix in generated code (#812)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,3 +167,4 @@ When starting work on a GitHub issue:
 - Never await without cancellation token - ever
 - Github comments and issues and PRs must be signed by CLaude - not commits. No ad link, just signature.
 - don't loose time solving cosmetic warnings (such as redundant usings) until the finalizing stage of a commit
+- `Build.ps1 build` does not build test projects, only packable projects.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RestorePrerelease>true</RestorePrerelease>
   </PropertyGroup>
   <PropertyGroup>
-    <PostSharpEngineeringVersion Condition="'$(PostSharpEngineeringVersion)'==''">2023.2.275</PostSharpEngineeringVersion>
+    <PostSharpEngineeringVersion Condition="'$(PostSharpEngineeringVersion)'==''">2023.2.282</PostSharpEngineeringVersion>
   
     <!-- We must match the version used by the lowest version of Visual Studio supported by the VSX, i.e. VS 17.12. -->
     <NewtonsoftJsonMinVersion>13.0.3</NewtonsoftJsonMinVersion>

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Refactoring/CSharpAttributeHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Refactoring/CSharpAttributeHelper.cs
@@ -50,11 +50,13 @@ namespace Metalama.Framework.DesignTime.Refactoring
                 {
                     if ( newUnit.Usings.All( u => u.Name?.ToString() != ns ) )
                     {
+#pragma warning disable LAMA0850 // Namespace from user code
                         newRoot =
                             newUnit.AddUsings(
                                 SyntaxFactory.UsingDirective( SyntaxFactory.IdentifierName( ns ).WithLeadingTrivia( SyntaxFactory.ElasticSpace ) )
                                     .WithTrailingTrivia( context.OptionalElasticEndOfLineTriviaList )
                                     .WithAdditionalAnnotations( Formatter.Annotation ) );
+#pragma warning restore LAMA0850
                     }
                 }
             }
@@ -253,7 +255,9 @@ namespace Metalama.Framework.DesignTime.Refactoring
 
         private static AttributeListSyntax CreateAttributeSyntax( AttributeDescription attribute, bool forAssembly = false )
         {
+#pragma warning disable LAMA0850 // "assembly" is well-known
             var target = forAssembly ? SyntaxFactory.AttributeTargetSpecifier( SyntaxFactory.Identifier( "assembly" ) ) : null;
+#pragma warning restore LAMA0850
 
             AttributeArgumentListSyntax? argumentList = null;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine.Analyzers/UnsafeIdentifierAnalyzer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine.Analyzers/UnsafeIdentifierAnalyzer.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using System.Collections.Immutable;
+
+namespace Metalama.Framework.Engine.Analyzers;
+
+/// <summary>
+/// Analyzer to detect potentially unsafe calls to SyntaxFactory.Identifier and SyntaxFactory.IdentifierName
+/// with dynamic names that may be C# keywords and should use SyntaxFactoryEx.SafeIdentifier/SafeIdentifierName instead.
+/// </summary>
+[DiagnosticAnalyzer( LanguageNames.CSharp )]
+[UsedImplicitly]
+public class UnsafeIdentifierAnalyzer : DiagnosticAnalyzer
+{
+    // Range: 0850-0859
+    internal static readonly DiagnosticDescriptor UnsafeIdentifierCall = new(
+        "LAMA0850",
+        "Potentially unsafe Identifier/IdentifierName call",
+        "Call to SyntaxFactory.{0} with dynamic name may produce invalid code if the name is a C# keyword. Consider using SyntaxFactoryEx.Safe{0} or SyntaxFactoryEx.WellKnown{0} instead.",
+        "Metalama",
+        DiagnosticSeverity.Warning,
+        true );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create( UnsafeIdentifierCall );
+
+    public override void Initialize( AnalysisContext context )
+    {
+        context.ConfigureGeneratedCodeAnalysis( GeneratedCodeAnalysisFlags.None );
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction( InitializeCompilation );
+    }
+
+    private static void InitializeCompilation( CompilationStartAnalysisContext context )
+    {
+        var syntaxFactorySymbol = context.Compilation.GetTypeByMetadataName( "Microsoft.CodeAnalysis.CSharp.SyntaxFactory" );
+
+        if ( syntaxFactorySymbol == null )
+        {
+            return;
+        }
+
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation( operationContext, syntaxFactorySymbol ),
+            OperationKind.Invocation );
+    }
+
+    private static void AnalyzeInvocation( OperationAnalysisContext context, INamedTypeSymbol syntaxFactorySymbol )
+    {
+        if ( context.Operation is not IInvocationOperation invocation )
+        {
+            return;
+        }
+
+        var method = invocation.TargetMethod;
+
+        // Check if it's SyntaxFactory.Identifier or SyntaxFactory.IdentifierName
+        if ( !SymbolEqualityComparer.Default.Equals( method.ContainingType, syntaxFactorySymbol ) )
+        {
+            return;
+        }
+
+        if ( method.Name is not ("Identifier" or "IdentifierName") )
+        {
+            return;
+        }
+
+        // Check if the first argument is a dynamic name (property access like .Name or variable)
+        if ( invocation.Arguments.Length == 0 )
+        {
+            return;
+        }
+
+        var firstArg = invocation.Arguments[0].Value;
+
+        // Skip if it's a string literal (constant value) - those are intentional hardcoded names
+        if ( firstArg.ConstantValue.HasValue )
+        {
+            return;
+        }
+
+        // Skip if it's a nameof expression (also safe)
+        if ( firstArg is INameOfOperation )
+        {
+            return;
+        }
+
+        // Report warning for dynamic names that could be keywords
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                UnsafeIdentifierCall,
+                invocation.Syntax.GetLocation(),
+                method.Name ) );
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/AdviceSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/AdviceSyntaxGenerator.cs
@@ -179,7 +179,7 @@ internal static class AdviceSyntaxGenerator
 
             var initializerName = context.InjectionNameProvider.GetInitializerName( member.DeclaringType, aspectLayerInstance.AspectLayerId, member );
 
-            initializerExpressionSyntax = InvocationExpression( IdentifierName( initializerName ) );
+            initializerExpressionSyntax = InvocationExpression( SyntaxFactoryEx.SafeIdentifierName( initializerName ) );
 
             initializerMethodSyntax =
                 MethodDeclaration(
@@ -190,7 +190,7 @@ internal static class AdviceSyntaxGenerator
                     context.SyntaxGenerator.TypeSyntax( targetType )
                         .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                     null,
-                    Identifier( initializerName ),
+                    SyntaxFactoryEx.SafeIdentifier( initializerName ),
                     null,
                     ParameterList(),
                     List<TypeParameterConstraintClauseSyntax>(),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractConstructorTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractConstructorTransformation.cs
@@ -7,11 +7,11 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.AdviceImpl.Contracts;
 
@@ -48,7 +48,7 @@ internal sealed class ContractConstructorTransformation : ContractBaseTransforma
 
                     bool? inputResult, outputResult;
                     BlockSyntax? inputContractBlock, outputContractBlock;
-                    var valueSyntax = IdentifierName( param.Name );
+                    var valueSyntax = SyntaxFactoryEx.SafeIdentifierName( param.Name );
 
                     if ( this.ContractDirection is ContractDirection.Input or ContractDirection.Both )
                     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractIndexerTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractIndexerTransformation.cs
@@ -7,11 +7,11 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.AdviceImpl.Contracts;
 
@@ -57,7 +57,7 @@ internal sealed class ContractIndexerTransformation : ContractBaseTransformation
 
                         inputResult = this.TryExecuteTemplate(
                             context,
-                            IdentifierName( "value" ),
+                            SyntaxFactoryEx.SafeIdentifierName( "value" ),
                             targetIndexer.Type,
                             targetIndexer.SetMethod,
                             out inputContractBlock );
@@ -76,7 +76,7 @@ internal sealed class ContractIndexerTransformation : ContractBaseTransformation
 
                         outputResult = this.TryExecuteTemplate(
                             context,
-                            IdentifierName( returnVariableName ),
+                            SyntaxFactoryEx.SafeIdentifierName( returnVariableName ),
                             targetIndexer.Type,
                             targetIndexer.GetMethod,
                             out outputContractBlock );
@@ -123,7 +123,7 @@ internal sealed class ContractIndexerTransformation : ContractBaseTransformation
 
                     bool? inputResult, outputResult;
                     BlockSyntax? inputContractBlock, outputContractBlock;
-                    var valueSyntax = IdentifierName( parameter.Name );
+                    var valueSyntax = SyntaxFactoryEx.SafeIdentifierName( parameter.Name );
 
                     if ( this.ContractDirection is ContractDirection.Input or ContractDirection.Both )
                     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractMethodTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractMethodTransformation.cs
@@ -7,11 +7,11 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.AdviceImpl.Contracts;
 
@@ -48,7 +48,7 @@ internal sealed class ContractMethodTransformation : ContractBaseTransformation
 
                     var variableName = context.GetReturnValueVariableName();
 
-                    if ( !this.TryExecuteTemplate( context, IdentifierName( variableName ), returnValueParam.Type, targetMethod, out var contractBlock ) )
+                    if ( !this.TryExecuteTemplate( context, SyntaxFactoryEx.SafeIdentifierName( variableName ), returnValueParam.Type, targetMethod, out var contractBlock ) )
                     {
                         return Array.Empty<InsertedStatement>();
                     }
@@ -64,7 +64,7 @@ internal sealed class ContractMethodTransformation : ContractBaseTransformation
 
                     bool? inputResult, outputResult;
                     BlockSyntax? inputContractBlock, outputContractBlock;
-                    var valueSyntax = IdentifierName( param.Name );
+                    var valueSyntax = SyntaxFactoryEx.SafeIdentifierName( param.Name );
 
                     if ( this.ContractDirection is ContractDirection.Input or ContractDirection.Both )
                     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractPropertyTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractPropertyTransformation.cs
@@ -7,11 +7,11 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.AdviceImpl.Contracts;
 
@@ -51,7 +51,7 @@ internal sealed class ContractPropertyTransformation : ContractBaseTransformatio
         {
             Invariant.Assert( targetProperty.SetMethod is not null );
 
-            inputResult = this.TryExecuteTemplate( context, IdentifierName( "value" ), targetProperty.Type, targetProperty.SetMethod, out inputContractBlock );
+            inputResult = this.TryExecuteTemplate( context, SyntaxFactoryEx.SafeIdentifierName( "value" ), targetProperty.Type, targetProperty.SetMethod, out inputContractBlock );
         }
         else
         {
@@ -67,7 +67,7 @@ internal sealed class ContractPropertyTransformation : ContractBaseTransformatio
 
             outputResult = this.TryExecuteTemplate(
                 context,
-                IdentifierName( returnVariableName ),
+                SyntaxFactoryEx.SafeIdentifierName( returnVariableName ),
                 targetProperty.Type,
                 targetProperty.GetMethod,
                 out outputContractBlock );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorTransformation.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Formatting;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Transformations;
@@ -63,7 +64,7 @@ internal sealed class IntroduceConstructorTransformation
                         a =>
                             Argument(
                                 a.ParameterName != null
-                                    ? NameColon( IdentifierName( a.ParameterName ) )
+                                    ? NameColon( SyntaxFactoryEx.SafeIdentifierName( a.ParameterName ) )
                                     : null,
                                 default,
                                 a.Expression.ToExpressionSyntax( syntaxSerializationContext ) ) ) ) );
@@ -87,7 +88,7 @@ internal sealed class IntroduceConstructorTransformation
             ConstructorDeclaration(
                 AdviceSyntaxGenerator.GetAttributeLists( finalConstructor, context ),
                 finalConstructor.GetSyntaxModifierList(),
-                Identifier( finalConstructor.DeclaringType.Name ),
+                SyntaxFactoryEx.SafeIdentifier( finalConstructor.DeclaringType.Name ),
                 context.SyntaxGenerator.ParameterList( finalConstructor, context.FinalCompilation ),
                 initializer,
                 hasNoBody

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceStaticConstructorTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceStaticConstructorTransformation.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Formatting;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Microsoft.CodeAnalysis.CSharp;
 using System;
@@ -33,7 +34,7 @@ internal sealed class IntroduceStaticConstructorTransformation : IntroduceMember
             ConstructorDeclaration(
                 AdviceSyntaxGenerator.GetAttributeLists( constructorBuilder, context ),
                 TokenList( Token( TriviaList(), SyntaxKind.StaticKeyword, TriviaList( Space ) ) ),
-                Identifier( constructorBuilder.DeclaringType.Name ),
+                SyntaxFactoryEx.SafeIdentifier( constructorBuilder.DeclaringType.Name ),
                 ParameterList(),
                 null,
                 context.SyntaxGenerator.FormattedBlock().WithGeneratedCodeAnnotation( this.AspectInstance.AspectClass.GeneratedCodeAnnotation ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterAdviceImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterAdviceImpl.cs
@@ -19,7 +19,6 @@ using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Transformations;
 using Metalama.Framework.Engine.Utilities.UserCode;
 using Metalama.Framework.RunTime;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Linq;
@@ -157,7 +156,7 @@ internal sealed class PullConstructorParameterAdviceImpl
 
                     case PullActionKind.AppendParameterAndPull:
                         // Create a new parameter.
-                        parameterValue = SyntaxFactory.IdentifierName( pullParameterAction.ParameterName.AssertNotNull() );
+                        parameterValue = SyntaxFactoryEx.SafeIdentifierName( pullParameterAction.ParameterName.AssertNotNull() );
 
                         TypedConstant? constant = null;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceEventTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceEventTransformation.cs
@@ -80,7 +80,7 @@ internal sealed class IntroduceEventTransformation : IntroduceMemberTransformati
                         SeparatedList(
                         [
                             VariableDeclarator(
-                                Identifier( TriviaList(), finalEvent.Name, TriviaList( ElasticSpace ) ),
+                                SyntaxFactoryEx.SafeIdentifier( TriviaList(), finalEvent.Name, TriviaList( ElasticSpace ) ),
                                 null,
                                 initializerExpression != null
                                     ? EqualsValueClause( initializerExpression )
@@ -98,7 +98,7 @@ internal sealed class IntroduceEventTransformation : IntroduceMemberTransformati
                                 (NameSyntax) syntaxGenerator.TypeSyntax( finalEvent.ExplicitInterfaceImplementations.Single().DeclaringType ) )
                             .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options )
                         : null,
-                    Identifier( finalEvent.GetCleanName() ),
+                    SyntaxFactoryEx.SafeIdentifier( finalEvent.GetCleanName() ),
                     GenerateAccessorList(),
                     default );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceFieldTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceFieldTransformation.cs
@@ -63,7 +63,7 @@ internal sealed class IntroduceFieldTransformation : IntroduceMemberTransformati
                         .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                     SingletonSeparatedList(
                         VariableDeclarator(
-                            Identifier( fieldBuilder.Name ),
+                            SyntaxFactoryEx.SafeIdentifier( fieldBuilder.Name ),
                             null,
                             initializerExpression != null
                                 ? EqualsValueClause( initializerExpression )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceMethodTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceMethodTransformation.cs
@@ -151,7 +151,7 @@ internal sealed class IntroduceMethodTransformation : IntroduceMemberTransformat
                             context.SyntaxGenerator.ReturnType( finalMethod )
                                 .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                             explicitInterfaceSpecifier,
-                            Identifier( finalMethod.GetCleanName() ),
+                            SyntaxFactoryEx.SafeIdentifier( finalMethod.GetCleanName() ),
                             context.SyntaxGenerator.TypeParameterList( finalMethod, context.FinalCompilation ),
                             context.SyntaxGenerator.ParameterList( finalMethod, context.FinalCompilation ),
                             context.SyntaxGenerator.ConstraintClauses( finalMethod ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceNamedTypeTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceNamedTypeTransformation.cs
@@ -6,6 +6,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis.CSharp;
@@ -55,7 +56,7 @@ internal sealed class IntroduceNamedTypeTransformation : IntroduceDeclarationTra
                                     VarianceKind.Out => Token( SyntaxKind.OutKeyword ),
                                     _ => default
                                 },
-                                Identifier( tp.Name ) ) ) ) );
+                                SyntaxFactoryEx.SafeIdentifier( tp.Name ) ) ) ) );
 
         var type =
             (this.BuilderData.TypeKind switch
@@ -64,7 +65,7 @@ internal sealed class IntroduceNamedTypeTransformation : IntroduceDeclarationTra
                     (TypeDeclarationSyntax) ClassDeclaration(
                         AdviceSyntaxGenerator.GetAttributeLists( introducedType, context ),
                         introducedType.GetSyntaxModifierList(),
-                        Identifier( introducedType.Name ),
+                        SyntaxFactoryEx.SafeIdentifier( introducedType.Name ),
                         typeArgs,
                         baseList,
                         context.SyntaxGenerator.ConstraintClauses( introducedType ),
@@ -73,7 +74,7 @@ internal sealed class IntroduceNamedTypeTransformation : IntroduceDeclarationTra
                     StructDeclaration(
                         AdviceSyntaxGenerator.GetAttributeLists( introducedType, context ),
                         introducedType.GetSyntaxModifierList(),
-                        Identifier( introducedType.Name ),
+                        SyntaxFactoryEx.SafeIdentifier( introducedType.Name ),
                         typeArgs,
                         baseList,
                         context.SyntaxGenerator.ConstraintClauses( introducedType ),
@@ -82,7 +83,7 @@ internal sealed class IntroduceNamedTypeTransformation : IntroduceDeclarationTra
                     InterfaceDeclaration(
                         AdviceSyntaxGenerator.GetAttributeLists( introducedType, context ),
                         introducedType.GetSyntaxModifierList(),
-                        Identifier( introducedType.Name ),
+                        SyntaxFactoryEx.SafeIdentifier( introducedType.Name ),
                         typeArgs,
                         baseList,
                         context.SyntaxGenerator.ConstraintClauses( introducedType ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceParameterTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceParameterTransformation.cs
@@ -43,7 +43,7 @@ internal sealed class IntroduceParameterTransformation : BaseSyntaxTreeTransform
             default,
             syntaxGenerationContext.SyntaxGenerator.TypeSyntax( this.Parameter.Type )
                 .WithOptionalTrailingTrivia( SyntaxFactory.ElasticSpace, syntaxGenerationContext.Options ),
-            SyntaxFactory.Identifier( this.Parameter.Name.AssertNotNull() ),
+            SyntaxFactoryEx.SafeIdentifier( this.Parameter.Name.AssertNotNull() ),
             null );
 
         if ( this.Parameter.DefaultValue != null )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroducePropertyTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroducePropertyTransformation.cs
@@ -77,7 +77,7 @@ internal class IntroducePropertyTransformation : IntroduceMemberTransformation<P
                     ? ExplicitInterfaceSpecifier(
                         (NameSyntax) syntaxGenerator.TypeSyntax( finalProperty.ExplicitInterfaceImplementations.Single().DeclaringType ) )
                     : null,
-                Identifier( finalProperty.GetCleanName() ),
+                SyntaxFactoryEx.SafeIdentifier( finalProperty.GetCleanName() ),
                 GenerateAccessorList(),
                 null,
                 initializerExpression != null

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideConstructorTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideConstructorTransformation.cs
@@ -86,7 +86,7 @@ internal sealed class OverrideConstructorTransformation : OverrideMemberTransfor
                     TokenList( modifiers ),
                     PredefinedType( Token( SyntaxKind.VoidKeyword ) ),
                     null,
-                    Identifier(
+                    SyntaxFactoryEx.SafeIdentifier(
                         context.InjectionNameProvider.GetOverrideName(
                             overriddenDeclaration.DeclaringType,
                             this.AspectLayerId,
@@ -99,11 +99,11 @@ internal sealed class OverrideConstructorTransformation : OverrideMemberTransfor
                 : ConstructorDeclaration(
                     List<AttributeListSyntax>(),
                     TokenList( Token( TriviaList(), SyntaxKind.PrivateKeyword, TriviaList( ElasticSpace ) ) ),
-                    Identifier( overriddenDeclaration.DeclaringType.Name ),
+                    SyntaxFactoryEx.SafeIdentifier( overriddenDeclaration.DeclaringType.Name ),
                     this.GetParameterList( context, overriddenDeclaration ),
                     ConstructorInitializer(
                         SyntaxKind.ThisConstructorInitializer,
-                        ArgumentList( SeparatedList( overriddenDeclaration.Parameters.SelectAsArray( x => Argument( IdentifierName( x.Name ) ) ) ) ) ),
+                        ArgumentList( SeparatedList( overriddenDeclaration.Parameters.SelectAsArray( x => Argument( SyntaxFactoryEx.SafeIdentifierName( x.Name ) ) ) ) ) ),
                     newMethodBody,
                     null );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideEventTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideEventTransformation.cs
@@ -129,7 +129,7 @@ internal sealed class OverrideEventTransformation : OverrideMemberTransformation
                     context.SyntaxGenerator.EventType( overriddenDeclaration )
                         .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                     null!,
-                    Identifier( eventName ),
+                    SyntaxFactoryEx.SafeIdentifier( eventName ),
                     AccessorList(
                         List(
                         [
@@ -161,7 +161,7 @@ internal sealed class OverrideEventTransformation : OverrideMemberTransformation
                         modifiers,
                         context.SyntaxGenerator.TypeSyntax( eventHandlerInvokeMethod.ReturnType ),
                         null,
-                        Identifier(
+                        SyntaxFactoryEx.SafeIdentifier(
                             TriviaList( ElasticSpace ),
                             context.InjectionNameProvider.GetRaiseOverrideName(
                                 overriddenDeclaration.DeclaringType,
@@ -176,13 +176,13 @@ internal sealed class OverrideEventTransformation : OverrideMemberTransformation
                                     List<AttributeListSyntax>(),
                                     TokenList(),
                                     context.SyntaxGenerator.TypeSyntax( overriddenDeclaration.Type ),
-                                    Identifier( TriviaList( ElasticSpace ), "handler", TriviaList() ),
+                                    SyntaxFactoryEx.WellKnownIdentifier( TriviaList( ElasticSpace ), "handler", TriviaList() ),
                                     null ),
                                 Parameter(
                                     List<AttributeListSyntax>(),
                                     TokenList( Token( default, SyntaxKind.RefKeyword, SyntaxFactoryEx.ElasticSpaceTriviaList ) ),
                                     context.SyntaxGenerator.TypeSyntax( argsType ),
-                                    Identifier( TriviaList( ElasticSpace ), "args", TriviaList() ),
+                                    SyntaxFactoryEx.WellKnownIdentifier( TriviaList( ElasticSpace ), "args", TriviaList() ),
                                     null )
                             ] ) ),
                         List<TypeParameterConstraintClauseSyntax>(),
@@ -309,13 +309,13 @@ internal sealed class OverrideEventTransformation : OverrideMemberTransformation
         => AssignmentExpression(
             SyntaxKind.AddAssignmentExpression,
             this.CreateMemberAccessExpression( AspectReferenceTargetKind.EventAddAccessor, context ),
-            IdentifierName( "value" ) );
+            SyntaxFactoryEx.WellKnownIdentifierName( "value" ) );
 
     private ExpressionSyntax CreateRemoveExpression( MemberInjectionContext context )
         => AssignmentExpression(
             SyntaxKind.SubtractAssignmentExpression,
             this.CreateMemberAccessExpression( AspectReferenceTargetKind.EventRemoveAccessor, context ),
-            IdentifierName( "value" ) );
+            SyntaxFactoryEx.WellKnownIdentifierName( "value" ) );
 
     private ExpressionSyntax CreateInvokeExpression( MemberInjectionContext context )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideFinalizerTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideFinalizerTransformation.cs
@@ -85,7 +85,7 @@ internal sealed class OverrideFinalizerTransformation : OverrideMemberTransforma
                 TokenList( modifiers ),
                 PredefinedType( SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.VoidKeyword ) ),
                 null,
-                Identifier(
+                SyntaxFactoryEx.SafeIdentifier(
                     context.InjectionNameProvider.GetOverrideName(
                         overriddenDeclaration.DeclaringType,
                         this.AspectLayerId,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMethodBaseTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMethodBaseTransformation.cs
@@ -84,7 +84,7 @@ internal abstract class OverrideMethodBaseTransformation : OverrideMemberTransfo
             modifiers,
             returnType.WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
             null,
-            Identifier(
+            SyntaxFactoryEx.SafeIdentifier(
                 context.InjectionNameProvider.GetOverrideName(
                     overriddenDeclaration.DeclaringType,
                     this.AspectLayerId,
@@ -118,7 +118,7 @@ internal abstract class OverrideMethodBaseTransformation : OverrideMemberTransfo
                     ArgumentList(
                         SeparatedList(
                             overriddenDeclaration.Parameters.SelectAsReadOnlyList(
-                                p => Argument( null, p.RefKind.InvocationRefKindToken(), IdentifierName( p.Name ) ) ) ) ) ),
+                                p => Argument( null, p.RefKind.InvocationRefKindToken(), SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) ),
             MethodKind.Finalizer =>
                 context.AspectReferenceSyntaxProvider.AssertNotNull().GetFinalizerReference( this.AspectLayerId ),
             MethodKind.Operator =>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideOperatorTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideOperatorTransformation.cs
@@ -89,7 +89,7 @@ internal sealed class OverrideOperatorTransformation : OverrideMemberTransformat
                 context.SyntaxGenerator.ReturnType( overriddenDeclaration )
                     .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                 null,
-                Identifier(
+                SyntaxFactoryEx.SafeIdentifier(
                     context.InjectionNameProvider.GetOverrideName(
                         overriddenDeclaration.DeclaringType,
                         this.AspectLayerId,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverridePropertyBaseTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverridePropertyBaseTransformation.cs
@@ -69,7 +69,7 @@ internal abstract class OverridePropertyBaseTransformation : OverridePropertyOrI
                     context.SyntaxGenerator.PropertyType( overriddenDeclaration )
                         .WithOptionalTrailingTrivia( SyntaxFactory.ElasticSpace, context.SyntaxGenerationContext.Options ),
                     null,
-                    SyntaxFactory.Identifier( propertyName ),
+                    SyntaxFactoryEx.SafeIdentifier( propertyName ),
                     SyntaxFactory.AccessorList(
                         SyntaxFactory.List(
                             new[]

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/RedirectEventTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/RedirectEventTransformation.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Code.Collections;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -45,7 +46,7 @@ internal sealed class RedirectEventTransformation : OverrideMemberTransformation
                     overriddenDeclaration.GetSyntaxModifierList(),
                     context.SyntaxGenerator.EventType( overriddenDeclaration ),
                     null,
-                    Identifier(
+                    SyntaxFactoryEx.SafeIdentifier(
                         context.InjectionNameProvider.GetOverrideName(
                             overriddenDeclaration.DeclaringType,
                             this.AspectLayerId,
@@ -83,18 +84,18 @@ internal sealed class RedirectEventTransformation : OverrideMemberTransformation
                         AssignmentExpression(
                             assignmentKind,
                             CreateAccessTargetExpression(),
-                            IdentifierName( "value" ) ) ) );
+                            SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ) );
         }
 
         ExpressionSyntax CreateAccessTargetExpression()
         {
             return
                 this._targetEvent.Definition.IsStatic
-                    ? IdentifierName( this._targetEvent.Name.AssertNotNull() )
+                    ? SyntaxFactoryEx.SafeIdentifierName( this._targetEvent.Name.AssertNotNull() )
                     : MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             ThisExpression(),
-                            IdentifierName( this._targetEvent.Name.AssertNotNull() ) )
+                            SyntaxFactoryEx.SafeIdentifierName( this._targetEvent.Name.AssertNotNull() ) )
                         .WithAspectReferenceAnnotation( this.AspectLayerId, AspectReferenceOrder.Previous );
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/RedirectMethodTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/RedirectMethodTransformation.cs
@@ -59,7 +59,7 @@ internal sealed class RedirectMethodTransformation : OverrideMemberTransformatio
                     context.SyntaxGenerator.ReturnType( overriddenDeclaration )
                         .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                     null,
-                    Identifier(
+                    SyntaxFactoryEx.SafeIdentifier(
                         context.InjectionNameProvider.GetOverrideName(
                             overriddenDeclaration.DeclaringType,
                             this.AspectLayerId,
@@ -79,18 +79,18 @@ internal sealed class RedirectMethodTransformation : OverrideMemberTransformatio
             return
                 InvocationExpression(
                     GetInvocationTargetExpression(),
-                    ArgumentList( SeparatedList( overriddenDeclaration.Parameters.SelectAsReadOnlyList( p => Argument( IdentifierName( p.Name ) ) ) ) ) );
+                    ArgumentList( SeparatedList( overriddenDeclaration.Parameters.SelectAsReadOnlyList( p => Argument( SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) );
         }
 
         ExpressionSyntax GetInvocationTargetExpression()
         {
             var expression =
                 overriddenDeclaration.IsStatic
-                    ? (ExpressionSyntax) IdentifierName( this._targetMethod.Name.AssertNotNull() )
+                    ? (ExpressionSyntax) SyntaxFactoryEx.SafeIdentifierName( this._targetMethod.Name.AssertNotNull() )
                     : MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         ThisExpression(),
-                        IdentifierName( this._targetMethod.Name.AssertNotNull() ) );
+                        SyntaxFactoryEx.SafeIdentifierName( this._targetMethod.Name.AssertNotNull() ) );
 
             return expression
                 .WithAspectReferenceAnnotation( this.AspectLayerId, AspectReferenceOrder.Previous );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/RedirectPropertyTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/RedirectPropertyTransformation.cs
@@ -52,7 +52,7 @@ internal sealed class RedirectPropertyTransformation : OverrideMemberTransformat
                     context.SyntaxGenerator.PropertyType( overriddenDeclaration )
                         .WithOptionalTrailingTrivia( ElasticSpace, context.SyntaxGenerationContext.Options ),
                     null,
-                    Identifier(
+                    SyntaxFactoryEx.SafeIdentifier(
                         context.InjectionNameProvider.GetOverrideName(
                             overriddenDeclaration.DeclaringType,
                             this.AspectLayerId,
@@ -109,18 +109,18 @@ internal sealed class RedirectPropertyTransformation : OverrideMemberTransformat
                         AssignmentExpression(
                             SyntaxKind.SimpleAssignmentExpression,
                             CreateAccessTargetExpression(),
-                            IdentifierName( "value" ) ) ) );
+                            SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ) );
         }
 
         ExpressionSyntax CreateAccessTargetExpression()
         {
             return
                 this._targetProperty.GetTarget( context.FinalCompilation ).IsStatic
-                    ? IdentifierName( this._targetProperty.Name.AssertNotNull() )
+                    ? SyntaxFactoryEx.SafeIdentifierName( this._targetProperty.Name.AssertNotNull() )
                     : MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             ThisExpression(),
-                            IdentifierName( this._targetProperty.Name.AssertNotNull() ) )
+                            SyntaxFactoryEx.SafeIdentifierName( this._targetProperty.Name.AssertNotNull() ) )
                         .WithAspectReferenceAnnotation( this.AspectLayerId, AspectReferenceOrder.Previous );
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/BoundTemplateMethod.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/BoundTemplateMethod.cs
@@ -4,9 +4,9 @@
 
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using MethodKind = Microsoft.CodeAnalysis.MethodKind;
 
 namespace Metalama.Framework.Engine.Advising;
@@ -56,7 +56,7 @@ internal sealed class BoundTemplateMethod
             var parameter = signature.Parameters[index];
 
             newArguments[runTimeParameter.SourceIndex] = TypeAnnotationMapper.AddExpressionTypeAnnotation(
-                SyntaxFactory.IdentifierName( parameter.Name ),
+                SyntaxFactoryEx.SafeIdentifierName( parameter.Name ),
                 parameter.Type );
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateBindingHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateBindingHelper.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Code.Collections;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Helpers;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating;
 using Metalama.Framework.Engine.Utilities;
@@ -72,7 +73,7 @@ internal static class TemplateBindingHelper
             {
                 var templateParameter = template.TemplateMember.TemplateClassMember.RunTimeParameters[i];
                 var parameter = targetMethod.Parameters[i];
-                ExpressionSyntax parameterSyntax = IdentifierName( parameter.Name );
+                ExpressionSyntax parameterSyntax = SyntaxFactoryEx.SafeIdentifierName( parameter.Name );
                 parameterSyntax = TypeAnnotationMapper.AddExpressionTypeAnnotation( parameterSyntax, parameter.Type );
                 mappingBuilder.Add( templateParameter.Name, parameterSyntax );
             }
@@ -132,7 +133,7 @@ internal static class TemplateBindingHelper
             {
                 var templateParameter = template.TemplateMember.TemplateClassMember.RunTimeParameters[i];
                 var parameter = targetConstructor.Parameters[i];
-                ExpressionSyntax parameterSyntax = IdentifierName( parameter.Name );
+                ExpressionSyntax parameterSyntax = SyntaxFactoryEx.SafeIdentifierName( parameter.Name );
                 parameterSyntax = TypeAnnotationMapper.AddExpressionTypeAnnotation( parameterSyntax, parameter.Type );
                 mappingBuilder.Add( templateParameter.Name, parameterSyntax );
             }
@@ -273,7 +274,7 @@ internal static class TemplateBindingHelper
             }
             else
             {
-                parameterSyntax = IdentifierName( methodParameter.Name );
+                parameterSyntax = SyntaxFactoryEx.SafeIdentifierName( methodParameter.Name );
                 parameterSyntax = TypeAnnotationMapper.AddExpressionTypeAnnotation( parameterSyntax, methodParameter.Type );
             }
 
@@ -342,7 +343,7 @@ internal static class TemplateBindingHelper
 
         void AddParameter( IParameter methodParameter, IParameterSymbol templateParameter )
         {
-            ExpressionSyntax parameterSyntax = IdentifierName( methodParameter.Name );
+            ExpressionSyntax parameterSyntax = SyntaxFactoryEx.SafeIdentifierName( methodParameter.Name );
 
             parameterSyntax = TypeAnnotationMapper.AddExpressionTypeAnnotation( parameterSyntax, methodParameter.Type );
 
@@ -448,7 +449,7 @@ internal static class TemplateBindingHelper
                             ExpressionSyntax tupleAccessExpression = MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 IdentifierName( "args" ),
-                                IdentifierName( delegateParameter.Name ) );
+                                SyntaxFactoryEx.SafeIdentifierName( delegateParameter.Name ) );
 
                             tupleAccessExpression = TypeAnnotationMapper.AddExpressionTypeAnnotation( tupleAccessExpression, delegateParameter.Type );
 
@@ -821,7 +822,7 @@ internal static class TemplateBindingHelper
             {
                 var expression = runTimeParameterMapping.TryGetValue( parameter.Name, out var mapped )
                     ? mapped
-                    : IdentifierName( parameter.Name );
+                    : SyntaxFactoryEx.SafeIdentifierName( parameter.Name );
 
                 if ( !parameter.HasDefaultValue )
                 {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/BaseParameterBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/BaseParameterBuilder.cs
@@ -9,9 +9,9 @@ using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Abstractions;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
-using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
 
 namespace Metalama.Framework.Engine.CodeModel.Introductions.Builders;
@@ -49,12 +49,12 @@ internal abstract class BaseParameterBuilder : NamedDeclarationBuilder, IParamet
 
     bool IExpression.IsAssignable => true;
 
-    public ref object? Value => ref RefHelper.Wrap( new SyntaxUserExpression( SyntaxFactory.IdentifierName( this.Name ), this.Type, true ) );
+    public ref object? Value => ref RefHelper.Wrap( new SyntaxUserExpression( SyntaxFactoryEx.SafeIdentifierName( this.Name ), this.Type, true ) );
 
     public TypedExpressionSyntax ToTypedExpressionSyntax( ISyntaxGenerationContext syntaxGenerationContext, IType? targetType = null )
         => new(
             new TypedExpressionSyntaxImpl(
-                SyntaxFactory.IdentifierName( this.Name ),
+                SyntaxFactoryEx.SafeIdentifierName( this.Name ),
                 this.Type,
                 ((SyntaxSerializationContext) syntaxGenerationContext).CompilationModel,
                 true ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedParameter.cs
@@ -7,10 +7,10 @@ using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.CodeModel.Abstractions;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Utilities;
-using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -67,12 +67,12 @@ internal sealed class IntroducedParameter : IntroducedDeclaration, IParameterImp
 
     bool IExpression.IsAssignable => true;
 
-    public ref object? Value => ref RefHelper.Wrap( new SyntaxUserExpression( SyntaxFactory.IdentifierName( this.Name ), this.Type, true ) );
+    public ref object? Value => ref RefHelper.Wrap( new SyntaxUserExpression( SyntaxFactoryEx.SafeIdentifierName( this.Name ), this.Type, true ) );
 
     public TypedExpressionSyntax ToTypedExpressionSyntax( ISyntaxGenerationContext syntaxGenerationContext, IType? targetType = null )
         => new(
             new TypedExpressionSyntaxImpl(
-                SyntaxFactory.IdentifierName( this.Name ),
+                SyntaxFactoryEx.SafeIdentifierName( this.Name ),
                 this.Type,
                 ((SyntaxSerializationContext) syntaxGenerationContext).CompilationModel,
                 true ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/ConstructorInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/ConstructorInvoker.cs
@@ -121,7 +121,7 @@ internal sealed class ConstructorInvoker : Invoker<IConstructor>, IConstructorIn
                     .Select(
                         ( e, i ) =>
                             Argument(
-                                NameColon( IdentifierName( this._constructor.Parameters[i].Name ) ),
+                                NameColon( SyntaxFactoryEx.SafeIdentifierName( this._constructor.Parameters[i].Name ) ),
                                 this._constructor.Parameters[i].RefKind.InvocationRefKindToken(),
                                 e ) ),
                 null );
@@ -161,7 +161,7 @@ internal sealed class ConstructorInvoker : Invoker<IConstructor>, IConstructorIn
                     .Select(
                         ( e, i ) =>
                             Argument(
-                                NameColon( IdentifierName( this._constructor.Parameters[i].Name ) ),
+                                NameColon( SyntaxFactoryEx.SafeIdentifierName( this._constructor.Parameters[i].Name ) ),
                                 this._constructor.Parameters[i].RefKind.InvocationRefKindToken(),
                                 e ) ),
                 InitializerExpression(
@@ -171,7 +171,7 @@ internal sealed class ConstructorInvoker : Invoker<IConstructor>, IConstructorIn
                             i =>
                                 AssignmentExpression(
                                     SyntaxKind.SimpleAssignmentExpression,
-                                    IdentifierName( i.FieldOrPropertyName ),
+                                    SyntaxFactoryEx.SafeIdentifierName( i.FieldOrPropertyName ),
                                     i.Value.ToExpressionSyntax( syntaxSerializationContext ) ) ) ) ) );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/EventInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/EventInvoker.cs
@@ -120,7 +120,7 @@ internal sealed class EventInvoker : Invoker<IEvent>, IEventInvoker
         this.CheckInvocationOptionsAndTarget();
 
         var receiverInfo = this.GetReceiverInfo( syntaxSerializationContext );
-        var name = IdentifierName( this.GetCleanTargetMemberName() );
+        var name = SyntaxFactoryEx.SafeIdentifierName( this.GetCleanTargetMemberName() );
 
         var receiverSyntax = receiverInfo.GetReceiverSyntax( this.Member, syntaxSerializationContext );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/FieldOrPropertyInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/FieldOrPropertyInvoker.cs
@@ -6,6 +6,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Code.Invokers;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Utilities.Roslyn;
@@ -32,7 +33,7 @@ internal class FieldOrPropertyInvoker : Invoker<IFieldOrProperty>, IFieldOrPrope
 
         var receiverInfo = this.GetReceiverInfo( context );
 
-        var name = IdentifierName( this.GetCleanTargetMemberName() );
+        var name = SyntaxFactoryEx.SafeIdentifierName( this.GetCleanTargetMemberName() );
 
         var receiverSyntax = receiverInfo.GetReceiverSyntax( this.Member, context );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Code.Invokers;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Utilities.Roslyn;
@@ -123,12 +124,12 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
                 if ( this.Member.IsGeneric )
                 {
                     name = GenericName(
-                        Identifier( this.GetCleanTargetMemberName() ),
+                        SyntaxFactoryEx.SafeIdentifier( this.GetCleanTargetMemberName() ),
                         TypeArgumentList( SeparatedList( this.Member.TypeArguments.SelectAsImmutableArray( t => context.SyntaxGenerator.TypeSyntax( t ) ) ) ) );
                 }
                 else
                 {
-                    name = IdentifierName( this.GetCleanTargetMemberName() );
+                    name = SyntaxFactoryEx.SafeIdentifierName( this.GetCleanTargetMemberName() );
                 }
 
                 var arguments = this.Member.GetArguments( this.Member.Parameters, args, context );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/ValueArrayExpression.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/ValueArrayExpression.cs
@@ -5,10 +5,10 @@
 using Metalama.Framework.Code;
 using Metalama.Framework.Code.Collections;
 using Metalama.Framework.Engine.CodeModel.Collections;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
 using SpecialType = Microsoft.CodeAnalysis.SpecialType;
@@ -33,7 +33,7 @@ internal sealed class ValueArrayExpression : UserExpression
             this._parent.SelectAsReadOnlyList(
                 p =>
                     p.RefKind.IsReadable()
-                        ? SyntaxFactory.IdentifierName( p.Name )
+                        ? SyntaxFactoryEx.SafeIdentifierName( p.Name )
                         : (SyntaxNode) syntaxGenerator.DefaultExpression( p.Type ) ) );
     }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/Pseudo/PseudoParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/Pseudo/PseudoParameter.cs
@@ -10,6 +10,7 @@ using Metalama.Framework.Engine.CodeModel.Collections;
 using Metalama.Framework.Engine.CodeModel.GenericContexts;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Utilities;
@@ -123,9 +124,9 @@ namespace Metalama.Framework.Engine.CodeModel.Source.Pseudo
             => this._namePrefix != null
                 ? SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName( this._namePrefix ),
-                    SyntaxFactory.IdentifierName( this.Name ) )
-                : SyntaxFactory.IdentifierName( this.Name );
+                    SyntaxFactoryEx.SafeIdentifierName( this._namePrefix ),
+                    SyntaxFactoryEx.SafeIdentifierName( this.Name ) )
+                : SyntaxFactoryEx.SafeIdentifierName( this.Name );
 
         public override bool BelongsToCurrentProject => this.ContainingDeclaration.BelongsToCurrentProject;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceParameter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceParameter.cs
@@ -8,11 +8,11 @@ using Metalama.Framework.Engine.CodeModel.Abstractions;
 using Metalama.Framework.Engine.CodeModel.GenericContexts;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.ReflectionMocks;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Metalama.Framework.Engine.Templating.Expressions;
 using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -98,12 +98,12 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
         bool IExpression.IsAssignable => true;
 
-        public ref object? Value => ref RefHelper.Wrap( new SyntaxVariableExpression( SyntaxFactory.IdentifierName( this.Name ), this.Type, this.RefKind ) );
+        public ref object? Value => ref RefHelper.Wrap( new SyntaxVariableExpression( SyntaxFactoryEx.SafeIdentifierName( this.Name ), this.Type, this.RefKind ) );
 
         public TypedExpressionSyntax ToTypedExpressionSyntax( ISyntaxGenerationContext syntaxGenerationContext, IType? targetType = null )
             => new(
                 new TypedExpressionSyntaxImpl(
-                    SyntaxFactory.IdentifierName( this.Name ),
+                    SyntaxFactoryEx.SafeIdentifierName( this.Name ),
                     this.Type,
                     ((SyntaxSerializationContext) syntaxGenerationContext).CompilationModel,
                     true ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
@@ -1659,7 +1659,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                     return MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
                                             this.CreateTypeSyntax( symbol.ContainingType ),
-                                            SyntaxFactoryEx.SafeIdentifierName( node.Identifier.Text ) )
+                                            SyntaxFactoryEx.WellKnownIdentifierName( node.Identifier ) )
                                         .WithTriviaFrom( nodeWithoutPreprocessorDirectives );
                             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
@@ -324,7 +324,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                             // Rename the type and add [OriginalId].
 
                                             transformedChild = transformedChild
-                                                .WithIdentifier( Identifier( newName ) )
+                                                .WithIdentifier( SyntaxFactoryEx.WellKnownIdentifier( newName ) )
                                                 .WithModifiers( TokenList( Token( SyntaxKind.InternalKeyword ).WithTrailingTrivia( ElasticSpace ) ) )
                                                 .WithAttributeLists(
                                                     transformedChild.AttributeLists.Add( AttributeList( SingletonSeparatedList( originalNameAttribute ) ) ) );
@@ -569,7 +569,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                         default,
                                         syntaxGenerator.TypeSyntax( method.ReturnType ),
                                         ExplicitInterfaceSpecifier( (NameSyntax) syntaxGenerator.TypeSyntax( implementedInterface ) ),
-                                        Identifier( method.Name ),
+                                        SyntaxFactoryEx.SafeIdentifier( method.Name ),
                                         default,
                                         ParameterList(
                                             SeparatedList(
@@ -578,7 +578,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                                         default,
                                                         default,
                                                         syntaxGenerator.TypeSyntax( p.Type ),
-                                                        Identifier( p.Name ),
+                                                        SyntaxFactoryEx.SafeIdentifier( p.Name ),
                                                         default ) ) ) ),
                                         default,
                                         method.ReturnType.SpecialType == SpecialType.System_Void
@@ -1055,7 +1055,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                                                     MemberAccessExpression(
                                                                         SyntaxKind.SimpleMemberAccessExpression,
                                                                         ThisExpression(),
-                                                                        IdentifierName( interfaceProperty.Name ) ) ),
+                                                                        SyntaxFactoryEx.SafeIdentifierName( interfaceProperty.Name ) ) ),
                                                                 Token( SyntaxKind.SemicolonToken ) )
                                                             : null,
                                                         AccessorDeclaration(
@@ -1070,8 +1070,8 @@ namespace Metalama.Framework.Engine.CompileTime
                                                                     MemberAccessExpression(
                                                                         SyntaxKind.SimpleMemberAccessExpression,
                                                                         ThisExpression(),
-                                                                        IdentifierName( interfaceProperty.Name ) ),
-                                                                    IdentifierName( "value" ) ) ),
+                                                                        SyntaxFactoryEx.SafeIdentifierName( interfaceProperty.Name ) ),
+                                                                    SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ),
                                                             Token( SyntaxKind.SemicolonToken ) )
                                                     }.WhereNotNull() ) ) );
                                 }
@@ -1388,7 +1388,7 @@ namespace Metalama.Framework.Engine.CompileTime
 
                 if ( unnestedType != null && node.Identifier.Text == unnestedType.Name )
                 {
-                    return visitedConstructor.WithIdentifier( Identifier( this._currentContext.NestedTypeNewName! ) );
+                    return visitedConstructor.WithIdentifier( SyntaxFactoryEx.WellKnownIdentifier( this._currentContext.NestedTypeNewName! ) );
                 }
                 else
                 {
@@ -1561,13 +1561,13 @@ namespace Metalama.Framework.Engine.CompileTime
                 static NameSyntax RenameType( NameSyntax syntax, string newIdentifier, int nestingLevel )
                     => syntax switch
                     {
-                        AliasQualifiedNameSyntax aliasQualifiedNameSyntax => aliasQualifiedNameSyntax.WithName( IdentifierName( newIdentifier ) ),
+                        AliasQualifiedNameSyntax aliasQualifiedNameSyntax => aliasQualifiedNameSyntax.WithName( SyntaxFactoryEx.WellKnownIdentifierName( newIdentifier ) ),
                         QualifiedNameSyntax qualifiedNameSyntax when nestingLevel > 0 => RenameType(
                             qualifiedNameSyntax.Left,
                             newIdentifier,
                             nestingLevel - 1 ),
-                        QualifiedNameSyntax qualifiedNameSyntax when nestingLevel == 0 => qualifiedNameSyntax.WithRight( IdentifierName( newIdentifier ) ),
-                        SimpleNameSyntax => IdentifierName( newIdentifier ),
+                        QualifiedNameSyntax qualifiedNameSyntax when nestingLevel == 0 => qualifiedNameSyntax.WithRight( SyntaxFactoryEx.WellKnownIdentifierName( newIdentifier ) ),
+                        SimpleNameSyntax => SyntaxFactoryEx.WellKnownIdentifierName( newIdentifier ),
                         _ => throw new AssertionFailedException( $"Unexpected syntax kind {syntax.Kind()} at '{syntax.GetDiagnosticLocation()}'." )
                     };
 
@@ -1659,7 +1659,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                     return MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
                                             this.CreateTypeSyntax( symbol.ContainingType ),
-                                            IdentifierName( node.Identifier.Text ) )
+                                            SyntaxFactoryEx.SafeIdentifierName( node.Identifier.Text ) )
                                         .WithTriviaFrom( nodeWithoutPreprocessorDirectives );
                             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
@@ -684,11 +684,11 @@ internal sealed partial class CompileTimeCompilationBuilder
         static NameSyntax ParseNamespace( string ns )
         {
             var parts = ns.Split( '.' );
-            NameSyntax result = SyntaxFactory.IdentifierName( parts[0] );
+            NameSyntax result = SyntaxFactoryEx.SafeIdentifierName( parts[0] );
 
             for ( var i = 1; i < parts.Length; i++ )
             {
-                result = SyntaxFactory.QualifiedName( result, SyntaxFactory.IdentifierName( parts[i] ) );
+                result = SyntaxFactory.QualifiedName( result, SyntaxFactoryEx.SafeIdentifierName( parts[i] ) );
             }
 
             return result;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/Serialization/SerializerGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/Serialization/SerializerGenerator.cs
@@ -479,7 +479,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                         Token( SyntaxKind.ReturnKeyword ).WithTrailingTrivia( Space ),
                         ObjectCreationExpression(
                             serializedTypeSyntax,
-                            ArgumentList( SingletonSeparatedList( Argument( IdentifierName( createInstanceMethod.Parameters[1].Name ) ) ) ),
+                            ArgumentList( SingletonSeparatedList( Argument( SyntaxFactoryEx.SafeIdentifierName( createInstanceMethod.Parameters[1].Name ) ) ) ),
                             null ),
                         Token( SyntaxKind.SemicolonToken ) ) );
         }
@@ -529,7 +529,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
         {
             var localVariableDeclaration = this.CreateTypedLocalVariable(
                 serializedTypeSyntax,
-                IdentifierName( baseSerializeMethod.Parameters[0].Name ),
+                SyntaxFactoryEx.SafeIdentifierName( baseSerializeMethod.Parameters[0].Name ),
                 out var localVariableName );
 
             var statements = new[]
@@ -538,9 +538,9 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                 localVariableDeclaration,
                 this.CreateFieldSerializationStatements(
                     serializedType,
-                    IdentifierName( localVariableName ),
-                    IdentifierName( baseSerializeMethod.Parameters[1].Name ),
-                    IdentifierName( baseSerializeMethod.Parameters[2].Name ) )
+                    SyntaxFactoryEx.WellKnownIdentifierName( localVariableName ),
+                    SyntaxFactoryEx.SafeIdentifierName( baseSerializeMethod.Parameters[1].Name ),
+                    SyntaxFactoryEx.SafeIdentifierName( baseSerializeMethod.Parameters[2].Name ) )
             };
 
             body = Block( statements.WhereNotNull() );
@@ -569,7 +569,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 BaseExpression(),
                                 IdentifierName( nameof(ReferenceTypeSerializer.SerializeObject) ) ),
-                            ArgumentList( SeparatedList( baseSerializeMethod.Parameters.Select( p => Argument( IdentifierName( p.Name ) ) ) ) ) ) );
+                            ArgumentList( SeparatedList( baseSerializeMethod.Parameters.Select( p => Argument( SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) ) );
         }
     }
 
@@ -590,7 +590,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
         {
             var localVariableDeclaration = this.CreateTypedLocalVariable(
                 serializedTypeSyntax,
-                IdentifierName( baseDeserializeMethod.Parameters[0].Name ),
+                SyntaxFactoryEx.SafeIdentifierName( baseDeserializeMethod.Parameters[0].Name ),
                 out var localVariableName );
 
             var statements = new[]
@@ -599,8 +599,8 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                 localVariableDeclaration,
                 this.CreateFieldDeserializationStatements(
                     serializedType,
-                    IdentifierName( localVariableName ),
-                    IdentifierName( baseDeserializeMethod.Parameters[1].Name ),
+                    SyntaxFactoryEx.WellKnownIdentifierName( localVariableName ),
+                    SyntaxFactoryEx.SafeIdentifierName( baseDeserializeMethod.Parameters[1].Name ),
                     this.SelectLateDeserializedFields,
                     static _ => Array.Empty<ISymbol>() )
             };
@@ -631,7 +631,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 BaseExpression(),
                                 IdentifierName( nameof(ReferenceTypeSerializer.DeserializeFields) ) ),
-                            ArgumentList( SeparatedList( baseDeserializeMethod.Parameters.Select( p => Argument( IdentifierName( p.Name ) ) ) ) ) ) );
+                            ArgumentList( SeparatedList( baseDeserializeMethod.Parameters.Select( p => Argument( SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) ) );
         }
     }
 
@@ -645,8 +645,8 @@ internal sealed class SerializerGenerator : ISerializerGenerator
 
         var body = this.CreateFieldSerializationStatements(
             serializedType,
-            IdentifierName( serializeMethod.Parameters[0].Name ),
-            IdentifierName( serializeMethod.Parameters[1].Name ),
+            SyntaxFactoryEx.SafeIdentifierName( serializeMethod.Parameters[0].Name ),
+            SyntaxFactoryEx.SafeIdentifierName( serializeMethod.Parameters[1].Name ),
             null );
 
         return this.CreateOverrideMethod(
@@ -668,7 +668,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                     Token( SyntaxKind.ReturnKeyword ).WithTrailingTrivia( Space ),
                     ObjectCreationExpression(
                         serializedTypeSyntax,
-                        ArgumentList( SingletonSeparatedList( Argument( IdentifierName( deserializeMethod.Parameters[0].Name ) ) ) ),
+                        ArgumentList( SingletonSeparatedList( Argument( SyntaxFactoryEx.SafeIdentifierName( deserializeMethod.Parameters[0].Name ) ) ) ),
                         null ),
                     Token( SyntaxKind.SemicolonToken ) ) );
 
@@ -683,11 +683,11 @@ internal sealed class SerializerGenerator : ISerializerGenerator
             TokenList( Token( SyntaxKind.PublicKeyword ).WithTrailingTrivia( Space ), Token( SyntaxKind.OverrideKeyword ).WithTrailingTrivia( Space ) ),
             this._context.SyntaxGenerator.TypeSyntax( methodSymbol.ReturnType ).WithTrailingTrivia( Space ),
             null,
-            Identifier( methodSymbol.Name ),
+            SyntaxFactoryEx.WellKnownIdentifier( methodSymbol.Name ),
             null,
             ParameterList(
                 SeparatedList(
-                    methodSymbol.Parameters.Select( p => Parameter( Identifier( p.Name ) ).WithType( this._context.SyntaxGenerator.TypeSyntax( p.Type ) ) ) ) ),
+                    methodSymbol.Parameters.Select( p => Parameter( SyntaxFactoryEx.SafeIdentifier( p.Name ) ).WithType( this._context.SyntaxGenerator.TypeSyntax( p.Type ) ) ) ) ),
             List<TypeParameterConstraintClauseSyntax>(),
             body,
             null );
@@ -719,7 +719,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                                     MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
                                         objectExpression,
-                                        IdentifierName( member.Name ) ) ),
+                                        SyntaxFactoryEx.SafeIdentifierName( member.Name ) ) ),
                                 Argument( LiteralExpression( SyntaxKind.StringLiteralExpression, Literal( serializedType.Type.Name ) ) )
                             ] ) ) ) ) );
         }
@@ -753,7 +753,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             targetExpression,
-                            IdentifierName( member.Name ) ),
+                            SyntaxFactoryEx.SafeIdentifierName( member.Name ) ),
                         InvocationExpression(
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
@@ -778,7 +778,7 @@ internal sealed class SerializerGenerator : ISerializerGenerator
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             targetExpression,
-                            IdentifierName( member.Name ) ),
+                            SyntaxFactoryEx.SafeIdentifierName( member.Name ) ),
                         LiteralExpression( SyntaxKind.DefaultLiteralExpression ) ) ) );
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Inlining/MethodLocalDeclarationInliner.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Inlining/MethodLocalDeclarationInliner.cs
@@ -104,7 +104,7 @@ namespace Metalama.Framework.Engine.Linking.Inlining
                     LocalDeclarationStatement(
                             VariableDeclaration(
                                 syntaxGenerationContext.SyntaxGenerator.TypeSyntax( specification.DestinationSemantic.Symbol.ReturnType ),
-                                SingletonSeparatedList( VariableDeclarator( Identifier( specification.ReturnVariableIdentifier.AssertNotNull() ) ) ) ) )
+                                SingletonSeparatedList( VariableDeclarator( SyntaxFactoryEx.SafeIdentifier( specification.ReturnVariableIdentifier.AssertNotNull() ) ) ) ) )
                         .NormalizeWhitespaceIfNecessary( syntaxGenerationContext )
                         .WithOptionalTrailingLineFeed( syntaxGenerationContext ),
                     linkedTargetBody )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Inlining/PropertyGetLocalDeclarationInliner.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Inlining/PropertyGetLocalDeclarationInliner.cs
@@ -92,7 +92,7 @@ namespace Metalama.Framework.Engine.Linking.Inlining
                     LocalDeclarationStatement(
                             VariableDeclaration(
                                 syntaxGenerationContext.SyntaxGenerator.TypeSyntax( specification.DestinationSemantic.Symbol.ReturnType ),
-                                SingletonSeparatedList( VariableDeclarator( Identifier( specification.ReturnVariableIdentifier.AssertNotNull() ) ) ) ) )
+                                SingletonSeparatedList( VariableDeclarator( SyntaxFactoryEx.SafeIdentifier( specification.ReturnVariableIdentifier.AssertNotNull() ) ) ) ) )
                         .NormalizeWhitespaceIfNecessary( syntaxGenerationContext )
                         .WithOptionalTrailingLineFeed( syntaxGenerationContext ),
                     linkedTargetBody )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.cs
@@ -397,7 +397,7 @@ namespace Metalama.Framework.Engine.Linking
                                         Token( TriviaList(), SyntaxKind.RefKeyword, TriviaList( ElasticSpace ) ),
                                         EventBrokerSyntaxHelper.GetEventBrokerField( eventBrokerFieldName, targetEvent.IsStatic ) ) );
 
-                                fieldInitializationArguments.Add( Argument( IdentifierName( brokerCallbacksField.FieldName ) ) );
+                                fieldInitializationArguments.Add( Argument( SyntaxFactoryEx.SafeIdentifierName( brokerCallbacksField.FieldName ) ) );
 
                                 if ( !targetEvent.IsStatic )
                                 {
@@ -446,8 +446,8 @@ namespace Metalama.Framework.Engine.Linking
         {
             // We must use the invoke method to get the parameter names, and not the tuple type, because the element name is not available for 1-tuples.
             var invokeMethod = delegateType.Methods.OfName( "Invoke" ).Single();
-            var parameterList = SeparatedList( invokeMethod.Parameters.SelectAsArray( p => Parameter( Identifier( p.Name ) ) ) );
-            var argumentList = SeparatedList( invokeMethod.Parameters.SelectAsArray( p => Argument( IdentifierName( p.Name ) ) ) );
+            var parameterList = SeparatedList( invokeMethod.Parameters.SelectAsArray( p => Parameter( SyntaxFactoryEx.SafeIdentifier( p.Name ) ) ) );
+            var argumentList = SeparatedList( invokeMethod.Parameters.SelectAsArray( p => Argument( SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) );
 
             return
                 SimpleLambdaExpression(
@@ -504,19 +504,19 @@ namespace Metalama.Framework.Engine.Linking
                 ] ) );
 
             ExpressionSyntax raiseMethod = isStatic
-                ? IdentifierName( raiseMethodName )
+                ? SyntaxFactoryEx.SafeIdentifierName( raiseMethodName )
                 : MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName( "me" ),
-                    IdentifierName( raiseMethodName ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "me" ),
+                    SyntaxFactoryEx.SafeIdentifierName( raiseMethodName ) );
 
             var expression = InvocationExpression(
                 raiseMethod,
                 ArgumentList(
                     SeparatedList<ArgumentSyntax>(
                     [
-                        Argument( IdentifierName( "handler" ) ),
-                        Argument( null, Token( default, SyntaxKind.RefKeyword, SyntaxFactoryEx.ElasticSpaceTriviaList ), IdentifierName( "args" ) )
+                        Argument( SyntaxFactoryEx.WellKnownIdentifierName( "handler" ) ),
+                        Argument( null, Token( default, SyntaxKind.RefKeyword, SyntaxFactoryEx.ElasticSpaceTriviaList ), SyntaxFactoryEx.WellKnownIdentifierName( "args" ) )
                     ] ) ) );
 
             return
@@ -540,16 +540,16 @@ namespace Metalama.Framework.Engine.Linking
                 ] ) );
 
             ExpressionSyntax overrideMethod = isStatic
-                ? IdentifierName( overrideMethodName )
+                ? SyntaxFactoryEx.SafeIdentifierName( overrideMethodName )
                 : MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName( "me" ),
-                    IdentifierName( overrideMethodName ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "me" ),
+                    SyntaxFactoryEx.SafeIdentifierName( overrideMethodName ) );
 
             var expression = AssignmentExpression(
                 operationKind,
                 overrideMethod,
-                IdentifierName( "handler" ) );
+                SyntaxFactoryEx.WellKnownIdentifierName( "handler" ) );
 
             return
                 ParenthesizedLambdaExpression(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAspectReferenceSyntaxProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAspectReferenceSyntaxProvider.cs
@@ -57,9 +57,9 @@ internal sealed class LinkerAspectReferenceSyntaxProvider : AspectReferenceSynta
                                         .SelectAsArray(
                                             p =>
                                                 Argument(
-                                                    NameColon( IdentifierName( p.Name ) ),
+                                                    NameColon( SyntaxFactoryEx.SafeIdentifierName( p.Name ) ),
                                                     p.RefKind.InvocationRefKindToken(),
-                                                    IdentifierName( p.Name ) ) ) ) ),
+                                                    SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ),
                             null ) ) ) ) );
 
     public override ExpressionSyntax GetEventRaiseReference(
@@ -149,7 +149,7 @@ internal sealed class LinkerAspectReferenceSyntaxProvider : AspectReferenceSynta
                             p => Argument(
                                 null,
                                 p.RefKind.InvocationRefKindToken(),
-                                IdentifierName( p.Name ) ) ) ) ) )
+                                SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) )
             .WithAspectReferenceAnnotation(
                 aspectLayer,
                 AspectReferenceOrder.Previous,
@@ -178,7 +178,7 @@ internal sealed class LinkerAspectReferenceSyntaxProvider : AspectReferenceSynta
             arguments.Add( Argument( ThisExpression() ) );
         }
 
-        arguments.AddRange( targetOperator.Parameters.SelectAsReadOnlyCollection( p => Argument( IdentifierName( p.Name ) ) ) );
+        arguments.AddRange( targetOperator.Parameters.SelectAsReadOnlyCollection( p => Argument( SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) );
 
         var invocationExpression = InvocationExpression(
             helperMember,
@@ -231,11 +231,11 @@ internal sealed class LinkerAspectReferenceSyntaxProvider : AspectReferenceSynta
         {
             memberName = GenericName( memberNameString )
                 .WithTypeArgumentList(
-                    TypeArgumentList( SeparatedList( generic.TypeParameters.SelectAsReadOnlyList( p => (TypeSyntax) IdentifierName( p.Name ) ) ) ) );
+                    TypeArgumentList( SeparatedList( generic.TypeParameters.SelectAsReadOnlyList( p => (TypeSyntax) SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) );
         }
         else
         {
-            memberName = IdentifierName( memberNameString );
+            memberName = SyntaxFactoryEx.SafeIdentifierName( memberNameString );
         }
 
         if ( !targetDeclaration.IsStatic )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionHelperProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionHelperProvider.cs
@@ -129,13 +129,13 @@ internal sealed class LinkerInjectionHelperProvider
 
         return MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
-            IdentifierName( HelperTypeName ),
+            SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
             GenericName(
-                Identifier( operatorData.MemberName ),
+                SyntaxFactoryEx.SafeIdentifier( operatorData.MemberName ),
                 TypeArgumentList( SeparatedList( typeParameters ) ) ) );
     }
 
-    public TypeSyntax GetSourceType() => QualifiedName( IdentifierName( HelperTypeName ), IdentifierName( _sourceCodeTypeName ) );
+    public TypeSyntax GetSourceType() => QualifiedName( SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ), SyntaxFactoryEx.WellKnownIdentifierName( _sourceCodeTypeName ) );
 
     public TypeSyntax GetOverriddenByType( SyntaxGenerationContext context, IAspectClass aspectType, int ordinal )
         => this.GetNumberedHelperType( context, _overriddenByTypeName, "override", aspectType, ordinal );
@@ -157,17 +157,17 @@ internal sealed class LinkerInjectionHelperProvider
             case 0:
                 return
                     QualifiedName(
-                        IdentifierName( HelperTypeName ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
                         GenericName(
-                            Identifier( baseTypeName ),
+                            SyntaxFactoryEx.WellKnownIdentifier( baseTypeName ),
                             TypeArgumentList( SingletonSeparatedList( aspectTypeSyntax ) ) ) );
 
             default:
                 return
                     QualifiedName(
-                        IdentifierName( HelperTypeName ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
                         GenericName(
-                            Identifier( baseTypeName ),
+                            SyntaxFactoryEx.WellKnownIdentifier( baseTypeName ),
                             TypeArgumentList( SeparatedList( [aspectTypeSyntax, GetOrdinalTypeArgument( aspectType.ShortName, description, ordinal )] ) ) ) );
         }
     }
@@ -182,25 +182,25 @@ internal sealed class LinkerInjectionHelperProvider
             case < 10:
                 return
                     QualifiedName(
-                        IdentifierName( HelperTypeName ),
-                        IdentifierName( _ordinalTypeName + ordinal ) );
+                        SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( _ordinalTypeName + ordinal ) );
 
             case < 100:
                 return
                     QualifiedName(
-                        IdentifierName( HelperTypeName ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
                         GenericName(
-                            Identifier( _compositeOrdinalTypeName ),
+                            SyntaxFactoryEx.WellKnownIdentifier( _compositeOrdinalTypeName ),
                             TypeArgumentList(
                                 SeparatedList<TypeSyntax>(
                                     new[]
                                     {
                                         QualifiedName(
-                                            IdentifierName( HelperTypeName ),
-                                            IdentifierName( _ordinalTypeName + (ordinal / 10) ) ),
+                                            SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
+                                            SyntaxFactoryEx.WellKnownIdentifierName( _ordinalTypeName + (ordinal / 10) ) ),
                                         QualifiedName(
-                                            IdentifierName( HelperTypeName ),
-                                            IdentifierName( _ordinalTypeName + (ordinal % 10) ) )
+                                            SyntaxFactoryEx.WellKnownIdentifierName( HelperTypeName ),
+                                            SyntaxFactoryEx.WellKnownIdentifierName( _ordinalTypeName + (ordinal % 10) ) )
                                     } ) ) ) );
 
             default:

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
@@ -102,7 +102,7 @@ internal sealed partial class LinkerInjectionStep
                                     Argument(
                                         null,
                                         p.Modifiers.FirstOrDefault( m => !m.IsKind( SyntaxKind.ParamsKeyword ) ),
-                                        SyntaxFactoryEx.SafeIdentifierName( p.Identifier.ValueText ) ) ) ) ) ),
+                                        SyntaxFactoryEx.WellKnownIdentifierName( p.Identifier ) ) ) ) ) ),
                 Block(),
                 null,
                 default );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
@@ -81,7 +81,7 @@ internal sealed partial class LinkerInjectionStep
                         List<AttributeListSyntax>(),
                         TokenList(),
                         this._injectionNameProvider.GetSourceType(),
-                        Identifier( AspectReferenceSyntaxProvider.LinkerOverrideParamName ),
+                        WellKnownIdentifier( AspectReferenceSyntaxProvider.LinkerOverrideParamName ),
                         EqualsValueClause(
                             LiteralExpression(
                                 SyntaxKind.DefaultLiteralExpression,
@@ -91,7 +91,7 @@ internal sealed partial class LinkerInjectionStep
                 List<AttributeListSyntax>(),
                 constructor.Definition.GetSyntaxModifierList( ModifierCategories.Unsafe )
                     .Insert( 0, TokenWithTrailingSpace( SyntaxKind.PrivateKeyword ) ),
-                Identifier( constructor.DeclaringType.AssertNotNull().Name.AssertNotNull() ),
+                SyntaxFactoryEx.SafeIdentifier( constructor.DeclaringType.AssertNotNull().Name.AssertNotNull() ),
                 parameters,
                 ConstructorInitializer(
                     SyntaxKind.ThisConstructorInitializer,
@@ -102,7 +102,7 @@ internal sealed partial class LinkerInjectionStep
                                     Argument(
                                         null,
                                         p.Modifiers.FirstOrDefault( m => !m.IsKind( SyntaxKind.ParamsKeyword ) ),
-                                        IdentifierName( p.Identifier.ValueText ) ) ) ) ) ),
+                                        SyntaxFactoryEx.SafeIdentifierName( p.Identifier.ValueText ) ) ) ) ) ),
                 Block(),
                 null,
                 default );
@@ -154,7 +154,7 @@ internal sealed partial class LinkerInjectionStep
                     ProceedHelper.CreateMemberAccessExpression( method, aspectLayerId, AspectReferenceTargetKind.Self, syntaxGenerationContext ),
                     ArgumentList(
                         SeparatedList(
-                            method.Parameters.SelectAsReadOnlyList( p => Argument( null, p.RefKind.InvocationRefKindToken(), IdentifierName( p.Name ) ) ) ) ) );
+                            method.Parameters.SelectAsReadOnlyList( p => Argument( null, p.RefKind.InvocationRefKindToken(), SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) );
 
             var (useStateMachine, emulatedTemplateKind) = (returnVariableName != null, asyncInfo, iteratorInfo) switch
             {
@@ -216,7 +216,7 @@ internal sealed partial class LinkerInjectionStep
 
                     body = Block(
                         CreateLocalVariableDeclaration( returnVariableName ),
-                        CreateEnumerableEpilogue( returnItemName, IdentifierName( returnVariableName ) ) );
+                        CreateEnumerableEpilogue( returnItemName, SafeIdentifierName( returnVariableName ) ) );
                 }
                 else if ( iteratorInfo.EnumerableKind is EnumerableKind.IEnumerator or EnumerableKind.UntypedIEnumerator
                          or EnumerableKind.IAsyncEnumerator )
@@ -231,10 +231,10 @@ internal sealed partial class LinkerInjectionStep
                                 VarIdentifier(),
                                 SingletonSeparatedList(
                                     VariableDeclarator(
-                                        Identifier( returnVariableName ),
+                                        SafeIdentifier( returnVariableName ),
                                         null,
-                                        EqualsValueClause( IdentifierName( bufferedEnumeratorName ) ) ) ) ) ),
-                        CreateEnumeratorEpilogue( IdentifierName( bufferedEnumeratorName ) ) );
+                                        EqualsValueClause( SafeIdentifierName( bufferedEnumeratorName ) ) ) ) ) ),
+                        CreateEnumeratorEpilogue( SafeIdentifierName( bufferedEnumeratorName ) ) );
                 }
                 else
                 {
@@ -242,7 +242,7 @@ internal sealed partial class LinkerInjectionStep
                         CreateLocalVariableDeclaration( returnVariableName ),
                         ReturnStatement(
                             TokenWithTrailingSpace( SyntaxKind.ReturnKeyword ),
-                            IdentifierName( returnVariableName ),
+                            SafeIdentifierName( returnVariableName ),
                             Token( SyntaxKind.SemicolonToken ) ) );
                 }
 
@@ -253,7 +253,7 @@ internal sealed partial class LinkerInjectionStep
                             VarIdentifier(),
                             SingletonSeparatedList(
                                 VariableDeclarator(
-                                    Identifier( variableName ),
+                                    SafeIdentifier( variableName ),
                                     null,
                                     EqualsValueClause( proceedExpression ) ) ) ) );
                 }
@@ -278,7 +278,7 @@ internal sealed partial class LinkerInjectionStep
                 modifiers,
                 returnType.WithOptionalTrailingTrivia( ElasticSpace, syntaxGenerationContext.Options ),
                 null,
-                Identifier( this._injectionNameProvider.GetOverrideName( method.DeclaringType, aspectLayerId, method ) ),
+                SafeIdentifier( this._injectionNameProvider.GetOverrideName( method.DeclaringType, aspectLayerId, method ) ),
                 syntaxGenerationContext.SyntaxGenerator.TypeParameterList( method, this._finalCompilationModel ),
                 syntaxGenerationContext.SyntaxGenerator.ParameterList( method, this._finalCompilationModel, true ),
                 syntaxGenerationContext.SyntaxGenerator.ConstraintClauses( method ),
@@ -296,7 +296,7 @@ internal sealed partial class LinkerInjectionStep
                         Token( SyntaxKind.ForEachKeyword ),
                         Token( SyntaxKind.OpenParenToken ),
                         VarIdentifier(),
-                        Identifier( itemName ),
+                        SafeIdentifier( itemName ),
                         Token( TriviaList( ElasticSpace ), SyntaxKind.InKeyword, TriviaList( ElasticSpace ) ),
                         enumerableExpression,
                         Token( SyntaxKind.CloseParenToken ),
@@ -305,7 +305,7 @@ internal sealed partial class LinkerInjectionStep
                                 SyntaxKind.YieldReturnStatement,
                                 Token( TriviaList(), SyntaxKind.YieldKeyword, TriviaList( ElasticSpace ) ),
                                 Token( TriviaList(), SyntaxKind.ReturnKeyword, TriviaList( ElasticSpace ) ),
-                                IdentifierName( itemName ),
+                                SafeIdentifierName( itemName ),
                                 Token( SyntaxKind.SemicolonToken ) ) ) );
             }
 
@@ -371,7 +371,7 @@ internal sealed partial class LinkerInjectionStep
                                     VarIdentifier(),
                                     SingletonSeparatedList(
                                         VariableDeclarator(
-                                            Identifier( returnVariableName ),
+                                            SafeIdentifier( returnVariableName ),
                                             null,
                                             EqualsValueClause(
                                                 this._aspectReferenceSyntaxProvider.GetPropertyReference(
@@ -381,7 +381,7 @@ internal sealed partial class LinkerInjectionStep
                                                     syntaxGenerationContext.SyntaxGenerator ) ) ) ) ) ),
                             ReturnStatement(
                                 TokenWithTrailingSpace( SyntaxKind.ReturnKeyword ),
-                                IdentifierName( returnVariableName ),
+                                SafeIdentifierName( returnVariableName ),
                                 Token( SyntaxKind.SemicolonToken ) ) )
                         : Block(
                             ReturnStatement(
@@ -427,7 +427,7 @@ internal sealed partial class LinkerInjectionStep
                     syntaxGenerationContext.SyntaxGenerator.PropertyType( property )
                         .WithOptionalTrailingTrivia( ElasticSpace, syntaxGenerationContext.Options ),
                     null,
-                    Identifier( this._injectionNameProvider.GetOverrideName( property.DeclaringType, aspectLayerId, property ) ),
+                    SafeIdentifier( this._injectionNameProvider.GetOverrideName( property.DeclaringType, aspectLayerId, property ) ),
                     AccessorList(
                         List(
                             new[]
@@ -484,7 +484,7 @@ internal sealed partial class LinkerInjectionStep
                                     VarIdentifier(),
                                     SingletonSeparatedList(
                                         VariableDeclarator(
-                                            Identifier( returnVariableName ),
+                                            SafeIdentifier( returnVariableName ),
                                             null,
                                             EqualsValueClause(
                                                 this._aspectReferenceSyntaxProvider.GetIndexerReference(
@@ -494,7 +494,7 @@ internal sealed partial class LinkerInjectionStep
                                                     syntaxGenerationContext.SyntaxGenerator ) ) ) ) ) ),
                             ReturnStatement(
                                 TokenWithTrailingSpace( SyntaxKind.ReturnKeyword ),
-                                IdentifierName( returnVariableName ),
+                                SafeIdentifierName( returnVariableName ),
                                 Token( SyntaxKind.SemicolonToken ) ) )
                         : Block(
                             ReturnStatement(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using MethodKind = Metalama.Framework.Code.MethodKind;
 
@@ -826,7 +827,7 @@ internal sealed partial class LinkerInjectionStep
                                                                         ExpressionStatement(
                                                                             AssignmentExpression(
                                                                                 SyntaxKind.SimpleAssignmentExpression,
-                                                                                IdentifierName( declarator.Identifier.ValueText ),
+                                                                                SafeIdentifierName( declarator.Identifier.ValueText ),
                                                                                 declarator.Initializer.AssertNotNull().Value ) ),
                                                                         s )
                                                                     .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -827,7 +827,7 @@ internal sealed partial class LinkerInjectionStep
                                                                         ExpressionStatement(
                                                                             AssignmentExpression(
                                                                                 SyntaxKind.SimpleAssignmentExpression,
-                                                                                SafeIdentifierName( declarator.Identifier.ValueText ),
+                                                                                WellKnownIdentifierName( declarator.Identifier ),
                                                                                 declarator.Initializer.AssertNotNull().Value ) ),
                                                                         s )
                                                                     .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
@@ -42,7 +42,7 @@ internal sealed partial class LinkerRewritingDriver
                                 .WithOptionalTrailingTrivia( ElasticSpace, context.Options ),
                             SingletonSeparatedList(
                                 VariableDeclarator(
-                                    Identifier( TriviaList( ElasticSpace ), GetCleanPrimaryConstructorFieldName( primaryConstructorField ), default ) ) ) ),
+                                    WellKnownIdentifier( TriviaList( ElasticSpace ), GetCleanPrimaryConstructorFieldName( primaryConstructorField ), default ) ) ) ),
                         Token( SyntaxKind.SemicolonToken ).WithOptionalTrailingLineFeed( context ) ) );
             }
 
@@ -54,7 +54,7 @@ internal sealed partial class LinkerRewritingDriver
                         TokenList( TokenWithTrailingSpace( SyntaxKind.PublicKeyword ) ),
                         context.SyntaxGenerator.TypeSyntax( primaryConstructorProperty.Type ),
                         null,
-                        Identifier( TriviaList( ElasticSpace ), primaryConstructorProperty.Name, default ),
+                        SyntaxFactoryEx.SafeIdentifier( TriviaList( ElasticSpace ), primaryConstructorProperty.Name, default ),
                         AccessorList(
                             List(
                             [
@@ -107,11 +107,11 @@ internal sealed partial class LinkerRewritingDriver
                                     (StatementSyntax) ExpressionStatement(
                                         AssignmentExpression(
                                             SyntaxKind.SimpleAssignmentExpression,
-                                            IdentifierName( p.Identifier ),
+                                            SafeIdentifierName( p.Identifier.ValueText ),
                                             MemberAccessExpression(
                                                     SyntaxKind.SimpleMemberAccessExpression,
                                                     ThisExpression(),
-                                                    IdentifierName( p.Identifier ) )
+                                                    SafeIdentifierName( p.Identifier.ValueText ) )
                                                 .WithSimplifierAnnotationIfNecessary( context ) ) ) ) ),
                         null,
                         default ) );
@@ -219,8 +219,8 @@ internal sealed partial class LinkerRewritingDriver
                                     MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
                                         ThisExpression(),
-                                        IdentifierName( cleanName ) ),
-                                    IdentifierName( cleanName ) )
+                                        WellKnownIdentifierName( cleanName ) ),
+                                    WellKnownIdentifierName( cleanName ) )
                                 .WithSimplifierAnnotationIfNecessary( context ) ) );
                 }
 
@@ -265,7 +265,7 @@ internal sealed partial class LinkerRewritingDriver
 
                                 case ParameterSyntax parameterDeclaration:
                                     name = parameterDeclaration.Identifier.ValueText;
-                                    expression = IdentifierName( parameterDeclaration.Identifier.ValueText );
+                                    expression = SafeIdentifierName( parameterDeclaration.Identifier.ValueText );
 
                                     break;
 
@@ -286,7 +286,7 @@ internal sealed partial class LinkerRewritingDriver
                                 MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
                                         ThisExpression(),
-                                        IdentifierName( name ) )
+                                        SafeIdentifierName( name ) )
                                     .WithSimplifierAnnotationIfNecessary( context ),
                                 expression ) ) );
                 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
@@ -107,11 +107,11 @@ internal sealed partial class LinkerRewritingDriver
                                     (StatementSyntax) ExpressionStatement(
                                         AssignmentExpression(
                                             SyntaxKind.SimpleAssignmentExpression,
-                                            SafeIdentifierName( p.Identifier.ValueText ),
+                                            WellKnownIdentifierName( p.Identifier ),
                                             MemberAccessExpression(
                                                     SyntaxKind.SimpleMemberAccessExpression,
                                                     ThisExpression(),
-                                                    SafeIdentifierName( p.Identifier.ValueText ) )
+                                                    WellKnownIdentifierName( p.Identifier ) )
                                                 .WithSimplifierAnnotationIfNecessary( context ) ) ) ) ),
                         null,
                         default ) );
@@ -265,7 +265,7 @@ internal sealed partial class LinkerRewritingDriver
 
                                 case ParameterSyntax parameterDeclaration:
                                     name = parameterDeclaration.Identifier.ValueText;
-                                    expression = SafeIdentifierName( parameterDeclaration.Identifier.ValueText );
+                                    expression = WellKnownIdentifierName( parameterDeclaration.Identifier );
 
                                     break;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.ConversionOperators.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.ConversionOperators.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking
@@ -162,7 +163,7 @@ namespace Metalama.Framework.Engine.Linking
                     modifiers,
                     @operator.Type.WithOptionalTrailingTrivia( ElasticSpace, this.SyntaxGenerationOptions ),
                     null,
-                    Identifier( name ),
+                    WellKnownIdentifier( name ),
                     null,
                     this.FilterAttributesOnSpecialImpl(
                         symbol.Parameters,
@@ -191,7 +192,7 @@ namespace Metalama.Framework.Engine.Linking
             {
                 var invocation =
                     InvocationExpression(
-                        IdentifierName( targetSymbol.Name ),
+                        SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name ),
                         ArgumentList() );
 
                 return context.SyntaxGenerator.FormattedBlock(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Destructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Destructors.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking
@@ -163,7 +164,7 @@ namespace Metalama.Framework.Engine.Linking
                         modifiers,
                         PredefinedType( SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.VoidKeyword ) ),
                         null,
-                        Identifier( name ),
+                        WellKnownIdentifier( name ),
                         null,
                         destructor.ParameterList.WithOptionalTrailingTrivia( default(SyntaxTriviaList), this.SyntaxGenerationOptions ),
                         List<TypeParameterConstraintClauseSyntax>(),
@@ -189,7 +190,7 @@ namespace Metalama.Framework.Engine.Linking
             {
                 var invocation =
                     InvocationExpression(
-                        MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), IdentifierName( targetSymbol.Name ) )
+                        MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name ) )
                             .WithSimplifierAnnotationIfNecessary( context ),
                         ArgumentList() );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.EventFields.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.EventFields.cs
@@ -131,7 +131,7 @@ namespace Metalama.Framework.Engine.Linking
                         SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.EventKeyword ),
                         eventFieldDeclaration.Declaration.Type.WithOptionalTrailingTrivia( ElasticSpace, this.SyntaxGenerationOptions ),
                         null,
-                        Identifier( symbol.Name ),
+                        SyntaxFactoryEx.SafeIdentifier( symbol.Name ),
                         AccessorList(
                             Token( context.OptionalElasticEndOfLineTriviaList, SyntaxKind.OpenBraceToken, context.OptionalElasticEndOfLineTriviaList ),
                             List( [transformedAdd, transformedRemove] ),
@@ -253,11 +253,11 @@ namespace Metalama.Framework.Engine.Linking
             {
                 if ( targetSymbol.IsStatic )
                 {
-                    return IdentifierName( targetSymbol.Name );
+                    return SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name );
                 }
                 else
                 {
-                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), IdentifierName( targetSymbol.Name ) )
+                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name ) )
                         .WithSimplifierAnnotationIfNecessary( context );
                 }
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Events.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Events.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking
@@ -230,9 +231,9 @@ namespace Metalama.Framework.Engine.Linking
                                 symbol.IsStatic
                                     ? context.SyntaxGenerator.TypeSyntax( symbol.ContainingType )
                                     : ThisExpression(),
-                                IdentifierName( GetBackingFieldName( (IEventSymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
+                                WellKnownIdentifierName( GetBackingFieldName( (IEventSymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
                             .WithSimplifierAnnotationIfNecessary( context ),
-                        IdentifierName( "value" ) ),
+                        WellKnownIdentifierName( "value" ) ),
                     Token( default, SyntaxKind.SemicolonToken, new SyntaxTriviaList( context.ElasticEndOfLineTrivia ) ) ) );
 
         private static BlockSyntax GetImplicitRemoverBody( IMethodSymbol symbol, SyntaxGenerationContext context )
@@ -245,9 +246,9 @@ namespace Metalama.Framework.Engine.Linking
                                 symbol.IsStatic
                                     ? context.SyntaxGenerator.TypeSyntax( symbol.ContainingType )
                                     : ThisExpression(),
-                                IdentifierName( GetBackingFieldName( (IEventSymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
+                                WellKnownIdentifierName( GetBackingFieldName( (IEventSymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
                             .WithSimplifierAnnotationIfNecessary( context ),
-                        IdentifierName( "value" ) ),
+                        WellKnownIdentifierName( "value" ) ),
                     Token( default, SyntaxKind.SemicolonToken, context.OptionalElasticEndOfLineTriviaList ) ) );
 
         private EventFieldDeclarationSyntax GetEventBackingField(
@@ -321,7 +322,7 @@ namespace Metalama.Framework.Engine.Linking
                             eventType.WithOptionalTrailingTrivia( ElasticSpace, this.SyntaxGenerationOptions ),
                             SingletonSeparatedList(
                                 VariableDeclarator(
-                                    Identifier( GetBackingFieldName( symbol ) ),
+                                    WellKnownIdentifier( GetBackingFieldName( symbol ) ),
                                     null,
                                     initializer ) ) ) )
                     .NormalizeWhitespaceIfNecessary( context )
@@ -423,7 +424,7 @@ namespace Metalama.Framework.Engine.Linking
                             : TokenList( SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.PrivateKeyword ) ),
                         eventType,
                         null,
-                        Identifier( name ),
+                        WellKnownIdentifier( name ),
                         cleanAccessorList )
                     .NormalizeWhitespaceIfNecessary( context )
                     .WithOptionalLeadingAndTrailingLineFeed( context )
@@ -491,11 +492,11 @@ namespace Metalama.Framework.Engine.Linking
             {
                 if ( targetSemantic.Kind is IntermediateSymbolSemanticKind.Base )
                 {
-                    return IdentifierName( GetOriginalImplMemberName( targetSemantic.Symbol ) );
+                    return WellKnownIdentifierName( GetOriginalImplMemberName( targetSemantic.Symbol ) );
                 }
                 else
                 {
-                    return IdentifierName( targetSemantic.Symbol.Name );
+                    return SafeIdentifierName( targetSemantic.Symbol.Name );
                 }
             }
         }
@@ -527,7 +528,7 @@ namespace Metalama.Framework.Engine.Linking
                                     eventBrokerTypeInfo.EventBrokerType.WithNullableAnnotation( NullableAnnotation.Annotated ) ),
                                 SingletonSeparatedList(
                                     VariableDeclarator(
-                                        Identifier( eventBrokerTransformationInfo.EventBrokerFieldName ),
+                                        WellKnownIdentifier( eventBrokerTransformationInfo.EventBrokerFieldName ),
                                         null,
                                         null ) ) ) )
                         .NormalizeWhitespaceIfNecessary( context )
@@ -572,7 +573,7 @@ namespace Metalama.Framework.Engine.Linking
                             : TokenList( SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.PublicKeyword ) ),
                         context.SyntaxGenerator.TypeSyntax( eventSymbol.Type ),
                         null,
-                        Identifier( eventBrokerInfo.BrokerProxyName ),
+                        WellKnownIdentifier( eventBrokerInfo.BrokerProxyName ),
                         AccessorList( List( [addAccessor, removeAccessor] ) ) )
                     .NormalizeWhitespaceIfNecessary( context )
                     .WithOptionalLeadingAndTrailingLineFeed( context )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Fields.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Fields.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking
@@ -90,7 +91,7 @@ namespace Metalama.Framework.Engine.Linking
                             : TokenList( SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.PrivateKeyword ) ),
                         type,
                         null,
-                        Identifier( GetEmptyImplMemberName( symbol ) ),
+                        WellKnownIdentifier( GetEmptyImplMemberName( symbol ) ),
                         accessorList.WithOptionalTrailingLineFeed( context ),
                         null,
                         null )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Indexers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Indexers.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 // Properties with overrides have the following structure:
@@ -277,7 +278,7 @@ namespace Metalama.Framework.Engine.Linking
                                 symbol.IsStatic
                                     ? context.SyntaxGenerator.TypeSyntax( symbol.ContainingType )
                                     : ThisExpression(),
-                                IdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
+                                WellKnownIdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
                             .WithSimplifierAnnotationIfNecessary( context ),
                         Token( SyntaxKind.SemicolonToken ) ) )
                 .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation );
@@ -292,9 +293,9 @@ namespace Metalama.Framework.Engine.Linking
                                     symbol.IsStatic
                                         ? context.SyntaxGenerator.TypeSyntax( symbol.ContainingType )
                                         : ThisExpression(),
-                                    IdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
+                                    WellKnownIdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
                                 .WithSimplifierAnnotationIfNecessary( context ),
-                            IdentifierName( "value" ) ) ) )
+                            WellKnownIdentifierName( "value" ) ) ) )
                 .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
         private MemberDeclarationSyntax GetOriginalImplIndexer(
@@ -443,11 +444,11 @@ namespace Metalama.Framework.Engine.Linking
             {
                 if ( targetSymbol.IsStatic )
                 {
-                    return IdentifierName( targetSymbol.Name );
+                    return SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name );
                 }
                 else
                 {
-                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), IdentifierName( targetSymbol.Name ) )
+                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name ) )
                         .WithSimplifierAnnotationIfNecessary( context );
                 }
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
@@ -317,7 +317,7 @@ namespace Metalama.Framework.Engine.Linking
                     InvocationExpression(
                         GetInvocationTarget(),
                         ArgumentList(
-                            SeparatedList( method.ParameterList.Parameters.SelectAsReadOnlyList( x => Argument( SafeIdentifierName( x.Identifier.ValueText ) ) ) ) ) );
+                            SeparatedList( method.ParameterList.Parameters.SelectAsReadOnlyList( x => Argument( WellKnownIdentifierName( x.Identifier ) ) ) ) ) );
 
                 if ( !targetSemantic.Symbol.ReturnsVoid )
                 {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking
@@ -280,7 +281,7 @@ namespace Metalama.Framework.Engine.Linking
                         modifiers,
                         returnType.WithOptionalTrailingTrivia( ElasticSpace, generationContext.Options ),
                         null,
-                        Identifier( name ),
+                        WellKnownIdentifier( name ),
                         method.TypeParameterList != null ? this.FilterAttributesOnSpecialImpl( symbol.TypeParameters, method.TypeParameterList ) : null,
                         this.FilterAttributesOnSpecialImpl(
                             symbol.Parameters,
@@ -316,7 +317,7 @@ namespace Metalama.Framework.Engine.Linking
                     InvocationExpression(
                         GetInvocationTarget(),
                         ArgumentList(
-                            SeparatedList( method.ParameterList.Parameters.SelectAsReadOnlyList( x => Argument( IdentifierName( x.Identifier ) ) ) ) ) );
+                            SeparatedList( method.ParameterList.Parameters.SelectAsReadOnlyList( x => Argument( SafeIdentifierName( x.Identifier.ValueText ) ) ) ) ) );
 
                 if ( !targetSemantic.Symbol.ReturnsVoid )
                 {
@@ -348,11 +349,11 @@ namespace Metalama.Framework.Engine.Linking
                 {
                     if ( targetSemantic.Kind is IntermediateSymbolSemanticKind.Base )
                     {
-                        return IdentifierName( GetOriginalImplMemberName( targetSemantic.Symbol ) );
+                        return WellKnownIdentifierName( GetOriginalImplMemberName( targetSemantic.Symbol ) );
                     }
                     else
                     {
-                        return IdentifierName( targetSemantic.Symbol.Name );
+                        return SafeIdentifierName( targetSemantic.Symbol.Name );
                     }
                 }
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Operators.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Operators.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking
@@ -168,7 +169,7 @@ namespace Metalama.Framework.Engine.Linking
                         modifiers,
                         @operator.ReturnType.WithOptionalTrailingTrivia( ElasticSpace, this.SyntaxGenerationOptions ),
                         null,
-                        Identifier( name ),
+                        WellKnownIdentifier( name ),
                         null,
                         this.FilterAttributesOnSpecialImpl(
                             symbol.Parameters,
@@ -198,7 +199,7 @@ namespace Metalama.Framework.Engine.Linking
             {
                 var invocation =
                     InvocationExpression(
-                        IdentifierName( targetSymbol.Name ),
+                        SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name ),
                         ArgumentList() );
 
                 return context.SyntaxGenerator.FormattedBlock(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.PositionalProperties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.PositionalProperties.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 // Properties with overrides have the following structure:
@@ -41,7 +42,7 @@ namespace Metalama.Framework.Engine.Linking
                     members.Add(
                         this.GetPropertyBackingField(
                             recordParameter.Type.AssertNotNull(),
-                            EqualsValueClause( IdentifierName( recordParameter.Identifier.ValueText ) ),
+                            EqualsValueClause( SafeIdentifierName( recordParameter.Identifier.ValueText ) ),
                             FilterAttributeListsForTarget( recordParameter.AttributeLists, SyntaxKind.FieldKeyword, false, false ),
                             symbol,
                             generationContext ) );
@@ -197,11 +198,11 @@ namespace Metalama.Framework.Engine.Linking
             {
                 if ( targetSymbol.IsStatic )
                 {
-                    return IdentifierName( targetSymbol.Name );
+                    return SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name );
                 }
                 else
                 {
-                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), IdentifierName( targetSymbol.Name ) )
+                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Name ) )
                         .WithSimplifierAnnotationIfNecessary( context );
                 }
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.PositionalProperties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.PositionalProperties.cs
@@ -42,7 +42,7 @@ namespace Metalama.Framework.Engine.Linking
                     members.Add(
                         this.GetPropertyBackingField(
                             recordParameter.Type.AssertNotNull(),
-                            EqualsValueClause( SafeIdentifierName( recordParameter.Identifier.ValueText ) ),
+                            EqualsValueClause( WellKnownIdentifierName( recordParameter.Identifier ) ),
                             FilterAttributeListsForTarget( recordParameter.AttributeLists, SyntaxKind.FieldKeyword, false, false ),
                             symbol,
                             generationContext ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 // Properties with overrides have the following structure:
@@ -353,7 +354,7 @@ namespace Metalama.Framework.Engine.Linking
                         type.WithOptionalTrailingTrivia( ElasticSpace, this.SyntaxGenerationOptions ),
                         SingletonSeparatedList(
                             VariableDeclarator(
-                                Identifier( GetBackingFieldName( symbol ) ),
+                                WellKnownIdentifier( GetBackingFieldName( symbol ) ),
                                 null,
                                 initializer ) ) ) )
                 .WithOptionalTrivia(
@@ -372,7 +373,7 @@ namespace Metalama.Framework.Engine.Linking
                                 symbol.IsStatic
                                     ? generationContext.SyntaxGenerator.TypeSyntax( symbol.ContainingType )
                                     : ThisExpression(),
-                                IdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
+                                WellKnownIdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
                             .WithSimplifierAnnotationIfNecessary( generationContext ),
                         Token( SyntaxKind.SemicolonToken ) ) )
                 .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation );
@@ -387,9 +388,9 @@ namespace Metalama.Framework.Engine.Linking
                                     symbol.IsStatic
                                         ? generationContext.SyntaxGenerator.TypeSyntax( symbol.ContainingType )
                                         : ThisExpression(),
-                                    IdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
+                                    WellKnownIdentifierName( GetBackingFieldName( (IPropertySymbol) symbol.AssociatedSymbol.AssertNotNull() ) ) )
                                 .WithSimplifierAnnotationIfNecessary( generationContext ),
-                            IdentifierName( "value" ) ) ) )
+                            WellKnownIdentifierName( "value" ) ) ) )
                 .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
         private MemberDeclarationSyntax GetOriginalImplProperty(
@@ -552,7 +553,7 @@ namespace Metalama.Framework.Engine.Linking
                             : TokenList( SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.PrivateKeyword ) ),
                         propertyType,
                         null,
-                        Identifier( name ),
+                        WellKnownIdentifier( name ),
                         cleanAccessorList?.WithOptionalTrailingLineFeed( context ),
                         expressionBody,
                         initializer.WithSourceCodeAnnotation(),
@@ -607,11 +608,11 @@ namespace Metalama.Framework.Engine.Linking
             {
                 if ( targetSymbol.Symbol.IsStatic )
                 {
-                    return IdentifierName( targetSymbol.Symbol.Name );
+                    return SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Symbol.Name );
                 }
                 else
                 {
-                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), IdentifierName( targetSymbol.Symbol.Name ) )
+                    return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), SyntaxFactoryEx.SafeIdentifierName( targetSymbol.Symbol.Name ) )
                         .WithSimplifierAnnotationIfNecessary( context );
                 }
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using static Metalama.Framework.Engine.SyntaxGeneration.SyntaxFactoryEx;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 // TODO: A lot methods here are called multiple times. Optimize.
@@ -553,22 +554,22 @@ internal sealed partial class LinkerRewritingDriver
             QualifiedName(
                 QualifiedName(
                     AliasQualifiedName(
-                        IdentifierName( Token( SyntaxKind.GlobalKeyword ) ),
-                        IdentifierName( "Metalama" ) ),
-                    IdentifierName( "Framework" ) ),
-                IdentifierName( "RunTime" ) ),
-            IdentifierName( "Source" ) );
+                        SyntaxFactoryEx.WellKnownIdentifierName( Token( SyntaxKind.GlobalKeyword ) ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( "Metalama" ) ),
+                    SyntaxFactoryEx.WellKnownIdentifierName( "Framework" ) ),
+                SyntaxFactoryEx.WellKnownIdentifierName( "RunTime" ) ),
+            SyntaxFactoryEx.WellKnownIdentifierName( "Source" ) );
 
     private static TypeSyntax GetEmptyImplParameterType()
         => QualifiedName(
             QualifiedName(
                 QualifiedName(
                     AliasQualifiedName(
-                        IdentifierName( Token( SyntaxKind.GlobalKeyword ) ),
-                        IdentifierName( "Metalama" ) ),
-                    IdentifierName( "Framework" ) ),
-                IdentifierName( "RunTime" ) ),
-            IdentifierName( "Empty" ) );
+                        SyntaxFactoryEx.WellKnownIdentifierName( Token( SyntaxKind.GlobalKeyword ) ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( "Metalama" ) ),
+                    SyntaxFactoryEx.WellKnownIdentifierName( "Framework" ) ),
+                SyntaxFactoryEx.WellKnownIdentifierName( "RunTime" ) ),
+            SyntaxFactoryEx.WellKnownIdentifierName( "Empty" ) );
 
     private static string GetSpecialMemberName( ISymbol symbol, string suffix )
     {
@@ -815,7 +816,7 @@ internal sealed partial class LinkerRewritingDriver
                         syntaxGenerationContext.SyntaxGenerator.TypeSyntax( staticDelegateField.FieldType ),
                         SingletonSeparatedList(
                             VariableDeclarator(
-                                Identifier( staticDelegateField.FieldName ),
+                                WellKnownIdentifier( staticDelegateField.FieldName ),
                                 null,
                                 EqualsValueClause( staticDelegateField.InitializeExpressionFunc( syntaxGenerationContext ) ) ) ) ) )
                     .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceBackingFieldSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceBackingFieldSubstitution.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -48,11 +49,11 @@ internal sealed class AspectReferenceBackingFieldSubstitution : SyntaxNodeSubsti
 
                 if ( this._aspectReference.OriginalSymbol.IsExplicitInterfaceMemberImplementation() )
                 {
-                    return memberAccessExpression.PartialUpdate( ThisExpression(), name: IdentifierName( backingFieldName ) );
+                    return memberAccessExpression.PartialUpdate( ThisExpression(), name: SyntaxFactoryEx.WellKnownIdentifierName( backingFieldName ) );
                 }
                 else
                 {
-                    return memberAccessExpression.WithName( IdentifierName( backingFieldName ) );
+                    return memberAccessExpression.WithName( SyntaxFactoryEx.WellKnownIdentifierName( backingFieldName ) );
                 }
 
             default:

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceBaseSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceBaseSubstitution.cs
@@ -62,7 +62,7 @@ internal sealed class AspectReferenceBaseSubstitution : AspectReferenceRenamingS
     }
 
     protected override SyntaxNode SubstituteFinalizerMemberAccess( MemberAccessExpressionSyntax currentNode )
-        => IdentifierName( "__LINKER_TO_BE_REMOVED__" )
+        => SyntaxFactoryEx.WellKnownIdentifierName( "__LINKER_TO_BE_REMOVED__" )
             .WithLinkerGeneratedFlags( LinkerGeneratedFlags.NullAspectReferenceExpression )
             .WithTriviaFromIfNecessary( currentNode, this._syntaxGenerationOptions );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceRenamingSubstitution.ConditionalAccessRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceRenamingSubstitution.ConditionalAccessRewriter.cs
@@ -2,10 +2,10 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking.Substitution;
 
@@ -46,7 +46,7 @@ internal partial class AspectReferenceRenamingSubstitution
         {
             if ( this._context != null )
             {
-                return node.WithName( IdentifierName( this._replacingIdentifier ) );
+                return node.WithName( SyntaxFactoryEx.WellKnownIdentifierName( this._replacingIdentifier ) );
             }
             else
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceRenamingSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceRenamingSubstitution.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -111,13 +112,13 @@ internal abstract partial class AspectReferenceRenamingSubstitution : SyntaxNode
         => MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             ThisExpression(),
-            IdentifierName( this.GetTargetMemberName() ) );
+            SyntaxFactoryEx.WellKnownIdentifierName( this.GetTargetMemberName() ) );
 
     private SyntaxNode SubstituteConstructorMemberAccess()
         => MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             ThisExpression(),
-            IdentifierName( this.GetTargetMemberName() ) );
+            SyntaxFactoryEx.WellKnownIdentifierName( this.GetTargetMemberName() ) );
 
     private SyntaxNode SubstituteOperatorMemberAccess( SubstitutionContext substitutionContext )
     {
@@ -127,7 +128,7 @@ internal abstract partial class AspectReferenceRenamingSubstitution : SyntaxNode
             MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 substitutionContext.SyntaxGenerationContext.SyntaxGenerator.TypeSyntax( targetSymbol.ContainingType ),
-                IdentifierName( this.GetTargetMemberName() ) );
+                SyntaxFactoryEx.WellKnownIdentifierName( this.GetTargetMemberName() ) );
 
         return memberAccess;
     }
@@ -139,7 +140,7 @@ internal abstract partial class AspectReferenceRenamingSubstitution : SyntaxNode
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     invocationExpression.ArgumentList.Arguments[0].Expression,
-                    IdentifierName( this.GetTargetMemberName() ) ),
+                    SyntaxFactoryEx.WellKnownIdentifierName( this.GetTargetMemberName() ) ),
                 ArgumentList( SeparatedList( invocationExpression.ArgumentList.Arguments.Skip( 1 ) ) ) );
 
         return memberAccess;
@@ -186,8 +187,8 @@ internal abstract partial class AspectReferenceRenamingSubstitution : SyntaxNode
     protected static SimpleNameSyntax RewriteName( SimpleNameSyntax name, string targetMemberName )
         => name switch
         {
-            GenericNameSyntax genericName => genericName.WithIdentifier( Identifier( targetMemberName.AssertNotNull() ) ),
-            IdentifierNameSyntax _ => name.WithIdentifier( Identifier( targetMemberName.AssertNotNull() ) ),
+            GenericNameSyntax genericName => genericName.WithIdentifier( SyntaxFactoryEx.WellKnownIdentifier( targetMemberName.AssertNotNull() ) ),
+            IdentifierNameSyntax _ => name.WithIdentifier( SyntaxFactoryEx.WellKnownIdentifier( targetMemberName.AssertNotNull() ) ),
             _ => throw new AssertionFailedException( $"Unsupported name: {name}" )
         };
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EmptyPartialMemberSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EmptyPartialMemberSubstitution.cs
@@ -50,7 +50,7 @@ internal abstract class EmptyPartialMemberSubstitution : SyntaxNodeSubstitution
         {
             return syntaxGenerator.FormattedBlock(
                     SyntaxFactoryEx.AssignmentStatement(
-                        IdentifierName( this._returnVariableIdentifier ),
+                        SyntaxFactoryEx.SafeIdentifierName( this._returnVariableIdentifier ),
                         SyntaxFactoryEx.Default,
                         substitutionContext.SyntaxGenerationContext ) )
                 .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventBrokerProxySubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventBrokerProxySubstitution.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -40,7 +41,7 @@ internal sealed class EventBrokerProxySubstitution : SyntaxNodeSubstitution
                 var newMemberAccess = MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     ThisExpression(),
-                    IdentifierName( this._brokerProxyName ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( this._brokerProxyName ) );
 
                 // Preserve trivia from the original member access
                 return newMemberAccess.WithTriviaFromIfNecessary( memberAccess, substitutionContext.SyntaxGenerationContext.Options );
@@ -50,7 +51,7 @@ internal sealed class EventBrokerProxySubstitution : SyntaxNodeSubstitution
                 var memberAccessExpression = MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     ThisExpression(),
-                    IdentifierName( this._brokerProxyName ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( this._brokerProxyName ) );
 
                 // Preserve trivia from the original identifier
                 return memberAccessExpression.WithTriviaFromIfNecessary( identifierName, substitutionContext.SyntaxGenerationContext.Options );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventBrokerSyntaxHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventBrokerSyntaxHelper.cs
@@ -19,14 +19,14 @@ internal static class EventBrokerSyntaxHelper
     {
         if ( isStatic )
         {
-            return IdentifierName( eventBrokerFieldName );
+            return SyntaxFactoryEx.WellKnownIdentifierName( eventBrokerFieldName );
         }
         else
         {
             return MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 ThisExpression(),
-                IdentifierName( eventBrokerFieldName ) );
+                SyntaxFactoryEx.WellKnownIdentifierName( eventBrokerFieldName ) );
         }
     }
 
@@ -48,8 +48,8 @@ internal static class EventBrokerSyntaxHelper
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             GetEventBrokerField( eventBrokerFieldName, isStatic ),
-                            IdentifierName( "AddHandler" ) ),
-                        ArgumentList( SingletonSeparatedList( Argument( IdentifierName( "value" ) ) ) ) ) )
+                            SyntaxFactoryEx.WellKnownIdentifierName( "AddHandler" ) ),
+                        ArgumentList( SingletonSeparatedList( Argument( SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ) ) ) )
                     .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) );
     }
 
@@ -67,8 +67,8 @@ internal static class EventBrokerSyntaxHelper
                     ConditionalAccessExpression(
                         GetEventBrokerField( eventBrokerFieldName, isStatic ),
                         InvocationExpression(
-                            MemberBindingExpression( IdentifierName( "RemoveHandler" ) ),
-                            ArgumentList( SingletonSeparatedList( Argument( IdentifierName( "value" ) ) ) ) ) ) )
+                            MemberBindingExpression( SyntaxFactoryEx.WellKnownIdentifierName( "RemoveHandler" ) ),
+                            ArgumentList( SingletonSeparatedList( Argument( SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ) ) ) ) )
                     .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseBackingFieldSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseBackingFieldSubstitution.cs
@@ -3,6 +3,8 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
+using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -38,18 +40,17 @@ internal sealed class EventRaiseBackingFieldSubstitution : SyntaxNodeSubstitutio
         {
             case IdentifierNameSyntax identifierName:
                 // Replacing the direct invocation.
-                return IdentifierName(
-                    Identifier( TriviaList( identifierName.Identifier.LeadingTrivia ), targetName, TriviaList( identifierName.Identifier.TrailingTrivia ) ) );
+                return SyntaxFactoryEx.SafeIdentifierName( targetName )
+                    .WithOptionalLeadingTrivia( identifierName.Identifier.LeadingTrivia, substitutionContext.SyntaxGenerationContext )
+                    .WithOptionalTrailingTrivia( identifierName.Identifier.TrailingTrivia, substitutionContext.SyntaxGenerationContext );
 
             case MemberAccessExpressionSyntax { Expression: { }, Name: IdentifierNameSyntax identifierName } simpleMemberAccess:
                 // Replacing the this expression invocation.
                 return
                     simpleMemberAccess.WithName(
-                        IdentifierName(
-                            Identifier(
-                                TriviaList( identifierName.Identifier.LeadingTrivia ),
-                                targetName,
-                                TriviaList( identifierName.Identifier.TrailingTrivia ) ) ) );
+                        SyntaxFactoryEx.SafeIdentifierName( targetName )
+                            .WithOptionalLeadingTrivia( identifierName.Identifier.LeadingTrivia, substitutionContext.SyntaxGenerationContext )
+                            .WithOptionalTrailingTrivia( identifierName.Identifier.TrailingTrivia, substitutionContext.SyntaxGenerationContext ) );
 
             case InvocationExpressionSyntax
             {
@@ -74,14 +75,16 @@ internal sealed class EventRaiseBackingFieldSubstitution : SyntaxNodeSubstitutio
                 ArgumentList.CloseParenToken.TrailingTrivia: var trailingTrivia
             }:
                 // Replacing the linker expression.
-                var eventFieldAccess = eventMemberAccess.WithName( IdentifierName( Identifier( TriviaList( leadingTrivia ), targetName, TriviaList() ) ) );
+                var eventFieldAccess = eventMemberAccess.WithName(
+                    SyntaxFactoryEx.SafeIdentifierName( targetName )
+                        .WithOptionalLeadingTrivia( leadingTrivia, substitutionContext.SyntaxGenerationContext ) );
                 var invokeArguments = EventRaiseArgumentsHelper.ExtractInvokeArguments( arguments );
 
                 // backingField?.Invoke()
                 return ConditionalAccessExpression(
                     eventFieldAccess,
                     InvocationExpression(
-                        MemberBindingExpression( IdentifierName( "Invoke" ) ),
+                        MemberBindingExpression( SyntaxFactoryEx.SafeIdentifierName( "Invoke" ) ),
                         ArgumentList(
                             Token( SyntaxKind.OpenParenToken ),
                             invokeArguments,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseBrokerCallSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseBrokerCallSubstitution.cs
@@ -5,6 +5,8 @@
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
+using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Framework.RunTime.Events;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -55,11 +57,12 @@ internal sealed class EventRaiseBrokerCallSubstitution : SyntaxNodeSubstitution
 
         var eventBrokerExpression =
             this._targetSemantic.Symbol.IsStatic
-                ? (ExpressionSyntax) IdentifierName( Identifier( TriviaList( leadingTrivia ), currentEventBrokerInfo.EventBrokerFieldName, TriviaList() ) )
+                ? (ExpressionSyntax) SyntaxFactoryEx.SafeIdentifierName( currentEventBrokerInfo.EventBrokerFieldName )
+                    .WithOptionalLeadingTrivia( leadingTrivia, substitutionContext.SyntaxGenerationContext )
                 : MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     ThisExpression( Token( TriviaList( leadingTrivia ), SyntaxKind.ThisKeyword, TriviaList() ) ),
-                    IdentifierName( currentEventBrokerInfo.EventBrokerFieldName ) );
+                    SyntaxFactoryEx.SafeIdentifierName( currentEventBrokerInfo.EventBrokerFieldName ) );
 
         switch ( currentNode )
         {
@@ -89,7 +92,7 @@ internal sealed class EventRaiseBrokerCallSubstitution : SyntaxNodeSubstitution
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             eventBrokerExpression,
-                            IdentifierName( nameof(EventBroker<,,>.Invoke) ) ),
+                            SyntaxFactoryEx.SafeIdentifierName( nameof(EventBroker<,,>.Invoke) ) ),
                         ArgumentList(
                             Token( SyntaxKind.OpenParenToken ),
                             SingletonSeparatedList( Argument( TupleExpression( invokeArguments ) ) ),
@@ -106,7 +109,7 @@ internal sealed class EventRaiseBrokerCallSubstitution : SyntaxNodeSubstitution
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             eventBrokerExpression,
-                            IdentifierName( nameof(EventBroker<,,>.Invoke) ) ),
+                            SyntaxFactoryEx.SafeIdentifierName( nameof(EventBroker<,,>.Invoke) ) ),
                         ArgumentList(
                             Token( SyntaxKind.OpenParenToken ),
                             SingletonSeparatedList( Argument( TupleExpression( SeparatedList( arguments ) ) ) ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseEventFieldSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseEventFieldSubstitution.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -33,21 +34,17 @@ internal sealed class EventRaiseEventFieldSubstitution : SyntaxNodeSubstitution
         {
             case IdentifierNameSyntax identifierName:
                 // Replacing the direct invocation.
-                return IdentifierName(
-                    Identifier(
-                        TriviaList( identifierName.Identifier.LeadingTrivia ),
-                        this._targetEvent.Name,
-                        TriviaList( identifierName.Identifier.TrailingTrivia ) ) );
+                return SyntaxFactoryEx.SafeIdentifierName( this._targetEvent.Name )
+                    .WithOptionalLeadingTrivia( identifierName.Identifier.LeadingTrivia, substitutionContext.SyntaxGenerationContext )
+                    .WithOptionalTrailingTrivia( identifierName.Identifier.TrailingTrivia, substitutionContext.SyntaxGenerationContext );
 
             case MemberAccessExpressionSyntax { Expression: { }, Name: IdentifierNameSyntax identifierName } simpleMemberAccess:
                 // Replacing the this expression invocation.
                 return
                     simpleMemberAccess.WithName(
-                        IdentifierName(
-                            Identifier(
-                                TriviaList( identifierName.Identifier.LeadingTrivia ),
-                                this._targetEvent.Name,
-                                TriviaList( identifierName.Identifier.TrailingTrivia ) ) ) );
+                        SyntaxFactoryEx.SafeIdentifierName( this._targetEvent.Name )
+                            .WithOptionalLeadingTrivia( identifierName.Identifier.LeadingTrivia, substitutionContext.SyntaxGenerationContext )
+                            .WithOptionalTrailingTrivia( identifierName.Identifier.TrailingTrivia, substitutionContext.SyntaxGenerationContext ) );
 
             case InvocationExpressionSyntax
             {
@@ -73,7 +70,7 @@ internal sealed class EventRaiseEventFieldSubstitution : SyntaxNodeSubstitution
             }:
                 // Replacing the linker expression.
                 var backingFieldAccess =
-                    eventMemberAccess.WithName( IdentifierName( this._targetEvent.Name ) )
+                    eventMemberAccess.WithName( SyntaxFactoryEx.SafeIdentifierName( this._targetEvent.Name ) )
                         .WithRequiredLeadingTrivia( leadingTrivia );
 
                 var invokeArguments = EventRaiseArgumentsHelper.ExtractInvokeArguments( arguments );
@@ -82,7 +79,7 @@ internal sealed class EventRaiseEventFieldSubstitution : SyntaxNodeSubstitution
                 return ConditionalAccessExpression(
                     backingFieldAccess,
                     InvocationExpression(
-                        MemberBindingExpression( IdentifierName( "Invoke" ) ),
+                        MemberBindingExpression( SyntaxFactoryEx.SafeIdentifierName( "Invoke" ) ),
                         ArgumentList(
                             Token( SyntaxKind.OpenParenToken ),
                             invokeArguments,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseHandlerCallSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseHandlerCallSubstitution.cs
@@ -71,8 +71,9 @@ internal sealed class EventRaiseHandlerCallSubstitution : SyntaxNodeSubstitution
                         InvocationExpression(
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName( Identifier( TriviaList( leadingTrivia ), handlerName, TriviaList() ) ),
-                                IdentifierName( "Invoke" ) ),
+                                SyntaxFactoryEx.SafeIdentifierName( handlerName )
+                                    .WithOptionalLeadingTrivia( leadingTrivia, substitutionContext.SyntaxGenerationContext ),
+                                SyntaxFactoryEx.SafeIdentifierName( "Invoke" ) ),
                             ArgumentList(
                                 Token( SyntaxKind.OpenParenToken ),
                                 SeparatedList(
@@ -98,8 +99,8 @@ internal sealed class EventRaiseHandlerCallSubstitution : SyntaxNodeSubstitution
                                                 },
                                                 MemberAccessExpression(
                                                     SyntaxKind.SimpleMemberAccessExpression,
-                                                    IdentifierName( argsName ),
-                                                    IdentifierName( tupleElements[i].Name ) ) ) ) ),
+                                                    SyntaxFactoryEx.SafeIdentifierName( argsName ),
+                                                    SyntaxFactoryEx.SafeIdentifierName( tupleElements[i].Name ) ) ) ) ),
                                 Token( TriviaList(), SyntaxKind.CloseParenToken, TriviaList( trailingTrivia ) ) ) );
                 }
                 else
@@ -111,8 +112,9 @@ internal sealed class EventRaiseHandlerCallSubstitution : SyntaxNodeSubstitution
                         InvocationExpression(
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName( Identifier( TriviaList( leadingTrivia ), handlerName, TriviaList() ) ),
-                                IdentifierName( "Invoke" ) ),
+                                SyntaxFactoryEx.SafeIdentifierName( handlerName )
+                                    .WithOptionalLeadingTrivia( leadingTrivia, substitutionContext.SyntaxGenerationContext ),
+                                SyntaxFactoryEx.SafeIdentifierName( "Invoke" ) ),
                             ArgumentList(
                                 Token( SyntaxKind.OpenParenToken ),
                                 SeparatedList( invokeArguments ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ExpressionBodySubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ExpressionBodySubstitution.cs
@@ -111,7 +111,7 @@ namespace Metalama.Framework.Engine.Linking.Substitution
                             {
                                 return syntaxGenerator.FormattedBlock(
                                         SyntaxFactoryEx.AssignmentStatement(
-                                            IdentifierName( this._returnVariableIdentifier ),
+                                            SyntaxFactoryEx.SafeIdentifierName( this._returnVariableIdentifier ),
                                             arrowExpressionClause.Expression,
                                             syntaxGenerator.SyntaxGenerationContext ) )
                                     .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ForcedInitializationSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ForcedInitializationSubstitution.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Comparers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -59,7 +60,7 @@ internal sealed class ForcedInitializationSubstitution : SyntaxNodeSubstitution
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 ThisExpression(),
-                                IdentifierName( LinkerRewritingDriver.GetBackingFieldName( symbol ) ) ),
+                                SyntaxFactoryEx.WellKnownIdentifierName( LinkerRewritingDriver.GetBackingFieldName( symbol ) ) ),
                             LiteralExpression(
                                 SyntaxKind.DefaultLiteralExpression,
                                 Token( SyntaxKind.DefaultKeyword ) ) ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/InliningSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/InliningSubstitution.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Engine.Formatting;
 using Metalama.Framework.Engine.Linking.Inlining;
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -60,7 +61,7 @@ namespace Metalama.Framework.Engine.Linking.Substitution
             {
                 statements.Add(
                     LabeledStatement(
-                            Identifier( this._specification.ReturnLabelIdentifier.AssertNotNull() ),
+                            SyntaxFactoryEx.SafeIdentifier( this._specification.ReturnLabelIdentifier.AssertNotNull() ),
                             EmptyStatement() )
                         .WithOptionalTrailingLineFeed( context.SyntaxGenerationContext )
                         .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/PropertyBackingFieldReferenceSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/PropertyBackingFieldReferenceSubstitution.cs
@@ -5,6 +5,7 @@
 #if ROSLYN_5_0_0_OR_GREATER
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -36,8 +37,10 @@ internal sealed class PropertyBackingFieldReferenceSubstitution : SyntaxNodeSubs
         {
             case FieldExpressionSyntax fieldExpression:
                 // Replacing the direct invocation.
-                return IdentifierName(
-                    Identifier( TriviaList( fieldExpression.Token.LeadingTrivia ), targetName, TriviaList( fieldExpression.Token.TrailingTrivia ) ) );
+                return SyntaxFactoryEx.WellKnownIdentifierName(
+                    TriviaList( fieldExpression.Token.LeadingTrivia ),
+                    targetName,
+                    TriviaList( fieldExpression.Token.TrailingTrivia ) );
 
             default:
                 throw new AssertionFailedException( $"Unsupported syntax: {currentNode}" );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/PropertyImplicitAccessorSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/PropertyImplicitAccessorSubstitution.cs
@@ -45,8 +45,8 @@ internal sealed class PropertyImplicitAccessorSubstitution : SyntaxNodeSubstitut
                             ExpressionStatement(
                                 AssignmentExpression(
                                     SyntaxKind.SimpleAssignmentExpression,
-                                    IdentifierName( targetName ),
-                                    IdentifierName( "value" ) ) ) )
+                                    SyntaxFactoryEx.WellKnownIdentifierName( targetName ),
+                                    SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ) )
                         .WithTriviaFromIfNecessary( accessorDeclaration, substitutionContext.SyntaxGenerationContext.Options );
 
             case AccessorDeclarationSyntax { RawKind: (int) SyntaxKind.GetAccessorDeclaration, Body: null, ExpressionBody: null } accessorDeclaration:
@@ -55,7 +55,7 @@ internal sealed class PropertyImplicitAccessorSubstitution : SyntaxNodeSubstitut
                     Block(
                             ReturnStatement(
                                 SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.ReturnKeyword ),
-                                IdentifierName( targetName ),
+                                SyntaxFactoryEx.WellKnownIdentifierName( targetName ),
                                 Token( SyntaxKind.SemicolonToken ) ) )
                         .WithTriviaFromIfNecessary( accessorDeclaration, substitutionContext.SyntaxGenerationContext.Options );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/RecordParameterSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/RecordParameterSubstitution.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -44,7 +45,7 @@ internal sealed class RecordParameterSubstitution : SyntaxNodeSubstitution
                                 ExpressionStatement(
                                     AssignmentExpression(
                                         SyntaxKind.SimpleAssignmentExpression,
-                                        IdentifierName( this._returnVariableIdentifier ),
+                                        SyntaxFactoryEx.SafeIdentifierName( this._returnVariableIdentifier ),
                                         CreateFieldAccessExpression() ) ) )
                             .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );
                 }
@@ -69,7 +70,7 @@ internal sealed class RecordParameterSubstitution : SyntaxNodeSubstitution
                                 AssignmentExpression(
                                     SyntaxKind.SimpleAssignmentExpression,
                                     CreateFieldAccessExpression(),
-                                    IdentifierName( "value" ) ) ) )
+                                    SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ) )
                         .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );
 
             default:
@@ -82,7 +83,7 @@ internal sealed class RecordParameterSubstitution : SyntaxNodeSubstitution
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     ThisExpression(),
-                    IdentifierName( LinkerRewritingDriver.GetBackingFieldName( (IPropertySymbol) this._targetAccessor.AssociatedSymbol.AssertNotNull() ) ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( LinkerRewritingDriver.GetBackingFieldName( (IPropertySymbol) this._targetAccessor.AssociatedSymbol.AssertNotNull() ) ) );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/RedirectionSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/RedirectionSubstitution.cs
@@ -3,10 +3,10 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Metalama.Framework.Engine.Linking.Substitution;
 
@@ -31,7 +31,7 @@ internal sealed class RedirectionSubstitution : SyntaxNodeSubstitution
         switch ( currentNode )
         {
             case SimpleNameSyntax name:
-                return name.WithIdentifier( Identifier( this._targetSemantic.Symbol.Name ) );
+                return name.WithIdentifier( SyntaxFactoryEx.SafeIdentifier( this._targetSemantic.Symbol.Name ) );
 
             case MemberAccessExpressionSyntax { RawKind: (int) SyntaxKind.SimpleMemberAccessExpression }:
                 return currentNode;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ReturnStatementSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ReturnStatementSubstitution.cs
@@ -172,7 +172,7 @@ internal sealed class ReturnStatementSubstitution : SyntaxNodeSubstitution
 
             if ( this._returnVariableIdentifier != null )
             {
-                identifier = IdentifierName( this._returnVariableIdentifier );
+                identifier = SyntaxFactoryEx.SafeIdentifierName( this._returnVariableIdentifier );
             }
             else
             {
@@ -193,7 +193,7 @@ internal sealed class ReturnStatementSubstitution : SyntaxNodeSubstitution
                         SyntaxKind.GotoStatement,
                         SyntaxFactoryEx.TokenWithTrailingSpace( SyntaxKind.GotoKeyword ),
                         default,
-                        IdentifierName( this._returnLabelIdentifier.AssertNotNull() ),
+                        SyntaxFactoryEx.SafeIdentifierName( this._returnLabelIdentifier.AssertNotNull() ),
                         Token( default, SyntaxKind.SemicolonToken, substitutionContext.SyntaxGenerationContext.OptionalElasticEndOfLineTriviaList ) )
                     .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation );
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
@@ -409,7 +409,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                     ConstructorDeclaration(
                         List<AttributeListSyntax>(),
                         finalConstructor.GetSyntaxModifierList(),
-                        Identifier( finalConstructor.DeclaringType.Name ),
+                        SyntaxFactoryEx.SafeIdentifier( finalConstructor.DeclaringType.Name ),
                         syntaxGenerationContext.SyntaxGenerator.ParameterList( finalParameters, initialCompilationModel ),
                         initialConstructor.IsImplicitlyDeclared
                             ? null
@@ -424,7 +424,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                                                         ? NameColon( p.Name )
                                                         : null,
                                                     GetArgumentRefToken( p ),
-                                                    IdentifierName( p.Name ) ) ) ) ) ),
+                                                    SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) ),
                         Block() ) );
 
                 if ( initialConstructor.Parameters.Any( p => p.DefaultValue != null ) )
@@ -446,14 +446,14 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                             ConstructorDeclaration(
                                 List<AttributeListSyntax>(),
                                 initialConstructor.GetSyntaxModifierList(),
-                                Identifier( initialConstructor.DeclaringType.Name ),
+                                SyntaxFactoryEx.SafeIdentifier( initialConstructor.DeclaringType.Name ),
                                 syntaxGenerationContext.SyntaxGenerator.ParameterList( nonOptionalParameters, initialCompilationModel ),
                                 ConstructorInitializer(
                                     SyntaxKind.ThisConstructorInitializer,
                                     ArgumentList(
                                         SeparatedList(
                                                 nonOptionalParameters.SelectAsArray(
-                                                    p => Argument( null, GetArgumentRefToken( p ), IdentifierName( p.Name ) ) ) )
+                                                    p => Argument( null, GetArgumentRefToken( p ), SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) )
                                             .AddRange(
                                                 optionalParameters.SelectAsArray(
                                                     p =>
@@ -519,7 +519,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 TypeKind.Class when !type.IsRecord => ClassDeclaration(
                     attributeLists: default,
                     SyntaxTokenList.Create( Token( SyntaxKind.PartialKeyword ) ),
-                    Identifier( type.Name ),
+                    SyntaxFactoryEx.SafeIdentifier( type.Name ),
                     CreateTypeParameters( type ),
                     baseList,
                     constraintClauses: default,
@@ -530,7 +530,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                     SyntaxTokenList.Create( Token( SyntaxKind.PartialKeyword ) ),
                     keyword: Token( SyntaxKind.RecordKeyword ),
                     classOrStructKeyword: Token( SyntaxKind.ClassKeyword ),
-                    Identifier( type.Name ),
+                    SyntaxFactoryEx.SafeIdentifier( type.Name ),
                     CreateTypeParameters( type ),
                     parameterList: null,
                     baseList,
@@ -542,7 +542,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 TypeKind.Struct when !type.IsRecord => StructDeclaration(
                     attributeLists: default,
                     SyntaxTokenList.Create( Token( SyntaxKind.PartialKeyword ) ),
-                    Identifier( type.Name ),
+                    SyntaxFactoryEx.SafeIdentifier( type.Name ),
                     CreateTypeParameters( type ),
                     baseList,
                     constraintClauses: default,
@@ -553,7 +553,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                     SyntaxTokenList.Create( Token( SyntaxKind.PartialKeyword ) ),
                     keyword: Token( SyntaxKind.RecordKeyword ),
                     classOrStructKeyword: Token( SyntaxKind.StructKeyword ),
-                    Identifier( type.Name ),
+                    SyntaxFactoryEx.SafeIdentifier( type.Name ),
                     CreateTypeParameters( type ),
                     parameterList: null,
                     baseList,
@@ -565,7 +565,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 TypeKind.Interface => InterfaceDeclaration(
                     attributeLists: default,
                     SyntaxTokenList.Create( Token( SyntaxKind.PartialKeyword ) ),
-                    Identifier( type.Name ),
+                    SyntaxFactoryEx.SafeIdentifier( type.Name ),
                     CreateTypeParameters( type ),
                     baseList,
                     constraintClauses: default,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -295,13 +295,13 @@ public sealed partial class ContextualSyntaxGenerator
 
                     constraints.Add(
                         TypeConstraint(
-                            SyntaxFactory.IdentifierName( Identifier( default, SyntaxKind.UnmanagedKeyword, "unmanaged", "unmanaged", default ) ) ) );
+                            SyntaxFactoryEx.WellKnownIdentifierName( "unmanaged" ) ) );
 
                     break;
 
                 case TypeKindConstraint.NotNull:
                     constraints ??= [];
-                    constraints.Add( TypeConstraint( SyntaxFactory.IdentifierName( "notnull" ) ) );
+                    constraints.Add( TypeConstraint( SyntaxFactoryEx.WellKnownIdentifierName( "notnull" ) ) );
 
                     break;
 
@@ -347,7 +347,7 @@ public sealed partial class ContextualSyntaxGenerator
                 clauses.Add(
                     TypeParameterConstraintClause(
                         TokenWithTrailingSpace( SyntaxKind.WhereKeyword ),
-                        SyntaxFactory.IdentifierName( genericParameter.Name ),
+                        SyntaxFactoryEx.SafeIdentifierName( genericParameter.Name ),
                         Token( SyntaxKind.ColonToken ),
                         SeparatedList( constraints ) ) );
             }
@@ -937,7 +937,7 @@ public sealed partial class ContextualSyntaxGenerator
             this.AttributesForDeclaration( parameter.ToFullRef(), compilation ),
             parameter.GetSyntaxModifierList(),
             this.TypeSyntax( parameter.Type ).WithOptionalTrailingTrivia( ElasticSpace, this.Options ),
-            Identifier( parameter.Name ),
+            SyntaxFactoryEx.SafeIdentifier( parameter.Name ),
             equalsValueClause );
     }
 
@@ -958,7 +958,7 @@ public sealed partial class ContextualSyntaxGenerator
 
             if ( parameter.HasNotNullConstraint )
             {
-                constraints = constraints.Add( TypeConstraint( SyntaxFactory.IdentifierName( "notnull" ) ) );
+                constraints = constraints.Add( TypeConstraint( SyntaxFactoryEx.WellKnownIdentifierName( "notnull" ) ) );
             }
             else if ( parameter.HasReferenceTypeConstraint )
             {
@@ -974,13 +974,7 @@ public sealed partial class ContextualSyntaxGenerator
                 {
                     constraints = constraints.Add(
                         TypeConstraint(
-                            SyntaxFactory.IdentifierName(
-                                Identifier(
-                                    default,
-                                    SyntaxKind.UnmanagedKeyword,
-                                    "unmanaged",
-                                    "unmanaged",
-                                    default ) ) ) );
+                            SyntaxFactoryEx.WellKnownIdentifierName( "unmanaged" ) ) );
                 }
                 else
                 {
@@ -1138,7 +1132,7 @@ public sealed partial class ContextualSyntaxGenerator
             return MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 this.TypeSyntax( tupleType.Compilation.Factory.GetSpecialType( Code.SpecialType.ValueTuple ) ),
-                SyntaxFactory.IdentifierName( "Create" ) );
+                SyntaxFactoryEx.WellKnownIdentifierName( "Create" ) );
         }
 
         static string? GetRightMostIdentifier( ExpressionSyntax expression )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxFactoryEx.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxFactoryEx.cs
@@ -51,6 +51,7 @@ public static partial class SyntaxFactoryEx
         => SyntaxFactory.ExpressionStatement(
             SyntaxFactory.AssignmentExpression( SyntaxKind.SimpleAssignmentExpression, DiscardIdentifierName(), discardedExpression ) );
 
+#pragma warning disable LAMA0850 // Intentional use of SyntaxFactory.Identifier/IdentifierName for special tokens
     internal static IdentifierNameSyntax DiscardIdentifierName() => SyntaxFactory.IdentifierName( DiscardIdentifier() );
 
     public static SyntaxToken DiscardIdentifier()
@@ -71,6 +72,126 @@ public static partial class SyntaxFactoryEx
                 "var",
                 "var",
                 SyntaxFactory.TriviaList( SyntaxFactory.ElasticSpace ) ) );
+#pragma warning restore LAMA0850
+
+    /// <summary>
+    /// Creates a safe identifier token from a name, escaping it with @ prefix if it's a C# keyword.
+    /// If the name already starts with @, it is returned as-is to prevent double escaping.
+    /// </summary>
+    /// <param name="name">The identifier name.</param>
+#pragma warning disable LAMA0850 // Intentional use of SyntaxFactory.Identifier
+    internal static SyntaxToken SafeIdentifier( string name )
+    {
+        // If the name already starts with @, return it as-is to prevent double escaping (@@).
+        if ( name.StartsWith( "@", StringComparison.Ordinal ) )
+        {
+            return SyntaxFactory.Identifier( name );
+        }
+
+        var keywordKind = SyntaxFacts.GetKeywordKind( name );
+
+        if ( keywordKind != SyntaxKind.None )
+        {
+            // The name is a C# keyword, so we need to escape it with @
+            return SyntaxFactory.Identifier(
+                SyntaxFactory.TriviaList(),
+                keywordKind,
+                "@" + name,
+                name,
+                SyntaxFactory.TriviaList() );
+        }
+
+        return SyntaxFactory.Identifier( name );
+    }
+
+    /// <summary>
+    /// Creates a safe identifier token from a name, escaping it with @ prefix if it's a C# keyword.
+    /// Preserves the specified leading and trailing trivia.
+    /// </summary>
+    /// <param name="leading">Leading trivia.</param>
+    /// <param name="name">The identifier name.</param>
+    /// <param name="trailing">Trailing trivia.</param>
+    internal static SyntaxToken SafeIdentifier( SyntaxTriviaList leading, string name, SyntaxTriviaList trailing )
+    {
+        // If the name already starts with @, return it as-is to prevent double escaping (@@).
+        if ( name.StartsWith( "@", StringComparison.Ordinal ) )
+        {
+            return SyntaxFactory.Identifier( leading, name, trailing );
+        }
+
+        var keywordKind = SyntaxFacts.GetKeywordKind( name );
+
+        if ( keywordKind != SyntaxKind.None )
+        {
+            // The name is a C# keyword, so we need to escape it with @
+            return SyntaxFactory.Identifier(
+                leading,
+                keywordKind,
+                "@" + name,
+                name,
+                trailing );
+        }
+
+        return SyntaxFactory.Identifier( leading, name, trailing );
+    }
+
+    /// <summary>
+    /// Creates an identifier token for a well-known name that is guaranteed not to be a C# keyword.
+    /// Use this for generated names with prefixes (e.g., "__aspectInstance"), type names, or namespace parts.
+    /// </summary>
+    /// <param name="name">The well-known identifier name.</param>
+    internal static SyntaxToken WellKnownIdentifier( string name ) => SyntaxFactory.Identifier( name );
+
+    /// <summary>
+    /// Creates an identifier token for a well-known name that is guaranteed not to be a C# keyword.
+    /// Preserves the specified leading and trailing trivia.
+    /// </summary>
+    /// <param name="leading">Leading trivia.</param>
+    /// <param name="name">The well-known identifier name.</param>
+    /// <param name="trailing">Trailing trivia.</param>
+    internal static SyntaxToken WellKnownIdentifier( SyntaxTriviaList leading, string name, SyntaxTriviaList trailing )
+        => SyntaxFactory.Identifier( leading, name, trailing );
+#pragma warning restore LAMA0850
+
+    /// <summary>
+    /// Creates a safe identifier name syntax from a name, escaping it with @ prefix if it's a C# keyword.
+    /// </summary>
+    /// <param name="name">The identifier name.</param>
+#pragma warning disable LAMA0850 // False positive: passing SyntaxToken from SafeIdentifier, not a string
+    internal static IdentifierNameSyntax SafeIdentifierName( string name )
+        => SyntaxFactory.IdentifierName( SafeIdentifier( name ) );
+#pragma warning restore LAMA0850
+
+    /// <summary>
+    /// Creates an identifier name syntax for a well-known name that is guaranteed not to be a C# keyword.
+    /// Use this for generated names with prefixes (e.g., "__aspectInstance"), type names, or namespace parts.
+    /// </summary>
+    /// <param name="name">The well-known identifier name.</param>
+#pragma warning disable LAMA0850 // False positive: passing SyntaxToken from WellKnownIdentifier, not a string
+    internal static IdentifierNameSyntax WellKnownIdentifierName( string name )
+        => SyntaxFactory.IdentifierName( WellKnownIdentifier( name ) );
+#pragma warning restore LAMA0850
+
+    /// <summary>
+    /// Creates an identifier name syntax for a well-known name that is guaranteed not to be a C# keyword.
+    /// Preserves the specified leading and trailing trivia.
+    /// </summary>
+    /// <param name="leading">Leading trivia.</param>
+    /// <param name="name">The well-known identifier name.</param>
+    /// <param name="trailing">Trailing trivia.</param>
+#pragma warning disable LAMA0850 // False positive: passing SyntaxToken from WellKnownIdentifier, not a string
+    internal static IdentifierNameSyntax WellKnownIdentifierName( SyntaxTriviaList leading, string name, SyntaxTriviaList trailing )
+        => SyntaxFactory.IdentifierName( WellKnownIdentifier( leading, name, trailing ) );
+#pragma warning restore LAMA0850
+
+    /// <summary>
+    /// Creates an identifier name syntax from a well-known token (e.g., GlobalKeyword).
+    /// </summary>
+    /// <param name="token">The well-known identifier token.</param>
+#pragma warning disable LAMA0850 // Intentional use for well-known tokens
+    internal static IdentifierNameSyntax WellKnownIdentifierName( SyntaxToken token )
+        => SyntaxFactory.IdentifierName( token );
+#pragma warning restore LAMA0850
 
     [PublicAPI]
     public static LiteralExpressionSyntax LiteralNonNullExpression( string s )
@@ -128,12 +249,12 @@ public static partial class SyntaxFactoryEx
             SyntaxFactory.QualifiedName(
                 SyntaxFactory.QualifiedName(
                     SyntaxFactory.AliasQualifiedName(
-                        SyntaxFactory.IdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) ),
-                        SyntaxFactory.IdentifierName( "Microsoft" ) ),
-                    SyntaxFactory.IdentifierName( "CodeAnalysis" ) ),
-                SyntaxFactory.IdentifierName( "CSharp" ) ),
-            SyntaxFactory.IdentifierName( "Syntax" ) ),
-        SyntaxFactory.IdentifierName( "ExpressionSyntax" ) );
+                        WellKnownIdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) ),
+                        WellKnownIdentifierName( "Microsoft" ) ),
+                    WellKnownIdentifierName( "CodeAnalysis" ) ),
+                WellKnownIdentifierName( "CSharp" ) ),
+            WellKnownIdentifierName( "Syntax" ) ),
+        WellKnownIdentifierName( "ExpressionSyntax" ) );
 
     internal static LiteralExpressionSyntax LiteralExpression( object literal, ObjectDisplayOptions options = ObjectDisplayOptions.None )
     {
@@ -202,7 +323,9 @@ public static partial class SyntaxFactoryEx
         return statement;
     }
 
+#pragma warning disable LAMA0850 // Intentional use for missing/empty tokens
     private static ExpressionSyntax EmptyExpression => SyntaxFactory.IdentifierName( SyntaxFactory.MissingToken( SyntaxKind.IdentifierToken ) );
+#pragma warning restore LAMA0850
 
     internal static StatementSyntax EmptyStatement
         => SyntaxFactory.ExpressionStatement( EmptyExpression, SyntaxFactory.MissingToken( SyntaxKind.SemicolonToken ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.AbstractGeneratorVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.AbstractGeneratorVisitor.cs
@@ -45,6 +45,6 @@ internal sealed partial class SyntaxGeneratorForIType
         }
 
         protected static IdentifierNameSyntax ToIdentifierName( string identifier )
-            => (IdentifierNameSyntax) RoslynSyntaxGenerator.IdentifierName( identifier );
+            => SyntaxFactoryEx.SafeIdentifierName( identifier );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.ExpressionSyntaxGeneratorVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.ExpressionSyntaxGeneratorVisitor.cs
@@ -38,7 +38,7 @@ internal sealed partial class SyntaxGeneratorForIType
                     {
                         return this.AddTriviaAndAnnotations(
                             SyntaxFactory.AliasQualifiedName(
-                                SyntaxFactory.IdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) ),
+                                SyntaxFactoryEx.WellKnownIdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) ),
                                 simpleNameSyntax ),
                             namedType );
                     }
@@ -67,7 +67,7 @@ internal sealed partial class SyntaxGeneratorForIType
             {
                 return this.AddTriviaAndAnnotations(
                     SyntaxFactory.AliasQualifiedName(
-                        SyntaxFactory.IdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) ),
                         syntax ),
                     ns );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.TypeSyntaxGeneratorVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.TypeSyntaxGeneratorVisitor.cs
@@ -116,11 +116,11 @@ internal sealed partial class SyntaxGeneratorForIType
             return SyntaxFactory.QualifiedName(
                 SyntaxFactory.AliasQualifiedName(
                     CreateGlobalIdentifier(),
-                    SyntaxFactory.IdentifierName( "System" ) ),
-                SyntaxFactory.IdentifierName( "Object" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "System" ) ),
+                SyntaxFactoryEx.WellKnownIdentifierName( "Object" ) );
         }
 
-        private static IdentifierNameSyntax CreateGlobalIdentifier() => SyntaxFactory.IdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) );
+        private static IdentifierNameSyntax CreateGlobalIdentifier() => SyntaxFactoryEx.WellKnownIdentifierName( SyntaxFactory.Token( SyntaxKind.GlobalKeyword ) );
 
         private TypeSyntax? TryCreateSpecializedNamedTypeSyntax( INamedType type )
         {
@@ -210,7 +210,7 @@ internal sealed partial class SyntaxGeneratorForIType
 
                             if ( modelElement.HasFriendlyName )
                             {
-                                elementSyntax = SyntaxFactory.TupleElement( type, SyntaxFactory.Identifier( modelElement.Name ) )
+                                elementSyntax = SyntaxFactory.TupleElement( type, SyntaxFactoryEx.SafeIdentifier( modelElement.Name ) )
                                     .WithSimplifierAnnotationIfNecessary( this.SyntaxGenerator._generationOptions );
                             }
                             else

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/CompileTimeParameterInfoSerializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/CompileTimeParameterInfoSerializer.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.ReflectionMocks;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -44,7 +45,7 @@ internal sealed class CompileTimeParameterInfoSerializer : ObjectSerializer<Comp
 
         return ElementAccessExpression(
                 InvocationExpression(
-                    MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, memberExpression, IdentifierName( getParametersMethodName ) ) ),
+                    MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, memberExpression, SyntaxFactoryEx.WellKnownIdentifierName( getParametersMethodName ) ) ),
                 BracketedArgumentList(
                     SingletonSeparatedList( Argument( LiteralExpression( SyntaxKind.NumericLiteralExpression, Literal( parameter.Index ) ) ) ) ) )
             .NormalizeWhitespaceIfNecessary( serializationContext.SyntaxGenerationContext );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/DictionarySerializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/DictionarySerializer.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -91,7 +92,7 @@ internal sealed class DictionarySerializer : ObjectSerializer
                 var comparerExpression = MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     serializationContext.GetTypeSyntax( typeof(StringComparer) ),
-                    IdentifierName( comparerName ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( comparerName ) );
 
                 creationExpression = creationExpression.AddArgumentListArguments( Argument( comparerExpression ) );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/DoubleSerializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/DoubleSerializer.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -16,7 +17,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.PredefinedType( SyntaxFactory.Token( SyntaxKind.DoubleKeyword ) ),
-                    SyntaxFactory.IdentifierName( "PositiveInfinity" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "PositiveInfinity" ) );
             }
 
             if ( double.IsNegativeInfinity( obj ) )
@@ -24,7 +25,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.PredefinedType( SyntaxFactory.Token( SyntaxKind.DoubleKeyword ) ),
-                    SyntaxFactory.IdentifierName( "NegativeInfinity" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "NegativeInfinity" ) );
             }
 
             if ( double.IsNaN( obj ) )
@@ -32,7 +33,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.PredefinedType( SyntaxFactory.Token( SyntaxKind.DoubleKeyword ) ),
-                    SyntaxFactory.IdentifierName( "NaN" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "NaN" ) );
             }
 
             return SyntaxFactory.LiteralExpression( SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal( obj ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/EnumSerializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/EnumSerializer.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
@@ -28,7 +29,7 @@ internal sealed class EnumSerializer : ObjectSerializer
             return MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 typeName,
-                IdentifierName( name ) );
+                SyntaxFactoryEx.SafeIdentifierName( name ) );
         }
 
         var underlyingType = Enum.GetUnderlyingType( o.GetType() );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/FloatSerializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/FloatSerializer.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -16,7 +17,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.PredefinedType( SyntaxFactory.Token( SyntaxKind.FloatKeyword ) ),
-                    SyntaxFactory.IdentifierName( "PositiveInfinity" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "PositiveInfinity" ) );
             }
 
             if ( float.IsNegativeInfinity( obj ) )
@@ -24,7 +25,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.PredefinedType( SyntaxFactory.Token( SyntaxKind.FloatKeyword ) ),
-                    SyntaxFactory.IdentifierName( "NegativeInfinity" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "NegativeInfinity" ) );
             }
 
             if ( float.IsNaN( obj ) )
@@ -32,7 +33,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.PredefinedType( SyntaxFactory.Token( SyntaxKind.FloatKeyword ) ),
-                    SyntaxFactory.IdentifierName( "NaN" ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( "NaN" ) );
             }
 
             return SyntaxFactory.LiteralExpression( SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal( obj ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/SyntaxUtility.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/SyntaxUtility.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Code;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
@@ -19,7 +20,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                     f => (ExpressionSyntax) SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         serializationContext.GetTypeSyntax( typeof(BindingFlags) ),
-                        SyntaxFactory.IdentifierName( f ) ) )
+                        SyntaxFactoryEx.WellKnownIdentifierName( f ) ) )
                 .Aggregate( ( l, r ) => SyntaxFactory.BinaryExpression( SyntaxKind.BitwiseOrExpression, l, r ) );
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/TypeSerializationHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxSerialization/TypeSerializationHelper.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -18,7 +19,7 @@ namespace Metalama.Framework.Engine.SyntaxSerialization
                     // Serializing a generic parameter always assume that we are in a lexical scope where
                     // the symbol exists. Getting the generic parameter e.g. using typeof(X).GetGenericArguments()[Y]
                     // is not supported and would require an API change.
-                    return TypeOfExpression( IdentifierName( symbol.Name ) );
+                    return TypeOfExpression( SyntaxFactoryEx.SafeIdentifierName( symbol.Name ) );
 
                 default:
                     return SerializeTypeFromSymbolLeaf( symbol, serializationContext );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/InstanceUserReceiver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/InstanceUserReceiver.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -27,7 +28,7 @@ namespace Metalama.Framework.Engine.Templating.Expressions
 
         public override TypedExpressionSyntaxImpl CreateMemberAccessExpression( string member )
             => new(
-                MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, this.ToSyntax(), IdentifierName( Identifier( member ) ) )
+                MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, this.ToSyntax(), SyntaxFactoryEx.SafeIdentifierName( member ) )
                     .WithAspectReferenceAnnotation( this.AspectReferenceSpecification ),
                 this.Type,
                 TemplateExpansionContext.CurrentSyntaxSerializationContext.CompilationModel,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/ParameterExpression.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/ParameterExpression.cs
@@ -3,8 +3,8 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Code;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Metalama.Framework.Engine.Templating.Expressions;
@@ -19,7 +19,7 @@ internal sealed class ParameterExpression : UserExpression
     }
 
     protected override ExpressionSyntax ToSyntax( SyntaxSerializationContext syntaxSerializationContext, IType? targetType = null )
-        => SyntaxFactory.IdentifierName( this._parameter.Name );
+        => SyntaxFactoryEx.SafeIdentifierName( this._parameter.Name );
 
     public override IType Type => this._parameter.Type;
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/ReceiverParameterUserReceiver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/ReceiverParameterUserReceiver.cs
@@ -4,7 +4,7 @@
 
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
-using Microsoft.CodeAnalysis.CSharp;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Metalama.Framework.Engine.Templating.Expressions;
@@ -19,7 +19,7 @@ internal class ReceiverParameterUserReceiver : InstanceUserReceiver
         this._parameter = parameter;
     }
 
-    protected override ExpressionSyntax ToSyntax() => SyntaxFactory.IdentifierName( this._parameter.Name );
+    protected override ExpressionSyntax ToSyntax() => SyntaxFactoryEx.SafeIdentifierName( this._parameter.Name );
 
     public override IType Type => this._parameter.Type;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/ThisTypeUserReceiver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/ThisTypeUserReceiver.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -33,7 +34,7 @@ namespace Metalama.Framework.Engine.Templating.Expressions
                 SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         TemplateExpansionContext.CurrentSyntaxGenerationContext.SyntaxGenerator.TypeExpression( this._type ),
-                        SyntaxFactory.IdentifierName( SyntaxFactory.Identifier( member ) ) )
+                        SyntaxFactoryEx.SafeIdentifierName( member ) )
                     .WithAspectReferenceAnnotation( this.AspectReferenceSpecification ),
                 TemplateExpansionContext.CurrentSyntaxSerializationContext.CompilationModel );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/TupleItemExpression.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/TupleItemExpression.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Code;
 using Metalama.Framework.Code.Invokers;
 using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.SyntaxSerialization;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -37,7 +38,7 @@ internal class TupleItemExpression : UserExpression
     protected override ExpressionSyntax ToSyntax( SyntaxSerializationContext syntaxSerializationContext, IType? targetType = null )
     {
         var instance = this._instance.ToTypedExpressionSyntax( syntaxSerializationContext );
-        var item = SyntaxFactory.IdentifierName( this._tupleType.TupleElements[this._index].Name );
+        var item = SyntaxFactoryEx.SafeIdentifierName( this._tupleType.TupleElements[this._index].Name );
 
         return (instance.ExpressionType?.IsNullable, this._options) switch
         {
@@ -52,7 +53,7 @@ internal class TupleItemExpression : UserExpression
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.PostfixUnaryExpression( SyntaxKind.SuppressNullableWarningExpression, instance.Syntax ),
-                        SyntaxFactory.IdentifierName( "Value" ) ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( "Value" ) ),
                     item ),
 
             // Use instance.Value.Item
@@ -62,7 +63,7 @@ internal class TupleItemExpression : UserExpression
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         instance.Syntax,
-                        SyntaxFactory.IdentifierName( "Value" ) ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( "Value" ) ),
                     item ),
 
             // Default: use instance.Item

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/MetaSyntaxRewriter.MetaSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/MetaSyntaxRewriter.MetaSyntaxFactoryImpl.cs
@@ -56,14 +56,14 @@ namespace Metalama.Framework.Engine.Templating
                 => SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     this.Type( typeof(SyntaxFactory) ),
-                    SyntaxFactory.IdentifierName( name ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( name ) );
 
             public MemberAccessExpressionSyntax GenericSyntaxFactoryMethod( string name, params TypeSyntax[] typeArguments )
                 => SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     this.Type( typeof(SyntaxFactory) ),
                     SyntaxFactory.GenericName(
-                        SyntaxFactory.Identifier( name ),
+                        SyntaxFactoryEx.WellKnownIdentifier( name ),
                         SyntaxFactory.TypeArgumentList( SyntaxFactory.SeparatedList( typeArguments ) ) ) );
 
             public ArrayTypeSyntax ArrayType<T>()
@@ -79,7 +79,7 @@ namespace Metalama.Framework.Engine.Templating
                 => SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     this.Type( typeof(SyntaxKind) ),
-                    SyntaxFactory.IdentifierName( kind.ToString() ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( kind.ToString() ) );
 
             public ExpressionSyntax Literal( ExpressionSyntax expression )
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.BuildTimeOnlyRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.BuildTimeOnlyRewriter.cs
@@ -157,7 +157,7 @@ namespace Metalama.Framework.Engine.Templating
                                         MemberAccessExpression(
                                                 SyntaxKind.SimpleMemberAccessExpression,
                                                 this._syntaxGenerator.TypeOrNamespace( symbol.ContainingType ),
-                                                SyntaxFactoryEx.SafeIdentifierName( node.Identifier.Text ) )
+                                                SyntaxFactoryEx.WellKnownIdentifierName( node.Identifier ) )
                                             .WithTriviaFrom( node ) );
                         }
                     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.BuildTimeOnlyRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.BuildTimeOnlyRewriter.cs
@@ -157,7 +157,7 @@ namespace Metalama.Framework.Engine.Templating
                                         MemberAccessExpression(
                                                 SyntaxKind.SimpleMemberAccessExpression,
                                                 this._syntaxGenerator.TypeOrNamespace( symbol.ContainingType ),
-                                                IdentifierName( node.Identifier.Text ) )
+                                                SyntaxFactoryEx.SafeIdentifierName( node.Identifier.Text ) )
                                             .WithTriviaFrom( node ) );
                         }
                     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.MetaContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.MetaContext.cs
@@ -2,8 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -131,7 +131,7 @@ namespace Metalama.Framework.Engine.Templating
                 else
                 {
                     var name = this._templateUniqueNames.GetUniqueIdentifier( symbol.Name + "Name" );
-                    value = SyntaxFactory.Identifier( name );
+                    value = SyntaxFactoryEx.WellKnownIdentifier( name );
                     this._templateCodeSymbolNameLocals.Add( symbol, value );
 
                     return value;
@@ -142,14 +142,14 @@ namespace Metalama.Framework.Engine.Templating
             {
                 var name = this._templateUniqueNames.GetUniqueIdentifier( hint + "Name" );
 
-                return SyntaxFactory.Identifier( name );
+                return SyntaxFactoryEx.WellKnownIdentifier( name );
             }
 
             public SyntaxToken GetVariable( string hint )
             {
                 var name = this._templateUniqueNames.GetUniqueIdentifier( hint );
 
-                return SyntaxFactory.Identifier( name );
+                return SyntaxFactoryEx.WellKnownIdentifier( name );
             }
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.TemplateMetaSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.TemplateMetaSyntaxFactoryImpl.cs
@@ -24,7 +24,7 @@ namespace Metalama.Framework.Engine.Templating
 
             public TemplateMetaSyntaxFactoryImpl( string templateSyntaxFactoryIdentifier )
             {
-                this._templateSyntaxFactoryIdentifier = SyntaxFactory.IdentifierName( templateSyntaxFactoryIdentifier );
+                this._templateSyntaxFactoryIdentifier = SyntaxFactoryEx.WellKnownIdentifierName( templateSyntaxFactoryIdentifier );
             }
 
             /// <summary>
@@ -37,13 +37,13 @@ namespace Metalama.Framework.Engine.Templating
                 => SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     this._templateSyntaxFactoryIdentifier,
-                    SyntaxFactory.IdentifierName( name ) );
+                    SyntaxFactoryEx.WellKnownIdentifierName( name ) );
 
             public MemberAccessExpressionSyntax GenericTemplateSyntaxFactoryMember( string name, params TypeSyntax[] genericParameters )
                 => SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     this._templateSyntaxFactoryIdentifier,
-                    SyntaxFactory.GenericName( SyntaxFactory.Identifier( name ) )
+                    SyntaxFactory.GenericName( SyntaxFactoryEx.WellKnownIdentifier( name ) )
                         .WithTypeArgumentList( SyntaxFactory.TypeArgumentList( SyntaxFactory.SeparatedList( genericParameters ) ) ) );
 
             /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -151,7 +151,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
         this.DeclareMetaVariable( symbol.Name, metaVariableIdentifier );
 
-        return SyntaxFactoryEx.WellKnownIdentifierName( metaVariableIdentifier.Text );
+        return SyntaxFactoryEx.WellKnownIdentifierName( metaVariableIdentifier );
     }
 
     private IdentifierNameSyntax ReserveRunTimeVariableName( string name )
@@ -537,7 +537,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 // Some identifier names must be escaped when used in a different context than the template.
                 return this.MetaSyntaxFactory.IdentifierName(
                     InvocationExpression( this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.EscapeIdentifier) ) )
-                        .AddArgumentListArguments( Argument( SyntaxFactoryEx.WellKnownIdentifierName( declaredSymbolNameLocal.Text ) ) ) );
+                        .AddArgumentListArguments( Argument( SyntaxFactoryEx.WellKnownIdentifierName( declaredSymbolNameLocal ) ) ) );
             }
             else if ( identifierSymbol is IParameterSymbol parameterSymbol
                       && SymbolEqualityComparer.Default.Equals( parameterSymbol.ContainingSymbol, this._rootTemplateSymbol ) )
@@ -1515,7 +1515,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                         ExpressionStatement(
                             AssignmentExpression(
                                 SyntaxKind.CoalesceAssignmentExpression,
-                                SyntaxFactoryEx.WellKnownIdentifierName( parameter.Identifier.Text ),
+                                SyntaxFactoryEx.WellKnownIdentifierName( parameter.Identifier ),
                                 this.TransformExpression( parameter.Default.AssertNotNull().Value ) ) ) );
 
                     templateOptionalParameters.Add( templateParameter );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -151,7 +151,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
         this.DeclareMetaVariable( symbol.Name, metaVariableIdentifier );
 
-        return IdentifierName( metaVariableIdentifier );
+        return SyntaxFactoryEx.WellKnownIdentifierName( metaVariableIdentifier.Text );
     }
 
     private IdentifierNameSyntax ReserveRunTimeVariableName( string name )
@@ -160,7 +160,9 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
         this.DeclareMetaVariable( name, metaVariableIdentifier );
 
+#pragma warning disable LAMA0850 // Intentional use: metaVariableIdentifier is a well-known generated identifier
         return IdentifierName( metaVariableIdentifier.AddMetaVariableAnnotation() );
+#pragma warning restore LAMA0850
     }
 
     private void DeclareMetaVariable( string hint, SyntaxToken metaVariableIdentifier )
@@ -404,12 +406,16 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                     this._currentMetaContext.AddRunTimeSymbolLocal( identifierSymbol!, declaredSymbolNameLocal );
                 }
 
+#pragma warning disable LAMA0850 // Intentional use: declaredSymbolNameLocal is a well-known generated identifier
                 return InvocationExpression( this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.EscapeIdentifier) ) )
-                    .AddArgumentListArguments( Argument( IdentifierName( declaredSymbolNameLocal ) ) );
+                    .AddArgumentListArguments( Argument( IdentifierName( declaredSymbolNameLocal.Text ) ) );
+#pragma warning restore LAMA0850
             }
             else if ( token.HasMetaVariableAnnotation() )
             {
+#pragma warning disable LAMA0850 // Intentional use: passing SyntaxToken
                 return IdentifierName( token );
+#pragma warning restore LAMA0850
             }
             else
             {
@@ -490,6 +496,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 // In templates, T? turns into e.g. int?.
 
                 // T.Type.IsNullable == true
+#pragma warning disable LAMA0850 // Intentional use: identifier.Identifier is a SyntaxToken, nameof() is well-known
                 var isNullableType = BinaryExpression(
                     SyntaxKind.EqualsExpression,
                     MemberAccessExpression(
@@ -500,6 +507,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                             IdentifierName( nameof(TemplateTypeArgument.Type) ) ),
                         IdentifierName( nameof(IType.IsNullable) ) ),
                     SyntaxFactoryEx.LiteralExpression( true ) );
+#pragma warning restore LAMA0850
 
                 return ConditionalExpression( isNullableType, this.Transform( node.ElementType ), base.TransformNullableType( node ) );
             }
@@ -529,7 +537,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 // Some identifier names must be escaped when used in a different context than the template.
                 return this.MetaSyntaxFactory.IdentifierName(
                     InvocationExpression( this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.EscapeIdentifier) ) )
-                        .AddArgumentListArguments( Argument( IdentifierName( declaredSymbolNameLocal ) ) ) );
+                        .AddArgumentListArguments( Argument( SyntaxFactoryEx.WellKnownIdentifierName( declaredSymbolNameLocal.Text ) ) ) );
             }
             else if ( identifierSymbol is IParameterSymbol parameterSymbol
                       && SymbolEqualityComparer.Default.Equals( parameterSymbol.ContainingSymbol, this._rootTemplateSymbol ) )
@@ -576,7 +584,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 transformedArgument,
-                                IdentifierName( "WithNameColon" ) ) )
+                                SyntaxFactoryEx.WellKnownIdentifierName( "WithNameColon" ) ) )
                         .WithArgumentList( ArgumentList( SingletonSeparatedList( Argument( transformedNameColon ) ) ) );
             }
 
@@ -697,7 +705,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
         else if ( symbol is ITypeParameterSymbol typeParameter && this._templateMemberClassifier.IsCompileTimeTemplateTypeParameter( typeParameter ) )
         {
-            return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, expression, IdentifierName( nameof(TemplateTypeArgument.Syntax) ) );
+            return MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, expression, SyntaxFactoryEx.WellKnownIdentifierName( nameof(TemplateTypeArgument.Syntax) ) );
         }
 
         // A local function that wraps the input `expression` into a LiteralExpression.
@@ -843,8 +851,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                                                                 Literal( name ) ) ) ) ) ),
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName( name ),
-                                            IdentifierName( propertyName ) ) ) ) ) ) )
+                                            SyntaxFactoryEx.SafeIdentifierName( name ),
+                                            SyntaxFactoryEx.WellKnownIdentifierName( propertyName ) ) ) ) ) ) )
                 .NormalizeWhitespace();
         }
     }
@@ -1064,7 +1072,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 {
                     // since expression references a parameter, we can just call ToString() on it
                     return InvocationExpression(
-                        MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, expression, IdentifierName( nameof(this.ToString) ) ) );
+                        MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, expression, SyntaxFactoryEx.WellKnownIdentifierName( nameof(this.ToString) ) ) );
                 }
             }
 
@@ -1131,7 +1139,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 {
                     var arguments = new List<ArgumentSyntax>
                     {
-                        Argument( IdentifierName( this._currentMetaContext.AssertNotNull().StatementListVariableName ) )
+                        Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext.AssertNotNull().StatementListVariableName ) )
                     };
 
                     arguments.AddRange( node.ArgumentList.Arguments.SelectAsReadOnlyList( a => Argument( (ExpressionSyntax) this.Visit( a.Expression )! ) ) );
@@ -1232,7 +1240,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
                     this._currentMetaContext.Statements.Add( variableDeclaration );
 
-                    receiver = IdentifierName( variableIdentifier );
+                    receiver = SyntaxFactoryEx.WellKnownIdentifierName( variableIdentifier );
                 }
 
                 if ( name is GenericNameSyntax genericName )
@@ -1266,8 +1274,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
                 ExpressionSyntax compiledTemplateExpression =
                     receiver == null
-                        ? IdentifierName( compiledTemplateName )
-                        : MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, receiver, IdentifierName( compiledTemplateName ) );
+                        ? SyntaxFactoryEx.WellKnownIdentifierName( compiledTemplateName )
+                        : MemberAccessExpression( SyntaxKind.SimpleMemberAccessExpression, receiver, SyntaxFactoryEx.WellKnownIdentifierName( compiledTemplateName ) );
 
                 var templateProviderExpression = symbol.IsStatic switch
                 {
@@ -1434,7 +1442,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     {
         var addStatementStatement = ExpressionStatement(
             InvocationExpression( this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( templateSyntaxFactoryMemberName ) )
-                .AddArgumentListArguments( Argument( IdentifierName( this._currentMetaContext!.StatementListVariableName ) ) )
+                .AddArgumentListArguments( Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.StatementListVariableName ) ) )
                 .AddArgumentListArguments( arguments ) );
 
         addStatementStatement = this.DeepIndent(
@@ -1461,7 +1469,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     }
 
     private ParameterSyntax CreateTemplateSyntaxFactoryParameter()
-        => Parameter( default, default, this._templateSyntaxFactoryType, Identifier( _templateSyntaxFactoryParameterName ), null );
+        => Parameter( default, default, this._templateSyntaxFactoryType, SyntaxFactoryEx.WellKnownIdentifier( _templateSyntaxFactoryParameterName ), null );
 
     public override SyntaxNode VisitMethodDeclaration( MethodDeclarationSyntax node )
     {
@@ -1507,7 +1515,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                         ExpressionStatement(
                             AssignmentExpression(
                                 SyntaxKind.CoalesceAssignmentExpression,
-                                IdentifierName( parameter.Identifier ),
+                                SyntaxFactoryEx.WellKnownIdentifierName( parameter.Identifier.Text ),
                                 this.TransformExpression( parameter.Default.AssertNotNull().Value ) ) ) );
 
                     templateOptionalParameters.Add( templateParameter );
@@ -1621,7 +1629,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
             : new[]
             {
                 this.CreateTemplateSyntaxFactoryParameter(),
-                Parameter( default, default, SyntaxFactoryEx.ExpressionSyntaxType, Identifier( "value" ), null )
+                Parameter( default, default, SyntaxFactoryEx.ExpressionSyntaxType, SyntaxFactoryEx.WellKnownIdentifier( "value" ), null )
             };
 
         // Create the method.
@@ -1692,7 +1700,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         SyntaxToken[]? accessibilityModifiers = null )
         => MethodDeclaration(
                 this.MetaSyntaxFactory.Type( typeof(SyntaxNode) ).WithTrailingTrivia( Space ),
-                Identifier( this._templateName ) )
+                SyntaxFactoryEx.WellKnownIdentifier( this._templateName ) )
             .AddParameterListParameters( parameters ?? [this.CreateTemplateSyntaxFactoryParameter()] )
             .WithModifiers( this.DetermineModifiers( accessibilityModifiers ) )
             .NormalizeWhitespace()
@@ -1886,7 +1894,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                         VariableDeclaration( listType )
                             .WithVariables(
                                 SingletonSeparatedList(
-                                    VariableDeclarator( Identifier( this._currentMetaContext.StatementListVariableName ) )
+                                    VariableDeclarator( SyntaxFactoryEx.WellKnownIdentifier( this._currentMetaContext.StatementListVariableName ) )
                                         .WithInitializer( EqualsValueClause( ObjectCreationExpression( listType, ArgumentList(), default ) ) ) ) ) )
                     .NormalizeWhitespace()
                     .WithLeadingTrivia( this.GetIndentation() )
@@ -1907,7 +1915,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                             VariableDeclaration( this._templateSyntaxFactoryType )
                                 .WithVariables(
                                     SingletonSeparatedList(
-                                        VariableDeclarator( Identifier( _templateSyntaxFactoryLocalName ) )
+                                        VariableDeclarator( SyntaxFactoryEx.WellKnownIdentifier( _templateSyntaxFactoryLocalName ) )
                                             .WithInitializer(
                                                 EqualsValueClause(
                                                     InvocationExpression(
@@ -1936,7 +1944,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
             // TemplateSyntaxFactory.ToStatementList( __s1 )
             var toArrayStatementExpression = InvocationExpression(
                 this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.ToStatementList) ),
-                ArgumentList( SingletonSeparatedList( Argument( IdentifierName( this._currentMetaContext.StatementListVariableName ) ) ) ) );
+                ArgumentList( SingletonSeparatedList( Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext.StatementListVariableName ) ) ) ) );
 
             if ( generateExpression )
             {
@@ -2088,7 +2096,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                                         ArgumentList(
                                             SeparatedList(
                                             [
-                                                Argument( IdentifierName( this._currentMetaContext!.StatementListVariableName ) ),
+                                                Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.StatementListVariableName ) ),
                                                 Argument( expressionSyntax )
                                             ] ) ) ) ) );
 
@@ -2536,10 +2544,12 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 // parameter.
                 else if ( this._templateCompileTimeTypeParameterNames.Contains( node.Identifier.ValueText ) )
                 {
+#pragma warning disable LAMA0850 // Intentional use: node.Identifier is a SyntaxToken, nameof() is well-known
                     return MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         IdentifierName( node.Identifier ),
                         IdentifierName( nameof(TemplateTypeArgument.Syntax) ) );
+#pragma warning restore LAMA0850
                 }
             }
             else
@@ -2834,7 +2844,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         runtimeExpressionInvocation,
-                        IdentifierName( nameof(TypedExpressionSyntax.ToUserExpression) ) ),
+                        SyntaxFactoryEx.WellKnownIdentifierName( nameof(TypedExpressionSyntax.ToUserExpression) ) ),
                     ArgumentList(
                         SingletonSeparatedList(
                             Argument( this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.Compilation) ) ) ) ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateExpansionContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateExpansionContext.cs
@@ -440,13 +440,13 @@ internal sealed partial class TemplateExpansionContext : UserCodeExecutionContex
 
         var forEach = ForEachStatement(
                 SyntaxFactoryEx.VarIdentifier(),
-                Identifier( resultItem ),
+                SyntaxFactoryEx.WellKnownIdentifier( resultItem ),
                 returnExpression,
                 Block(
                     SingletonList<StatementSyntax>(
                         YieldStatement(
                             SyntaxKind.YieldReturnStatement,
-                            IdentifierName( resultItem ) ) ) ) )
+                            SyntaxFactoryEx.WellKnownIdentifierName( resultItem ) ) ) ) )
             .WithAwaitKeyword( Token( SyntaxKind.AwaitKeyword ) );
 
         return Block( forEach, CreateYieldBreakStatement() ).WithFlattenBlockAnnotation();
@@ -497,11 +497,11 @@ internal sealed partial class TemplateExpansionContext : UserCodeExecutionContex
             local = VariableDeclaration( SyntaxFactoryEx.VarIdentifier() )
                 .WithVariables(
                     SingletonSeparatedList(
-                        VariableDeclarator( Identifier( enumerator ) )
+                        VariableDeclarator( SyntaxFactoryEx.WellKnownIdentifier( enumerator ) )
                             .WithInitializer( EqualsValueClause( returnExpression ) ) ) );
 
             usingExpression = null;
-            enumeratorIdentifier = IdentifierName( enumerator );
+            enumeratorIdentifier = SyntaxFactoryEx.WellKnownIdentifierName( enumerator );
         }
 
         var whileStatement = WhileStatement(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
@@ -322,13 +322,13 @@ namespace Metalama.Framework.Engine.Templating
                 SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         expression,
-                        SyntaxFactory.IdentifierName( member ) )
+                        SyntaxFactoryEx.SafeIdentifierName( member ) )
                     .WithSimplifierAnnotationIfNecessary( this.SyntaxSerializationContext.SyntaxGenerationContext ),
                 this.SyntaxSerializationContext.CompilationModel );
         }
 
         public SyntaxToken GetUniqueIdentifier( string hint )
-            => SyntaxFactory.Identifier( this._templateExpansionContext.LexicalScope.GetUniqueIdentifier( hint ) );
+            => SyntaxFactoryEx.WellKnownIdentifier( this._templateExpansionContext.LexicalScope.GetUniqueIdentifier( hint ) );
 
         public ExpressionSyntax Serialize<T>( T o )
             => this._templateExpansionContext.SyntaxSerializationService.Serialize( o, this.SyntaxSerializationContext );
@@ -681,7 +681,7 @@ namespace Metalama.Framework.Engine.Templating
 
             statementList.Add( new StatementOrTrivia( variableDeclaration ) );
 
-            return new SyntaxUserExpression( SyntaxFactory.IdentifierName( localVariableName ), type, true, true );
+            return new SyntaxUserExpression( SyntaxFactoryEx.WellKnownIdentifierName( localVariableName ), type, true, true );
         }
 
         public IExpression DefineLocalVariable( List<StatementOrTrivia> statementList, string name, Type type, ExpressionSyntax? expression )
@@ -727,13 +727,13 @@ namespace Metalama.Framework.Engine.Templating
             var declarator = SyntaxFactory.VariableDeclarator( localVariableName )
                 .WithInitializer( SyntaxFactory.EqualsValueClause( expression ) );
 
+#pragma warning disable LAMA0850 // Intentional use: passing SyntaxToken from WellKnownIdentifier
             var varType = SyntaxFactory.IdentifierName(
-                SyntaxFactory.Identifier(
+                SyntaxFactoryEx.WellKnownIdentifier(
                     default,
-                    SyntaxKind.VarKeyword,
-                    "var",
                     "var",
                     default ) );
+#pragma warning restore LAMA0850
 
             var variableDeclaration = SyntaxFactory.LocalDeclarationStatement(
                 default,
@@ -744,7 +744,7 @@ namespace Metalama.Framework.Engine.Templating
 
             statementList.Add( new StatementOrTrivia( variableDeclaration ) );
 
-            return new SyntaxUserExpression( SyntaxFactory.IdentifierName( localVariableName ), expressionType, true, true );
+            return new SyntaxUserExpression( SyntaxFactoryEx.WellKnownIdentifierName( localVariableName ), expressionType, true, true );
         }
 
         public IExpression DefineLocalVariable( List<StatementOrTrivia> statementList, string name, IExpression expression )
@@ -758,7 +758,7 @@ namespace Metalama.Framework.Engine.Templating
                 : name;
         }
 
-        public SyntaxToken EscapeIdentifier( SyntaxToken token ) => SyntaxFactory.Identifier( this.EscapeIdentifier( token.Text ) );
+        public SyntaxToken EscapeIdentifier( SyntaxToken token ) => SyntaxFactoryEx.SafeIdentifier( this.EscapeIdentifier( token.Text ) );
 
         public ExpressionSyntax RewriteAssignmentExpression( AssignmentExpressionSyntax assignmentExpression )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Transformations/ProceedHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Transformations/ProceedHelper.cs
@@ -122,7 +122,7 @@ internal static class ProceedHelper
 
             if ( cancellationTokenParameter != null )
             {
-                arguments = arguments.AddArguments( Argument( IdentifierName( cancellationTokenParameter.Name ) ) );
+                arguments = arguments.AddArguments( Argument( SyntaxFactoryEx.SafeIdentifierName( cancellationTokenParameter.Name ) ) );
             }
 
             var bufferExpression =
@@ -207,12 +207,12 @@ internal static class ProceedHelper
         if ( targetMember is IGeneric { TypeParameters.Count: > 0 } generic )
         {
             memberName = GenericName(
-                Identifier( memberNameString ),
-                TypeArgumentList( SeparatedList( generic.TypeParameters.SelectAsReadOnlyList( p => (TypeSyntax) IdentifierName( p.Name ) ) ) ) );
+                SyntaxFactoryEx.SafeIdentifier( memberNameString ),
+                TypeArgumentList( SeparatedList( generic.TypeParameters.SelectAsReadOnlyList( p => (TypeSyntax) SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) );
         }
         else
         {
-            memberName = IdentifierName( memberNameString );
+            memberName = SyntaxFactoryEx.SafeIdentifierName( memberNameString );
         }
 
         if ( !targetMember.IsStatic )
@@ -233,7 +233,7 @@ internal static class ProceedHelper
             {
                 expression = MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName( extensionBlock.ReceiverParameter.Name ),
+                    SyntaxFactoryEx.SafeIdentifierName( extensionBlock.ReceiverParameter.Name ),
                     memberName );
             }
             else

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Transformations/TransformationHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Transformations/TransformationHelper.cs
@@ -64,7 +64,7 @@ internal static class TransformationHelper
                 targetProperty,
                 AspectReferenceTargetKind.PropertySetAccessor,
                 syntaxGenerationContext.SyntaxGenerator ),
-            SyntaxFactory.IdentifierName( "value" ) );
+            SyntaxFactoryEx.WellKnownIdentifierName( "value" ) );
 
     public static ExpressionSyntax CreateIndexerProceedGetExpression(
         AspectReferenceSyntaxProvider aspectReferenceSyntaxProvider,
@@ -89,7 +89,7 @@ internal static class TransformationHelper
                 targetIndexer,
                 AspectReferenceTargetKind.PropertySetAccessor,
                 syntaxGenerationContext.SyntaxGenerator ),
-            SyntaxFactory.IdentifierName( "value" ) );
+            SyntaxFactoryEx.WellKnownIdentifierName( "value" ) );
 
     public static BracketedParameterListSyntax GetIndexerOverrideParameterList(
         CompilationModel compilation,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxExtensions.cs
@@ -169,6 +169,10 @@ public static class SyntaxExtensions
         return node.WithLeadingTrivia( leadingTrivia );
     }
 
+    internal static TNode WithOptionalLeadingTrivia<TNode>( this TNode node, SyntaxTriviaList leadingTrivia, SyntaxGenerationContext context )
+        where TNode : SyntaxNode
+        => node.WithOptionalLeadingTrivia( leadingTrivia, context.Options );
+
     internal static TNode WithRequiredLeadingTrivia<TNode>( this TNode node, IEnumerable<SyntaxTrivia> leadingTrivia )
         where TNode : SyntaxNode
         => node.WithLeadingTrivia( TriviaList( leadingTrivia ) );
@@ -289,6 +293,10 @@ public static class SyntaxExtensions
         return node.WithTrailingTrivia( trailingTrivia );
     }
 
+    internal static TNode WithOptionalTrailingTrivia<TNode>( this TNode node, SyntaxTriviaList trailingTrivia, SyntaxGenerationContext context )
+        where TNode : SyntaxNode
+        => node.WithOptionalTrailingTrivia( trailingTrivia, context.Options );
+
     // Resharper disable once UnusedMember.Global
     internal static SyntaxToken WithOptionalTrailingTrivia( this SyntaxToken token, SyntaxTriviaList trailingTrivia, SyntaxGenerationOptions options )
     {
@@ -343,6 +351,10 @@ public static class SyntaxExtensions
     internal static TNode WithTriviaFromIfNecessary<TNode>( this TNode node, SyntaxNode fromNode, SyntaxGenerationOptions options )
         where TNode : SyntaxNode
         => node.WithOptionalTrivia( fromNode.GetLeadingTrivia(), fromNode.GetTrailingTrivia(), options );
+
+    internal static TNode WithTriviaFromIfNecessary<TNode>( this TNode node, SyntaxNode fromNode, SyntaxGenerationContext context )
+        where TNode : SyntaxNode
+        => node.WithTriviaFromIfNecessary( fromNode, context.Options );
 
     internal static bool ShouldBePreserved( this SyntaxTriviaList trivia, SyntaxGenerationOptions options )
         => options.TriviaMatters || trivia.ContainsDirectives();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxHelpers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxHelpers.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -24,7 +25,7 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn
                             List<AttributeListSyntax>(),
                             TokenList(),
                             p.Type,
-                            Identifier( TriviaList( ElasticSpace ), p.Name, TriviaList( ElasticSpace ) ),
+                            SyntaxFactoryEx.SafeIdentifier( TriviaList( ElasticSpace ), p.Name, TriviaList( ElasticSpace ) ),
                             null ) );
 
             return WithAdditionalParameters( parameterList, additionalParameterSyntax );
@@ -64,7 +65,7 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn
                             List<AttributeListSyntax>(),
                             TokenList(),
                             p.Type,
-                            Identifier( TriviaList( ElasticSpace ), p.Name, TriviaList( ElasticSpace ) ),
+                            SyntaxFactoryEx.SafeIdentifier( TriviaList( ElasticSpace ), p.Name, TriviaList( ElasticSpace ) ),
                             default ) );
 
             if ( parameterList.Parameters.Last().Modifiers.Any( m => m.IsKind( SyntaxKind.ParamsKeyword ) ) )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping;
+
+// Issue #812: Names of introduced declarations should be @ escaped when necessary
+// When introducing a field with a name that is a C# keyword, the generated code
+// should escape the name with @ (e.g., @const), but currently it doesn't.
+
+internal class IntroduceKeywordFieldAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce a field with a C# keyword name
+        builder.IntroduceField( "const", typeof(int) );
+    }
+}
+
+[IntroduceKeywordFieldAspect]
+internal class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping.t.cs
@@ -1,0 +1,17 @@
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping;
+// Issue #812: Names of introduced declarations should be @ escaped when necessary
+// When introducing a field with a name that is a C# keyword, the generated code
+// should escape the name with @ (e.g., @const), but currently it doesn't.
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+internal class IntroduceKeywordFieldAspect : TypeAspect
+{
+  public override void BuildAspect(IAspectBuilder<INamedType> builder) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+}
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+[IntroduceKeywordFieldAspect]
+internal class TargetClass
+{
+  private global::System.Int32 @const;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_AllMembers.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_AllMembers.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_AllMembers;
+
+// Issue #812: Tests introduction of all member kinds with C# keyword names
+
+internal class IntroduceAllKeywordMembersAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce field
+        builder.IntroduceField( nameof(FieldTemplate), buildField: f => f.Name = "const" );
+
+        // Introduce property
+        builder.IntroduceProperty( nameof(PropertyTemplate), buildProperty: p => p.Name = "int" );
+
+        // Introduce method
+        builder.IntroduceMethod( nameof(MethodTemplate), buildMethod: m => m.Name = "void" );
+
+        // Introduce method with keyword parameter name
+        builder.IntroduceMethod(
+            nameof(MethodWithKeywordParamTemplate),
+            buildMethod: m => m.Name = "MethodWithKeywordParam" );
+
+        // Introduce event
+        builder.IntroduceEvent( nameof(EventTemplate), buildEvent: e => e.Name = "event" );
+    }
+
+    [Template]
+    public int FieldTemplate;
+
+    [Template]
+    public string PropertyTemplate { get; set; }
+
+    [Template]
+    public void MethodTemplate() { }
+
+    [Template]
+    public void MethodWithKeywordParamTemplate( string @class ) { }
+
+    [Template]
+    public event Action EventTemplate;
+}
+
+[IntroduceAllKeywordMembersAspect]
+internal class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_AllMembers.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_AllMembers.t.cs
@@ -1,0 +1,34 @@
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_AllMembers;
+// Issue #812: Tests introduction of all member kinds with C# keyword names
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+internal class IntroduceAllKeywordMembersAspect : TypeAspect
+{
+  public override void BuildAspect(IAspectBuilder<INamedType> builder) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  [Template]
+  public int FieldTemplate;
+  [Template]
+  public string PropertyTemplate { get; set; }
+  [Template]
+  public void MethodTemplate() => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  [Template]
+  public void MethodWithKeywordParamTemplate(string @class) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  [Template]
+  public event Action EventTemplate;
+}
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+[IntroduceAllKeywordMembersAspect]
+internal class TargetClass
+{
+  public global::System.Int32 @const;
+  public global::System.String @int { get; set; }
+  public void MethodWithKeywordParam(global::System.String @class)
+  {
+  }
+  public void @void()
+  {
+  }
+  public event global::System.Action @event;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Invokers.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Invokers.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @IgnoredDiagnostic(CS0649)
+// @IgnoredDiagnostic(CS0067)
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Code.Invokers;
+using System;
+using System.Linq;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_Invokers;
+
+// Issue #812: Tests invokers referencing members with C# keyword names
+
+internal class InvokeKeywordFieldAspect : FieldOrPropertyAspect
+{
+    public override void BuildAspect( IAspectBuilder<IFieldOrProperty> builder )
+    {
+        builder.OverrideAccessors(
+            nameof(GetTemplate),
+            nameof(SetTemplate),
+            new { target = builder.Target.DeclaringType!.Fields.OfName( "const" ).Single() } );
+    }
+
+    [Template]
+    public dynamic? GetTemplate( [CompileTime] IField target )
+    {
+        // Invoke field with keyword name via invoker
+        _ = target.Value;
+        _ = target.WithOptions( InvokerOptions.Final ).Value;
+
+        return meta.Proceed();
+    }
+
+    [Template]
+    public void SetTemplate( [CompileTime] IField target )
+    {
+        // Invoke field with keyword name via invoker
+        target.Value = 42;
+        target.WithOptions( InvokerOptions.Final ).Value = 42;
+
+        meta.Proceed();
+    }
+}
+
+internal class InvokeKeywordPropertyAspect : FieldOrPropertyAspect
+{
+    public override void BuildAspect( IAspectBuilder<IFieldOrProperty> builder )
+    {
+        builder.OverrideAccessors(
+            nameof(GetTemplate),
+            nameof(SetTemplate),
+            new { target = builder.Target.DeclaringType!.Properties.OfName( "int" ).Single() } );
+    }
+
+    [Template]
+    public dynamic? GetTemplate( [CompileTime] IProperty target )
+    {
+        // Invoke property with keyword name via invoker
+        _ = target.Value;
+
+        return meta.Proceed();
+    }
+
+    [Template]
+    public void SetTemplate( [CompileTime] IProperty target )
+    {
+        // Invoke property with keyword name via invoker
+        target.Value = "test";
+
+        meta.Proceed();
+    }
+}
+
+internal class InvokeKeywordMethodAspect : MethodAspect
+{
+    public override void BuildAspect( IAspectBuilder<IMethod> builder )
+    {
+        builder.Override( nameof(OverrideTemplate), new { target = builder.Target.DeclaringType!.Methods.OfName( "void" ).Single() } );
+    }
+
+    [Template]
+    public dynamic? OverrideTemplate( [CompileTime] IMethod target )
+    {
+        // Invoke method with keyword name via invoker
+        target.Invoke();
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+internal class TargetClass
+{
+    public int @const;
+    public string @int { get; set; }
+    public void @void() { }
+    public void MethodWithParam( string @class ) { }
+    public event Action @event;
+
+    [InvokeKeywordFieldAspect]
+    public int FieldInvoker { get; set; }
+
+    [InvokeKeywordPropertyAspect]
+    public string PropertyInvoker { get; set; }
+
+    [InvokeKeywordMethodAspect]
+    public void MethodInvoker() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Invokers.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Invokers.t.cs
@@ -1,0 +1,50 @@
+internal class TargetClass
+{
+  public int @const;
+  public string @int { get; set; }
+  public void @void()
+  {
+  }
+  public void MethodWithParam(string @class)
+  {
+  }
+  public event Action @event;
+  private int _fieldInvoker;
+  [InvokeKeywordFieldAspect]
+  public int FieldInvoker
+  {
+    get
+    {
+      _ = this.@const;
+      _ = this.@const;
+      return this._fieldInvoker;
+    }
+    set
+    {
+      this.@const = 42;
+      this.@const = 42;
+      this._fieldInvoker = value;
+    }
+  }
+  private string _propertyInvoker = default !;
+  [InvokeKeywordPropertyAspect]
+  public string PropertyInvoker
+  {
+    get
+    {
+      _ = this.@int;
+      return this._propertyInvoker;
+    }
+    set
+    {
+      this.@int = "test";
+      this._propertyInvoker = value;
+    }
+  }
+  [InvokeKeywordMethodAspect]
+  public void MethodInvoker()
+  {
+    this.@void();
+    return;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_MethodParams;
+
+// Issue #812: Tests contracts on parameters with C# keyword names
+
+internal class NotNullAttribute : ContractAspect
+{
+    public override void Validate( dynamic? value )
+    {
+        if ( value == null )
+        {
+            throw new ArgumentNullException();
+        }
+    }
+}
+
+internal class PositiveAttribute : ContractAspect
+{
+    public override void Validate( dynamic? value )
+    {
+        if ( value <= 0 )
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+    }
+}
+
+// <target>
+internal class TargetClass
+{
+    // Method with single keyword parameter name
+    public void MethodWithKeywordParam( [NotNull] string @class )
+    {
+        Console.WriteLine( $"class = {@class}" );
+    }
+
+    // Method with multiple keyword parameter names
+    public int MethodWithMultipleKeywordParams( [Positive] int @int, [NotNull] string @string, bool @return )
+    {
+        Console.WriteLine( $"int = {@int}, string = {@string}, return = {@return}" );
+
+        return @int;
+    }
+
+    // Constructor with keyword parameter names
+    public TargetClass( [NotNull] string @class, [Positive] int @for )
+    {
+        Console.WriteLine( $"class = {@class}, for = {@for}" );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.cs
@@ -3,7 +3,6 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 using System;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_MethodParams;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.t.cs
@@ -1,43 +1,38 @@
-internal class NotNullAttribute : ContractAspect
-{
-  public override void Validate(dynamic? value) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
-}
-internal class PositiveAttribute : ContractAspect
-{
-  public override void Validate(dynamic? value) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
-}
 internal class TargetClass
 {
-  public void MethodWithKeywordParam(string @class)
+  // Method with single keyword parameter name
+  public void MethodWithKeywordParam([NotNull] string @class)
   {
     if (@class == null)
     {
-      throw new ArgumentNullException();
+      throw new global::System.ArgumentNullException();
     }
     Console.WriteLine($"class = {@class}");
   }
-  public int MethodWithMultipleKeywordParams(int @int, string @string, bool @return)
+  // Method with multiple keyword parameter names
+  public int MethodWithMultipleKeywordParams([Positive] int @int, [NotNull] string @string, bool @return)
   {
     if (@int <= 0)
     {
-      throw new ArgumentOutOfRangeException();
+      throw new global::System.ArgumentOutOfRangeException();
     }
     if (@string == null)
     {
-      throw new ArgumentNullException();
+      throw new global::System.ArgumentNullException();
     }
     Console.WriteLine($"int = {@int}, string = {@string}, return = {@return}");
     return @int;
   }
-  public TargetClass(string @class, int @for)
+  // Constructor with keyword parameter names
+  public TargetClass([NotNull] string @class, [Positive] int @for)
   {
     if (@class == null)
     {
-      throw new ArgumentNullException();
+      throw new global::System.ArgumentNullException();
     }
     if (@for <= 0)
     {
-      throw new ArgumentOutOfRangeException();
+      throw new global::System.ArgumentOutOfRangeException();
     }
     Console.WriteLine($"class = {@class}, for = {@for}");
   }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_MethodParams.t.cs
@@ -1,0 +1,44 @@
+internal class NotNullAttribute : ContractAspect
+{
+  public override void Validate(dynamic? value) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+}
+internal class PositiveAttribute : ContractAspect
+{
+  public override void Validate(dynamic? value) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+}
+internal class TargetClass
+{
+  public void MethodWithKeywordParam(string @class)
+  {
+    if (@class == null)
+    {
+      throw new ArgumentNullException();
+    }
+    Console.WriteLine($"class = {@class}");
+  }
+  public int MethodWithMultipleKeywordParams(int @int, string @string, bool @return)
+  {
+    if (@int <= 0)
+    {
+      throw new ArgumentOutOfRangeException();
+    }
+    if (@string == null)
+    {
+      throw new ArgumentNullException();
+    }
+    Console.WriteLine($"int = {@int}, string = {@string}, return = {@return}");
+    return @int;
+  }
+  public TargetClass(string @class, int @for)
+  {
+    if (@class == null)
+    {
+      throw new ArgumentNullException();
+    }
+    if (@for <= 0)
+    {
+      throw new ArgumentOutOfRangeException();
+    }
+    Console.WriteLine($"class = {@class}, for = {@for}");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_NoDoubleAt.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_NoDoubleAt.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_NoDoubleAt;
+
+// Test that names already starting with @ are not double-escaped to @@
+
+internal class IntroducePreEscapedFieldAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce a field with a name that already starts with @
+        // This should NOT become @@const, but stay as @const
+        builder.IntroduceField( "@const", typeof(int) );
+    }
+}
+
+[IntroducePreEscapedFieldAspect]
+internal class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_NoDoubleAt.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_NoDoubleAt.t.cs
@@ -1,0 +1,15 @@
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_NoDoubleAt;
+// Test that names already starting with @ are not double-escaped to @@
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+internal class IntroducePreEscapedFieldAspect : TypeAspect
+{
+  public override void BuildAspect(IAspectBuilder<INamedType> builder) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+}
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+[IntroducePreEscapedFieldAspect]
+internal class TargetClass
+{
+  private global::System.Int32 @const;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Types.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Types.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_Types;
+
+// Issue #812: Tests introduction of nested types with C# keyword names
+
+internal class IntroduceKeywordTypesAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce nested class with keyword name
+        builder.IntroduceClass( "class" );
+
+        // Introduce nested class with another keyword name
+        builder.IntroduceClass( "struct" );
+    }
+}
+
+[IntroduceKeywordTypesAspect]
+internal class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Types.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug812_KeywordEscaping_Types.t.cs
@@ -1,0 +1,20 @@
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug812_KeywordEscaping_Types;
+// Issue #812: Tests introduction of nested types with C# keyword names
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+internal class IntroduceKeywordTypesAspect : TypeAspect
+{
+  public override void BuildAspect(IAspectBuilder<INamedType> builder) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+}
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+[IntroduceKeywordTypesAspect]
+internal class TargetClass
+{
+  class @class
+  {
+  }
+  class @struct
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Runner/TemplatingTestRunner.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Runner/TemplatingTestRunner.cs
@@ -381,11 +381,11 @@ namespace Metalama.Framework.Tests.TemplateTests.Runner
                 return
                     SyntaxFactory.InvocationExpression(
                         targetMethod.IsStatic
-                            ? SyntaxFactory.IdentifierName( targetMethod.Name )
+                            ? SyntaxFactoryEx.SafeIdentifierName( targetMethod.Name )
                             : SyntaxFactory.MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 SyntaxFactory.ThisExpression(),
-                                SyntaxFactory.IdentifierName( targetMethod.Name ) ),
+                                SyntaxFactoryEx.SafeIdentifierName( targetMethod.Name ) ),
                         SyntaxFactory.ArgumentList(
                             SyntaxFactory.SeparatedList(
                                 targetMethod.Parameters.SelectAsImmutableArray(
@@ -400,7 +400,7 @@ namespace Metalama.Framework.Tests.TemplateTests.Runner
                                                 RefKind.Ref => SyntaxFactory.Token( SyntaxKind.RefKeyword ),
                                                 _ => throw new AssertionFailedException( $"Unexpected value for RefKind in {p}: {p.RefKind}." )
                                             },
-                                            SyntaxFactory.IdentifierName( p.Name ) ) ) ) ) );
+                                            SyntaxFactoryEx.SafeIdentifierName( p.Name ) ) ) ) ) );
             }
         }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/InvokerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/InvokerTests.cs
@@ -332,11 +332,11 @@ class TargetCode
                 AssertEx.DynamicEquals( property.Value, @"this.P" );
 
                 AssertEx.DynamicEquals(
-                    property.WithObject( SyntaxFactory.IdentifierName( "a" ) ).WithOptions( InvokerOptions.NullConditional ).Value,
+                    property.WithObject( SyntaxFactoryEx.SafeIdentifierName( "a" ) ).WithOptions( InvokerOptions.NullConditional ).Value,
                     @"((global::TargetCode)a)?.P" );
 
                 AssertEx.DynamicEquals(
-                    ((FieldOrPropertyInvoker) property.WithObject( SyntaxFactory.IdentifierName( "a" ) )).SetValue( SyntaxFactory.IdentifierName( "b" ) ),
+                    ((FieldOrPropertyInvoker) property.WithObject( SyntaxFactoryEx.SafeIdentifierName( "a" ) )).SetValue( SyntaxFactoryEx.SafeIdentifierName( "b" ) ),
                     @"((global::TargetCode)a).P = b" );
             }
         }
@@ -366,7 +366,7 @@ class TargetCode
                 AssertEx.DynamicEquals( property.Value, @"this.P" );
 
                 AssertEx.DynamicEquals(
-                    property.GetMethod!.WithObject( SyntaxFactory.IdentifierName( "a" ) ).WithOptions( InvokerOptions.NullConditional ).Invoke(),
+                    property.GetMethod!.WithObject( SyntaxFactoryEx.SafeIdentifierName( "a" ) ).WithOptions( InvokerOptions.NullConditional ).Invoke(),
                     @"((global::TargetCode)a)?.P" );
             }
         }
@@ -398,7 +398,7 @@ class TargetCode
                 var @event = type.Events.Single();
 
                 TypedExpressionSyntaxImpl parameterExpression = new(
-                    SyntaxFactory.IdentifierName( "value" ),
+                    SyntaxFactoryEx.SafeIdentifierName( "value" ),
                     syntaxSerializationContext.CompilationModel );
 
                 AssertEx.DynamicEquals( @event.Add( parameterExpression ), @"this.MyEvent += value" );
@@ -437,7 +437,7 @@ class TargetCode
                 var @event = type.Events.Single();
 
                 TypedExpressionSyntaxImpl parameterExpression = new(
-                    SyntaxFactory.IdentifierName( "value" ),
+                    SyntaxFactoryEx.SafeIdentifierName( "value" ),
                     syntaxSerializationContext.CompilationModel );
 
                 AssertEx.DynamicEquals(


### PR DESCRIPTION
## Summary
- Added `SafeIdentifier` and `SafeIdentifierName` methods in `SyntaxFactoryEx.cs` that escape C# keywords with `@` prefix when necessary
- Added `WellKnownIdentifier` and `WellKnownIdentifierName` methods for generated names that don't need escaping (like `__o_p__` prefixed names)
- Created `LAMA0850` analyzer (`UnsafeIdentifierAnalyzer.cs`) to detect unsafe `Identifier`/`IdentifierName` calls and guide developers to use safe alternatives
- Fixed all `LAMA0850` warnings across the codebase by using the appropriate safe methods
- Fixed `LAMA0832` warnings in EventRaise substitution files by using `WithOptionalLeadingTrivia`/`WithOptionalTrailingTrivia` with context options
- Added `SyntaxGenerationContext` overloads for `WithOptionalLeadingTrivia`, `WithOptionalTrailingTrivia`, and `WithTriviaFromIfNecessary` for simpler code
- Created Bug812 test files to verify keyword escaping works correctly for fields, properties, methods, events, parameters, and nested types

Closes #812

-- Claude