### PR TITLE
Fix compile-time flow termination on return and throw in templates (#1125)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RestorePrerelease>true</RestorePrerelease>
   </PropertyGroup>
   <PropertyGroup>
-    <PostSharpEngineeringVersion Condition="'$(PostSharpEngineeringVersion)'==''">2023.2.288</PostSharpEngineeringVersion>
+    <PostSharpEngineeringVersion Condition="'$(PostSharpEngineeringVersion)'==''">2023.2.290</PostSharpEngineeringVersion>
   
     <!-- We must match the version used by the lowest version of Visual Studio supported by the VSX, i.e. VS 17.12. -->
     <NewtonsoftJsonMinVersion>13.0.3</NewtonsoftJsonMinVersion>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.MetaContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.MetaContext.cs
@@ -131,10 +131,11 @@ namespace Metalama.Framework.Engine.Templating
             }
 
             /// <summary>
-            /// Creates a child <see cref="MetaContext"/> copies everything from the parent context but has its own
-            /// list of statements.
+            /// Creates a child <see cref="MetaContext"/> that inherits all compile-time/run-time semantics from
+            /// the parent but has its own statement list. Used for local statement grouping without changing
+            /// flow control behavior (e.g., grouping statements before adding them to the parent).
             /// </summary>
-            public static MetaContext CreateHelperContext( MetaContext parentContext )
+            public static MetaContext CreateStatementGroupContext( MetaContext parentContext )
             {
                 return new MetaContext(
                     parentContext.StatementListVariableName,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.MetaContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.MetaContext.cs
@@ -35,13 +35,69 @@ namespace Metalama.Framework.Engine.Templating
                 string statementListVariableName,
                 Dictionary<ISymbol, SyntaxToken> generatedCodeSymbolNameLocals,
                 Dictionary<ISymbol, SyntaxToken> templateCodeSymbolNameLocals,
-                TemplateLexicalScope templateUniqueNames )
+                TemplateLexicalScope templateUniqueNames,
+                MetaContext? parent = null,
+                bool isRunTimeBlock = false,
+                bool isCompileTimeConditionalBlock = false )
             {
                 this.StatementListVariableName = statementListVariableName;
                 this._generatedCodeSymbolNameLocals = generatedCodeSymbolNameLocals;
                 this._templateCodeSymbolNameLocals = templateCodeSymbolNameLocals;
                 this._templateUniqueNames = templateUniqueNames;
                 this.Statements = new List<StatementSyntax>();
+                this.Parent = parent;
+                this.IsRunTimeBlock = isRunTimeBlock;
+                this.IsCompileTimeConditionalBlock = isCompileTimeConditionalBlock;
+            }
+
+            /// <summary>
+            /// Gets the parent context, or <c>null</c> if this is the root context.
+            /// </summary>
+            public MetaContext? Parent { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether this context corresponds to a run-time block.
+            /// </summary>
+            public bool IsRunTimeBlock { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether this context corresponds to a compile-time conditional block
+            /// (e.g., the body of a compile-time if/while/for statement).
+            /// </summary>
+            public bool IsCompileTimeConditionalBlock { get; }
+
+            /// <summary>
+            /// Determines whether this context or any of its ancestors is a run-time block.
+            /// A return statement inside a run-time block should not terminate compile-time flow.
+            /// </summary>
+            public bool IsInsideRunTimeBlock()
+            {
+                for ( var context = this; context != null; context = context.Parent )
+                {
+                    if ( context.IsRunTimeBlock )
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// Determines whether this context or any of its ancestors is a compile-time conditional block.
+            /// Only returns inside compile-time conditionals should terminate compile-time flow.
+            /// </summary>
+            public bool IsInsideCompileTimeConditionalBlock()
+            {
+                for ( var context = this; context != null; context = context.Parent )
+                {
+                    if ( context.IsCompileTimeConditionalBlock )
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             /// <summary>
@@ -59,7 +115,19 @@ namespace Metalama.Framework.Engine.Templating
 
                 var templateLexicalScope = parentContext?._templateUniqueNames ?? new TemplateLexicalScope( ImmutableHashSet<string>.Empty );
 
-                return new MetaContext( statementListVariableName, generatedCodeSymbolNameLocals, templateCodeSymbolNameLocals, templateLexicalScope );
+                // Only mark as a run-time block if there's a parent context.
+                // The root context (parentContext == null) is the template body itself and should not
+                // be considered a "run-time block" for the purpose of compile-time flow termination.
+                // A "run-time block" in this context means a block inside a run-time conditional
+                // (like if(runtime_condition)), where returns should not terminate compile-time flow.
+
+                return new MetaContext(
+                    statementListVariableName,
+                    generatedCodeSymbolNameLocals,
+                    templateCodeSymbolNameLocals,
+                    templateLexicalScope,
+                    parentContext,
+                    isRunTimeBlock: parentContext != null );
             }
 
             /// <summary>
@@ -72,14 +140,20 @@ namespace Metalama.Framework.Engine.Templating
                     parentContext.StatementListVariableName,
                     parentContext._generatedCodeSymbolNameLocals,
                     parentContext._templateCodeSymbolNameLocals,
-                    parentContext._templateUniqueNames );
+                    parentContext._templateUniqueNames,
+                    parentContext );
             }
 
             /// <summary>
             /// Creates a child <see cref="MetaContext"/> that corresponds to a new compile-time block (lexical scope).
             /// Symbols defined in the child scope are not defined in the parent scope.
             /// </summary>
-            public static MetaContext CreateForCompileTimeBlock( MetaContext parentContext )
+            /// <param name="parentContext">The parent context.</param>
+            /// <param name="isConditionalBlock">
+            /// <c>true</c> if this block is the body of a compile-time conditional (if/while/for/do);
+            /// <c>false</c> for regular lexical scopes like the template body.
+            /// </param>
+            public static MetaContext CreateForCompileTimeBlock( MetaContext parentContext, bool isConditionalBlock = false )
             {
                 // Compile-time blocks are currently without effect because the dictionary maps resolved symbols, and not symbol
                 // names. Two declaration of variables with the same name are still different symbols, so we don't strictly
@@ -92,7 +166,9 @@ namespace Metalama.Framework.Engine.Templating
                     parentContext.StatementListVariableName,
                     lexicalScope,
                     parentContext._templateCodeSymbolNameLocals,
-                    parentContext._templateUniqueNames );
+                    parentContext._templateUniqueNames,
+                    parentContext,
+                    isCompileTimeConditionalBlock: isConditionalBlock );
             }
 
             /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -2072,12 +2072,13 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
         else
         {
-            // Push a new MetaContext so statements got added to a new list of statements.
-            // If isConditionalBlock is true, we still need to mark this as a conditional block
-            // even though it's not a lexical scope (e.g., statements in a switch case).
+            // Push a new MetaContext so statements get added to a new list of statements.
+            // Switch case statements are not wrapped in a block syntactically, but if they're inside
+            // a compile-time switch, return/throw should still terminate compile-time flow. We use
+            // CreateForCompileTimeBlock to mark the context as a conditional block in this case.
             newContext = isConditionalBlock
                 ? MetaContext.CreateForCompileTimeBlock( this._currentMetaContext!, isConditionalBlock: true )
-                : MetaContext.CreateHelperContext( this._currentMetaContext! );
+                : MetaContext.CreateStatementGroupContext( this._currentMetaContext! );
 
             using ( this.WithMetaContext( newContext ) )
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -1140,12 +1140,10 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
                     this.AddAddStatementStatement( node, transformedReturnStatement );
 
-                    // If the return should terminate compile-time flow, add an early return from the template.
-                    if ( this._shouldGenerateEarlyReturn )
-                    {
-                        this._currentMetaContext!.Statements.Add( this.GenerateEarlyTemplateReturn() );
-                        this._shouldGenerateEarlyReturn = false;
-                    }
+                    // Note: meta.Return() emits a return statement to the run-time code but does NOT
+                    // terminate compile-time flow. Only actual 'return' statements in the template
+                    // should terminate compile-time flow.
+                    this._shouldGenerateEarlyReturn = false;
 
                     return null;
                 }
