### PR TITLE
Fix AttributeConstruction.Create with unbound generic types (#1014)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework/Code/DeclarationBuilders/AttributeConstruction.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/DeclarationBuilders/AttributeConstruction.cs
@@ -120,14 +120,14 @@ namespace Metalama.Framework.Code.DeclarationBuilders
             constructorArguments ??= ImmutableArray<object?>.Empty;
             namedArguments ??= ImmutableArray<KeyValuePair<string, object?>>.Empty;
 
-            // Translate provided IType - typed parameters to System.Type to get the correct constructor.
-            // Also translate CompileTimeType to System.Type, since CompileTimeType can't be translated to a symbol in the run-time assembly.
+            // Translate IType and System.Type arguments to System.Type to get the correct constructor.
+            // This handles IType implementations, CompileTimeType, RuntimeType, and other Type subclasses.
             var constructorArgumentTypes =
                 constructorArguments
                     .Select( x => x?.GetType() )
                     .Select(
                         x => x == null ? null :
-                            typeof(IType).IsAssignableFrom( x ) || x.FullName == "Metalama.Framework.Engine.ReflectionMocks.CompileTimeType" ? typeof(Type) :
+                            typeof(IType).IsAssignableFrom( x ) || typeof(Type).IsAssignableFrom( x ) ? typeof(Type) :
                             x )
                     .ToArray();
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Attributes/AddWithParameterOfUnboundGenericType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Attributes/AddWithParameterOfUnboundGenericType.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Code.DeclarationBuilders;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Attributes.AddWithParameterOfUnboundGenericType;
+
+public class MyAttribute : Attribute
+{
+    public MyAttribute( Type t ) { }
+}
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Bug #1014: Using an unbound generic type like List<> throws:
+        // "The type 'System.RuntimeType' cannot be used at run-time"
+        builder.IntroduceAttribute(
+            AttributeConstruction.Create(
+                typeof(MyAttribute),
+                constructorArguments: new object?[] { typeof(List<>) } ) );
+    }
+}
+
+// <target>
+[MyAspect]
+internal class C;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Attributes/AddWithParameterOfUnboundGenericType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Attributes/AddWithParameterOfUnboundGenericType.t.cs
@@ -1,0 +1,3 @@
+[MyAspect]
+[global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Attributes.AddWithParameterOfUnboundGenericType.MyAttribute(typeof(global::System.Collections.Generic.List<>))]
+internal class C;


### PR DESCRIPTION
 ## Summary
  - Fixes #1014: `System.InvalidOperationException` when using unbound generic types like `typeof(List<>)` in `AttributeConstruction.Create`
  - The issue was that `RuntimeType` (the actual type of `Type` objects at runtime) was not being mapped to `System.Type` for constructor signature matching
  - Simplified the type mapping logic by using `typeof(Type).IsAssignableFrom(x)` which covers `RuntimeType`, `CompileTimeType`, and all other `Type` subclasses