@@ -2014,8 +2012,13 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     /// Transforms a list of <see cref="StatementSyntax"/> of the source template into a list of <see cref="StatementSyntax"/> for the compiled
     /// template.
     /// </summary>
-    private IEnumerable<StatementSyntax> ToMetaStatements( in SyntaxList<StatementSyntax> statements )
-        => statements.SelectMany( s => this.ToMetaStatements( s ) );
+    /// <param name="statements">The statements to transform.</param>
+    /// <param name="isConditionalBlock">
+    /// <c>true</c> if these statements are inside a compile-time conditional (if/while/for/do/switch case);
+    /// <c>false</c> for regular statements.
+    /// </param>
+    private IEnumerable<StatementSyntax> ToMetaStatements( in SyntaxList<StatementSyntax> statements, bool isConditionalBlock = false )
+        => statements.SelectMany( s => this.ToMetaStatements( s, isConditionalBlock ) );
 
     /// <summary>
     /// Transforms a <see cref="StatementSyntax"/> of the source template into a single <see cref="StatementSyntax"/> for the compiled template.
@@ -2069,9 +2072,12 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
         else
         {
-            // Push a new MetaContext so statements got added to a new list of statements, but
-            // this MetaContext is neither a run-time nor a compile-time lexical scope. 
-            newContext = MetaContext.CreateHelperContext( this._currentMetaContext! );
+            // Push a new MetaContext so statements got added to a new list of statements.
+            // If isConditionalBlock is true, we still need to mark this as a conditional block
+            // even though it's not a lexical scope (e.g., statements in a switch case).
+            newContext = isConditionalBlock
+                ? MetaContext.CreateForCompileTimeBlock( this._currentMetaContext!, isConditionalBlock: true )
+                : MetaContext.CreateHelperContext( this._currentMetaContext! );
 
             using ( this.WithMetaContext( newContext ) )
             {
@@ -2127,19 +2133,20 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
                         newContext.Statements.Add( add.WithLeadingTrivia( leadingTrivia ).WithTrailingTrivia( trailingTrivia ) );
 
-                        // If a return statement was processed and should terminate compile-time flow,
-                        // add an early return from the template.
-                        if ( this._shouldGenerateEarlyReturn )
-                        {
-                            newContext.Statements.Add( this.GenerateEarlyTemplateReturn() );
-                            this._shouldGenerateEarlyReturn = false;
-                        }
-
                         break;
                     }
 
                 default:
                     throw new AssertionFailedException( $"Unexpected node kind {transformedNode.Kind()} at '{singleStatement.GetLocation()};." );
+            }
+
+            // If a return or throw statement was processed and should terminate compile-time flow,
+            // add an early return from the template. This is checked after the switch for clarity,
+            // though the flag can only be set when the statement was transformed to an ExpressionSyntax.
+            if ( this._shouldGenerateEarlyReturn )
+            {
+                newContext.Statements.Add( this.GenerateEarlyTemplateReturn() );
+                this._shouldGenerateEarlyReturn = false;
             }
         }
     }
@@ -2258,7 +2265,9 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
             for ( var i = 0; i < node.Sections.Count; i++ )
             {
                 var section = node.Sections[i];
-                var transformedStatements = this.ToMetaStatements( section.Statements ).ToMutableList();
+
+                // Compile-time switch: pass isConditionalBlock=true so returns/throws inside terminate compile-time flow.
+                var transformedStatements = this.ToMetaStatements( section.Statements, isConditionalBlock: true ).ToMutableList();
 
                 // If the last statement does not transfer control elsewhere, add a break statement.
                 // This happens when the transfer control statement in a template is run-time (e.g. a throw).
@@ -2518,6 +2527,36 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         return ReturnStatement( blockExpression )
             .WithLeadingTrivia( this.GetIndentation() )
             .NormalizeWhitespace();
+    }
+
+    public override SyntaxNode VisitThrowStatement( ThrowStatementSyntax node )
+    {
+        // Transform the throw expression to create run-time syntax.
+        var transformedExpression = node.Expression != null ? this.Transform( node.Expression ) : null;
+
+        // Generate: SyntaxFactory.ThrowStatement( expression )
+        InvocationExpressionSyntax invocationExpression;
+
+        if ( transformedExpression != null )
+        {
+            invocationExpression = InvocationExpression( this.MetaSyntaxFactory.SyntaxFactoryMethod( nameof(ThrowStatement) ) )
+                .AddArgumentListArguments( Argument( transformedExpression ) );
+        }
+        else
+        {
+            // Rethrow: throw;
+            invocationExpression = InvocationExpression( this.MetaSyntaxFactory.SyntaxFactoryMethod( nameof(ThrowStatement) ) );
+        }
+
+        var addThrowExpression = this.WithCallToAddSimplifierAnnotation( invocationExpression );
+
+        // If this throw is NOT inside a run-time block AND is inside a compile-time conditional
+        // block (e.g., compile-time if/while/for), it should terminate compile-time flow.
+        // Same logic as return statements.
+        this._shouldGenerateEarlyReturn = !this._currentMetaContext!.IsInsideRunTimeBlock()
+                                          && this._currentMetaContext.IsInsideCompileTimeConditionalBlock();
+
+        return addThrowExpression;
     }
 
     private InvocationExpressionSyntax ConvertToUserExpression( ExpressionSyntax expression )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -66,7 +66,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     private ISymbol? _rootTemplateSymbol;
 
     /// <summary>
-    /// Set to true by <see cref="VisitReturnStatement"/> when the return should terminate compile-time flow.
+    /// Set to true by <see cref="VisitReturnStatement"/> or <see cref="VisitThrowStatement"/> when the statement should terminate compile-time flow.
     /// Callers should check this flag and generate an early template return if needed.
     /// </summary>
     private bool _shouldGenerateEarlyReturn;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -65,6 +65,12 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     private int _nextStatementListId;
     private ISymbol? _rootTemplateSymbol;
 
+    /// <summary>
+    /// Set to true by <see cref="VisitReturnStatement"/> when the return should terminate compile-time flow.
+    /// Callers should check this flag and generate an early template return if needed.
+    /// </summary>
+    private bool _shouldGenerateEarlyReturn;
+
     public TemplateCompilerRewriter(
         string templateName,
         TemplateCompilerSemantics syntaxKind,
@@ -1127,13 +1133,22 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 }
 
             case MetaMemberKind.Return:
-                var returnStatement = ReturnStatement( node.ArgumentList.Arguments.SingleOrDefault()?.Expression );
+                {
+                    var returnStatement = ReturnStatement( node.ArgumentList.Arguments.SingleOrDefault()?.Expression );
 
-                var transformedReturnStatement = (ExpressionSyntax) this.VisitReturnStatement( returnStatement );
+                    var transformedReturnStatement = (ExpressionSyntax) this.VisitReturnStatement( returnStatement );
 
-                this.AddAddStatementStatement( node, transformedReturnStatement );
+                    this.AddAddStatementStatement( node, transformedReturnStatement );
 
-                return null;
+                    // If the return should terminate compile-time flow, add an early return from the template.
+                    if ( this._shouldGenerateEarlyReturn )
+                    {
+                        this._currentMetaContext!.Statements.Add( this.GenerateEarlyTemplateReturn() );
+                        this._shouldGenerateEarlyReturn = false;
+                    }
+
+                    return null;
+                }
 
             case MetaMemberKind.DefineLocalVariable:
                 {
@@ -1999,16 +2014,22 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     /// Transforms a list of <see cref="StatementSyntax"/> of the source template into a list of <see cref="StatementSyntax"/> for the compiled
     /// template.
     /// </summary>
-    private IEnumerable<StatementSyntax> ToMetaStatements( in SyntaxList<StatementSyntax> statements ) => statements.SelectMany( this.ToMetaStatements );
+    private IEnumerable<StatementSyntax> ToMetaStatements( in SyntaxList<StatementSyntax> statements )
+        => statements.SelectMany( s => this.ToMetaStatements( s ) );
 
     /// <summary>
     /// Transforms a <see cref="StatementSyntax"/> of the source template into a single <see cref="StatementSyntax"/> for the compiled template.
     /// This method is guaranteed to return a single <see cref="StatementSyntax"/>. If the source statement results in several compiled statements,
     /// they will be wrapped into a block.
     /// </summary>
-    private StatementSyntax ToMetaStatement( StatementSyntax statement )
+    /// <param name="statement">A statement of the source template.</param>
+    /// <param name="isConditionalBlock">
+    /// <c>true</c> if this statement is the body of a compile-time conditional (if/while/for/do);
+    /// <c>false</c> for regular statements.
+    /// </param>
+    private StatementSyntax ToMetaStatement( StatementSyntax statement, bool isConditionalBlock = false )
     {
-        var statements = this.ToMetaStatements( statement );
+        var statements = this.ToMetaStatements( statement, isConditionalBlock );
 
         // Declaration statements (for local variable or function) and labeled statements cannot be embedded in e.g. an if statement directly,
         // so enclose them in a block here, in case they're used that way.
@@ -2021,15 +2042,19 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     /// Transforms a <see cref="StatementSyntax"/> of the source template into a list of <see cref="StatementSyntax"/> for the compiled template.
     /// </summary>
     /// <param name="statement">A statement of the source template.</param>
+    /// <param name="isConditionalBlock">
+    /// <c>true</c> if this statement is the body of a compile-time conditional (if/while/for/do);
+    /// <c>false</c> for regular statements.
+    /// </param>
     /// <returns>A list of statements for the compiled template.</returns>
-    private List<StatementSyntax> ToMetaStatements( StatementSyntax statement )
+    private List<StatementSyntax> ToMetaStatements( StatementSyntax statement, bool isConditionalBlock = false )
     {
         MetaContext newContext;
 
         if ( statement is BlockSyntax block )
         {
             // Push the compile-time template block.
-            newContext = MetaContext.CreateForCompileTimeBlock( this._currentMetaContext! );
+            newContext = MetaContext.CreateForCompileTimeBlock( this._currentMetaContext!, isConditionalBlock );
 
             using ( this.WithMetaContext( newContext ) )
             {
@@ -2101,6 +2126,14 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                                             ] ) ) ) ) );
 
                         newContext.Statements.Add( add.WithLeadingTrivia( leadingTrivia ).WithTrailingTrivia( trailingTrivia ) );
+
+                        // If a return statement was processed and should terminate compile-time flow,
+                        // add an early return from the template.
+                        if ( this._shouldGenerateEarlyReturn )
+                        {
+                            newContext.Statements.Add( this.GenerateEarlyTemplateReturn() );
+                            this._shouldGenerateEarlyReturn = false;
+                        }
 
                         break;
                     }
@@ -2264,8 +2297,9 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
         else
         {
-            var transformedStatement = this.ToMetaStatement( node.Statement );
-            var transformedElseStatement = node.Else != null ? this.ToMetaStatement( node.Else.Statement ) : null;
+            // Compile-time if: pass isConditionalBlock=true so returns inside terminate compile-time flow.
+            var transformedStatement = this.ToMetaStatement( node.Statement, isConditionalBlock: true );
+            var transformedElseStatement = node.Else != null ? this.ToMetaStatement( node.Else.Statement, isConditionalBlock: true ) : null;
 
             // The condition may contains constructs like typeof or nameof that need to be transformed.
             var condition = (ExpressionSyntax) this.Visit( node.Condition )!;
@@ -2336,7 +2370,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
         else
         {
-            var transformedStatement = this.ToMetaStatement( node.Statement );
+            // Compile-time while: pass isConditionalBlock=true so returns inside terminate compile-time flow.
+            var transformedStatement = this.ToMetaStatement( node.Statement, isConditionalBlock: true );
 
             return WhileStatement(
                 node.AttributeLists,
@@ -2354,7 +2389,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
         else
         {
-            var transformedStatement = this.ToMetaStatement( node.Statement );
+            // Compile-time do: pass isConditionalBlock=true so returns inside terminate compile-time flow.
+            var transformedStatement = this.ToMetaStatement( node.Statement, isConditionalBlock: true );
 
             return DoStatement(
                 node.AttributeLists,
@@ -2373,7 +2409,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
         this.Indent();
 
-        var statement = this.ToMetaStatement( node.Statement );
+        // Compile-time foreach: pass isConditionalBlock=true so returns inside terminate compile-time flow.
+        var statement = this.ToMetaStatement( node.Statement, isConditionalBlock: true );
 
         this.Unindent();
 
@@ -2449,7 +2486,38 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                         Argument( LiteralExpression( awaitResult ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression ) ) );
         }
 
-        return this.WithCallToAddSimplifierAnnotation( invocationExpression );
+        var addReturnExpression = this.WithCallToAddSimplifierAnnotation( invocationExpression );
+
+        // If this return is NOT inside a run-time block AND is inside a compile-time conditional
+        // block (e.g., compile-time if/while/for), it should terminate compile-time flow.
+        // We only generate early return when inside a compile-time conditional to avoid skipping
+        // declarations (like local functions) that come after a top-level return.
+        // Bug 1125: return inside compile-time if should stop flow when condition is true.
+        // Bug 32744: return at top level should NOT skip local functions after it.
+        this._shouldGenerateEarlyReturn = !this._currentMetaContext!.IsInsideRunTimeBlock()
+                                          && this._currentMetaContext.IsInsideCompileTimeConditionalBlock();
+
+        return addReturnExpression;
+    }
+
+    /// <summary>
+    /// Generates a return statement that exits the template and returns the current statement list.
+    /// This is used after processing a return statement that should terminate compile-time flow.
+    /// </summary>
+    private StatementSyntax GenerateEarlyTemplateReturn()
+    {
+        // Generate: TemplateSyntaxFactory.ToStatementList( __s1 )
+        var toStatementListExpression = InvocationExpression(
+            this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.ToStatementList) ),
+            ArgumentList( SingletonSeparatedList( Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.StatementListVariableName ) ) ) ) );
+
+        // Wrap in Block: MetaSyntaxFactory.Block( default, ToStatementList(...) )
+        // This matches the pattern used for normal template returns.
+        var blockExpression = this.MetaSyntaxFactory.Block( SyntaxFactoryEx.Default, toStatementListExpression );
+
+        return ReturnStatement( blockExpression )
+            .WithLeadingTrivia( this.GetIndentation() )
+            .NormalizeWhitespace();
     }
 
     private InvocationExpressionSyntax ConvertToUserExpression( ExpressionSyntax expression )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1125.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1125.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Linq;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1125;
+
+// Bug: Compile-time control flow does not stop after a `return` instruction,
+// causing NullReferenceException when accessing members of null references.
+
+internal class ReturnDoesNotStopCompileTimeFlowAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        // This will always be null because the predicate always returns false.
+        var prop = meta.Target.Type.Properties.SingleOrDefault( x => false );
+
+        if ( prop == null )
+        {
+            return null;
+            // The compile-time flow does not stop here, but continues.
+        }
+
+        // NullReferenceException at compile time because prop is null.
+        return prop.Value;
+    }
+}
+
+internal class TargetCode
+{
+    public string Property { get; set; }
+
+    // <target>
+    [ReturnDoesNotStopCompileTimeFlowAspect]
+    private object? Method() => null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1125.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1125.t.cs
@@ -1,0 +1,5 @@
+[ReturnDoesNotStopCompileTimeFlowAspect]
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeElse.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeElse.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeElse
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // When the compile-time condition is false, the else branch executes
+        // and the return in the else block should stop the compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always false.
+            if ( meta.Target.Method.Name.Length == 0 )
+            {
+                return meta.Proceed();
+            }
+            else
+            {
+                return null;
+                // Compile-time flow should stop here.
+            }
+
+            // This code should NOT be reached at compile time.
+            ThrowIfReached();
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+            => throw new InvalidOperationException( "Compile-time flow should have stopped at return." );
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeElse.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeElse.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfFalse.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfFalse.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfFalse
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // When the compile-time condition is false, the return should NOT be executed
+        // and the code after the if block should run.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always false.
+            if ( meta.Target.Method.Name.Length == 0 )
+            {
+                return null;
+            }
+
+            // This code SHOULD be reached at compile time when the condition is false.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfFalse.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfFalse.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return this.Method();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfInRunTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfInRunTimeIf.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfInRunTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Compile-time if nested inside run-time if:
+        // - The run-time if is emitted to output.
+        // - Inside the run-time if, compile-time condition is evaluated.
+        // - If compile-time condition is true, the return is emitted inside run-time if.
+        // - Compile-time flow should CONTINUE past the run-time if because
+        //   the run-time if might not execute at runtime.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            var p = meta.Target.Parameters[0];
+
+            // Run-time condition - always emitted.
+            if ( p.Value == null )
+            {
+                // Compile-time condition that is always true.
+                if ( meta.Target.Method.Name.Length > 0 )
+                {
+                    return null;
+                }
+            }
+
+            // This code SHOULD be emitted because the run-time if might not execute.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return a;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfInRunTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfInRunTimeIf.t.cs
@@ -1,0 +1,8 @@
+private object? Method(object? a)
+{
+  if (a == null)
+  {
+    return null;
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfTrue.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfTrue.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Bug #1125: When the compile-time condition is true, the return should stop
+        // the compile-time control flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always true.
+            if ( meta.Target.Method.Name.Length > 0 )
+            {
+                return null;
+                // Compile-time flow should stop here.
+            }
+
+            // This code should NOT be reached at compile time when the condition is true.
+            ThrowIfReached();
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+            => throw new InvalidOperationException( "Compile-time flow should have stopped at return." );
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfTrue.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfTrue.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeSwitch.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeSwitch.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeSwitch
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Return inside a compile-time switch case should terminate compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            switch ( meta.Target.Method.Parameters.Count )
+            {
+                case 0:
+                    return null;
+                    // Compile-time flow should stop here.
+
+                default:
+                    break;
+            }
+
+            // This code should NOT be reached when parameter count is 0.
+            ThrowIfReached();
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+            => throw new InvalidOperationException( "Compile-time flow should have stopped at return." );
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeSwitch.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInLambda
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // A return inside a lambda should NOT stop the outer template.
+        // The lambda has its own scope; its return is independent.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Define a run-time lambda with a return - use meta.RunTime to clarify scope
+            Func<object?, object?> lambda = meta.RunTime( ( object? input ) =>
+            {
+                if ( input == null )
+                {
+                    return "default";  // This return is in the lambda, not the template
+                }
+
+                return input;
+            } );
+
+            // Call the lambda (its return value is used here)
+            var result = lambda( meta.Proceed() );
+
+            // This code SHOULD be reached - the lambda's return doesn't stop the template
+            return result;
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using System;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Engine.Templating;
 
@@ -17,7 +16,7 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInLambda
         private dynamic? Template()
         {
             // Define a run-time lambda with a return - use meta.RunTime to clarify scope
-            Func<object?, object?> lambda = meta.RunTime( ( object? input ) =>
+            var lambda = meta.RunTime( ( object? input ) =>
             {
                 if ( input == null )
                 {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.t.cs
@@ -1,0 +1,13 @@
+private object? Method()
+{
+  global::System.Func<global::System.Object?, global::System.Object?> lambda = (object? input) =>
+  {
+    if (input == null)
+    {
+      return (global::System.Object)"default";
+    }
+    return (global::System.Object)input;
+  };
+  var result = lambda(this.Method());
+  return (global::System.Object?)result;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLambda.t.cs
@@ -1,6 +1,6 @@
 private object? Method()
 {
-  global::System.Func<global::System.Object?, global::System.Object?> lambda = (object? input) =>
+  var lambda = (object? input) =>
   {
     if (input == null)
     {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLocalFunction.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLocalFunction.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInLocalFunction
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // A return inside a local function should NOT stop the outer template.
+        // The local function has its own scope; its return is independent.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Define a run-time local function with a return
+            object? LocalFunc( object? input )
+            {
+                if ( input == null )
+                {
+                    return "default";  // This return is in the local function, not the template
+                }
+
+                return input;
+            }
+
+            // Call the local function (its return value is used here)
+            var result = LocalFunc( meta.Proceed() );
+
+            // This code SHOULD be reached - the local function's return doesn't stop the template
+            return result;
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLocalFunction.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInLocalFunction.t.cs
@@ -1,0 +1,13 @@
+private object? Method()
+{
+  object? LocalFunc(object? input)
+  {
+    if (input == null)
+    {
+      return (global::System.Object?)"default";
+    }
+    return (global::System.Object?)input;
+  }
+  var result = LocalFunc(this.Method());
+  return (global::System.Object?)result;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIf.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInRunTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Run-time if with return - the if statement and return are both emitted
+        // to the output. Compile-time flow continues because the run-time condition
+        // might not be true at run-time.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            var p = meta.Target.Parameters[0];
+
+            // Run-time condition - the whole if is emitted to the output.
+            if ( p.Value == null )
+            {
+                return null;
+            }
+
+            // This code is always emitted because the run-time condition might be false.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return a;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIf.t.cs
@@ -1,0 +1,8 @@
+private object? Method(object? a)
+{
+  if (a == null)
+  {
+    return null;
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIfInCompileTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIfInCompileTimeIf.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInRunTimeIfInCompileTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Run-time if nested inside compile-time if:
+        // - Compile-time condition is evaluated. If true, the run-time if is emitted.
+        // - The compile-time flow should CONTINUE past the compile-time if because
+        //   even though compile-time took this branch, the inner run-time if might not execute.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            var p = meta.Target.Parameters[0];
+
+            // Compile-time condition that is always true.
+            if ( meta.Target.Method.Name.Length > 0 )
+            {
+                // Run-time condition - emitted because compile-time condition was true.
+                if ( p.Value == null )
+                {
+                    return null;
+                }
+            }
+
+            // This code SHOULD be emitted because the run-time if might not execute.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return a;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIfInCompileTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeIfInCompileTimeIf.t.cs
@@ -1,0 +1,8 @@
+private object? Method(object? a)
+{
+  if (a == null)
+  {
+    return null;
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeSwitch.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeSwitch.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInRunTimeSwitch
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Return inside a run-time switch should NOT terminate compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            switch ( meta.Target.Parameters[0].Value )
+            {
+                case null:
+                    return null;
+
+                default:
+                    break;
+            }
+
+            // This code SHOULD be reached at compile time because the switch is run-time.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInRunTimeSwitch.t.cs
@@ -1,0 +1,11 @@
+private object? Method(object? a)
+{
+  switch (a)
+  {
+    case null:
+      return null;
+    default:
+      break;
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeElse.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeElse.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInCompileTimeElse
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Throw in else block should also terminate compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always false, so else is executed.
+            if ( meta.Target.Method.Name.Length == 0 )
+            {
+                return meta.Proceed();
+            }
+            else
+            {
+                throw new InvalidOperationException( "Expected exception" );
+                // Compile-time flow should stop here.
+            }
+
+            // This code should NOT be reached at compile time.
+            ThrowIfReached();
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+            => throw new InvalidOperationException( "Compile-time flow should have stopped at throw." );
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeElse.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeElse.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  throw new global::System.InvalidOperationException("Expected exception");
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfFalse.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfFalse.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInCompileTimeIfFalse
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // When the compile-time condition is false, the throw is not executed
+        // and compile-time flow continues.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always false.
+            if ( meta.Target.Method.Name.Length == 0 )
+            {
+                throw new InvalidOperationException( "Should not be reached" );
+            }
+
+            // This code SHOULD be reached because the condition is false.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfFalse.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfFalse.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return this.Method();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfInRunTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfInRunTimeIf.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInCompileTimeIfInRunTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Throw inside a compile-time if that's inside a run-time if
+        // should NOT terminate compile-time flow because we're inside a run-time block.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Run-time condition.
+            if ( meta.Target.Parameters[0].Value == null )
+            {
+                // Compile-time condition that is always true.
+                if ( meta.Target.Method.Name.Length > 0 )
+                {
+                    throw new ArgumentNullException();
+                }
+
+                // This code should still be processed because we're in a run-time block.
+                ThrowIfReached();
+            }
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+        {
+            // This SHOULD be reached because we're inside a run-time if block.
+            // The compile-time if just controls which code is emitted.
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfInRunTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfInRunTimeIf.t.cs
@@ -1,0 +1,8 @@
+private object? Method(object? a)
+{
+  if (a == null)
+  {
+    throw new global::System.ArgumentNullException();
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfTrue.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfTrue.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInCompileTimeIfTrue
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // When the compile-time condition is true, the throw should stop
+        // the compile-time control flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always true.
+            if ( meta.Target.Method.Name.Length > 0 )
+            {
+                throw new InvalidOperationException( "Expected exception" );
+                // Compile-time flow should stop here.
+            }
+
+            // This code should NOT be reached at compile time when the condition is true.
+            ThrowIfReached();
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+            => throw new InvalidOperationException( "Compile-time flow should have stopped at throw." );
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfTrue.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeIfTrue.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  throw new global::System.InvalidOperationException("Expected exception");
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeSwitch.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeSwitch.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInCompileTimeSwitch
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Throw inside a compile-time switch case should terminate compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            switch ( meta.Target.Method.Parameters.Count )
+            {
+                case 0:
+                    throw new InvalidOperationException( "Expected exception" );
+                    // Compile-time flow should stop here.
+
+                default:
+                    break;
+            }
+
+            // This code should NOT be reached when parameter count is 0.
+            ThrowIfReached();
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static void ThrowIfReached()
+            => throw new InvalidOperationException( "Compile-time flow should have stopped at throw." );
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInCompileTimeSwitch.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  throw new global::System.InvalidOperationException("Expected exception");
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIf.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInRunTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Throw inside a run-time if should NOT terminate compile-time flow
+        // because the condition is evaluated at run time.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Run-time condition - the throw inside should be serialized but
+            // compile-time flow should continue.
+            if ( meta.Target.Parameters[0].Value == null )
+            {
+                throw new ArgumentNullException();
+            }
+
+            // This code SHOULD be reached at compile time because the if is run-time.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIf.t.cs
@@ -1,0 +1,8 @@
+private object? Method(object? a)
+{
+  if (a == null)
+  {
+    throw new global::System.ArgumentNullException();
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIfInCompileTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIfInCompileTimeIf.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInRunTimeIfInCompileTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Throw inside a run-time if that's inside a compile-time if.
+        // The compile-time if controls whether the run-time if is emitted,
+        // but the throw inside the run-time if should NOT terminate compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition that is always true.
+            if ( meta.Target.Method.Name.Length > 0 )
+            {
+                // Run-time condition.
+                if ( meta.Target.Parameters[0].Value == null )
+                {
+                    throw new ArgumentNullException();
+                }
+
+                // This SHOULD be reached because the throw is inside a run-time block.
+            }
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIfInCompileTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeIfInCompileTimeIf.t.cs
@@ -1,0 +1,8 @@
+private object? Method(object? a)
+{
+  if (a == null)
+  {
+    throw new global::System.ArgumentNullException();
+  }
+  return this.Method(a);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeSwitch.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeSwitch.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Throw.ThrowInRunTimeSwitch
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Throw inside a run-time switch should NOT terminate compile-time flow.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            switch ( meta.Target.Parameters[0].Value )
+            {
+                case null:
+                    throw new ArgumentNullException();
+
+                default:
+                    break;
+            }
+
+            // This code SHOULD be reached at compile time because the switch is run-time.
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( object? a )
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Throw/ThrowInRunTimeSwitch.t.cs
@@ -1,0 +1,11 @@
+private object? Method(object? a)
+{
+  switch (a)
+  {
+    case null:
+      throw new global::System.ArgumentNullException();
+    default:
+      break;
+  }
+  return this.Method(a);
+}


### PR DESCRIPTION
## Summary
- Fix compile-time control flow termination for 
eturn statements in T# templates (Bug #1125)
- Fix compile-time control flow termination for throw statements (same pattern)
- Fix meta.Return() to NOT terminate compile-time flow (only actual return statements should)
- Add proper handling for switch case statements (cases are not blocks)

## Changes
- Added VisitThrowStatement to handle throw flow termination
- Fixed meta.Return() handling - it emits a return but continues template execution
- Added isConditionalBlock parameter to ToMetaStatements for proper context tracking
- Updated VisitSwitchStatement to pass conditional block context
