### PR TITLE
Fix: Template compiler handles dynamic with target-typed expressions

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
@@ -1618,6 +1618,35 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
         return node.Update( transformedIdentifier, transformedArgumentList, transformedInitializer ).AddScopeAnnotation( localScope );
     }
 
+    /// <summary>
+    /// Determines if an expression is target-typed (i.e., requires type context to infer its type).
+    /// Target-typed expressions include: default, null, throw, stackalloc, etc.
+    /// This method skips parentheses to examine the underlying expression.
+    /// </summary>
+    private static bool IsTargetTypedExpression( ExpressionSyntax expression )
+    {
+        return expression switch
+        {
+            // Skip parentheses recursively
+            ParenthesizedExpressionSyntax parenthesized => IsTargetTypedExpression( parenthesized.Expression ),
+
+            // default literal
+            LiteralExpressionSyntax { RawKind: (int) SyntaxKind.DefaultLiteralExpression } => true,
+
+            // null literal
+            LiteralExpressionSyntax { RawKind: (int) SyntaxKind.NullLiteralExpression } => true,
+
+            // throw expression
+            ThrowExpressionSyntax => true,
+
+            // stackalloc (can be target-typed in some contexts)
+            StackAllocArrayCreationExpressionSyntax => true,
+            ImplicitStackAllocArrayCreationExpressionSyntax => true,
+
+            _ => false
+        };
+    }
+
     public override SyntaxNode VisitVariableDeclaration( VariableDeclarationSyntax node )
     {
         var transformedType = this.Visit( node.Type );
@@ -1635,7 +1664,15 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
                 }
                 else
                 {
-                    if ( !this._templateMemberClassifier.IsNodeOfDynamicType( variable.Initializer.Value ) )
+                    // Check if the initializer is a target-typed expression
+                    if ( IsTargetTypedExpression( variable.Initializer.Value ) )
+                    {
+                        this.ReportDiagnostic(
+                            TemplatingDiagnosticDescriptors.CannotUseDynamicWithTargetTypedExpression,
+                            variable.Identifier,
+                            variable.Identifier.Text );
+                    }
+                    else if ( !this._templateMemberClassifier.IsNodeOfDynamicType( variable.Initializer.Value ) )
                     {
                         this.ReportDiagnostic(
                             TemplatingDiagnosticDescriptors.DynamicVariableSetToNonDynamic,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
@@ -183,6 +183,15 @@ namespace Metalama.Framework.Engine.Templating
                     _category,
                     Error );
 
+        internal static readonly DiagnosticDefinition<string>
+            CannotUseDynamicWithTargetTypedExpression
+                = new(
+                    "LAMA0225",
+                    "Cannot initialize a dynamic-typed variable with a target-typed expression.",
+                    "The 'dynamic' keyword cannot be used in the local variable '{0}' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.",
+                    _category,
+                    Error );
+
         internal static readonly DiagnosticDefinition<(ISymbol Symbol, ISymbol RunTimeSymbol, ISymbol CompileTimeSymbol)> TemplatingScopeConflict
             = new(
                 "LAMA0226",

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicNullableDefault.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicNullableDefault.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Tests.Dynamic.DynamicNullableDefault;
+
+[CompileTime]
+internal class Aspect
+{
+    [TestTemplate]
+    private dynamic? Template()
+    {
+        // This should produce a compile-time error: cannot use dynamic? with default initializer
+        dynamic? x = default;
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+internal class TargetCode
+{
+    private int Method( int a )
+    {
+        return a;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicNullableDefault.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicNullableDefault.cs
@@ -5,6 +5,8 @@
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Engine.Templating;
 
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+
 namespace Metalama.Framework.Tests.TemplateTests.Tests.Dynamic.DynamicNullableDefault;
 
 [CompileTime]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicNullableDefault.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicNullableDefault.t.cs
@@ -1,0 +1,2 @@
+// TestTemplateCompiler.TryCompile failed.
+// Error LAMA0225 on `x`: `The 'dynamic' keyword cannot be used in the local variable 'x' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicWithTargetTypedExpressions.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicWithTargetTypedExpressions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.Tests.Dynamic.DynamicWithTargetTypedExpressions;
+
+[CompileTime]
+internal class Aspect
+{
+    [TestTemplate]
+    private dynamic? Template()
+    {
+        // All of these should produce compile-time errors
+        dynamic? x1 = default;              // default literal
+        dynamic? x2 = (default);            // parenthesized default
+        dynamic? x3 = ((default));          // double parenthesized default
+        dynamic? x4 = null;                 // null literal
+        dynamic? x5 = (null);               // parenthesized null
+        dynamic x6 = default;               // non-nullable dynamic with default
+        dynamic x7 = null;                  // non-nullable dynamic with null
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+internal class TargetCode
+{
+    private int Method( int a )
+    {
+        return a;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicWithTargetTypedExpressions.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicWithTargetTypedExpressions.cs
@@ -5,6 +5,10 @@
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Engine.Templating;
 
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type
+#pragma warning disable IDE0047 // Remove unnecessary parentheses
+
 namespace Metalama.Framework.Tests.TemplateTests.Tests.Dynamic.DynamicWithTargetTypedExpressions;
 
 [CompileTime]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicWithTargetTypedExpressions.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Dynamic/DynamicWithTargetTypedExpressions.t.cs
@@ -1,0 +1,8 @@
+// TestTemplateCompiler.TryCompile failed.
+// Error LAMA0225 on `x1`: `The 'dynamic' keyword cannot be used in the local variable 'x1' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`
+// Error LAMA0225 on `x2`: `The 'dynamic' keyword cannot be used in the local variable 'x2' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`
+// Error LAMA0225 on `x3`: `The 'dynamic' keyword cannot be used in the local variable 'x3' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`
+// Error LAMA0225 on `x4`: `The 'dynamic' keyword cannot be used in the local variable 'x4' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`
+// Error LAMA0225 on `x5`: `The 'dynamic' keyword cannot be used in the local variable 'x5' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`
+// Error LAMA0225 on `x6`: `The 'dynamic' keyword cannot be used in the local variable 'x6' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`
+// Error LAMA0225 on `x7`: `The 'dynamic' keyword cannot be used in the local variable 'x7' because it is initialized with a target-typed expression (such as 'default' or 'null'). Use an explicit cast or a different initializer.`


### PR DESCRIPTION
## Summary
- Add compile-time error (LAMA0225) when dynamic-typed variables are initialized with target-typed expressions (default, null)
- Previously, `dynamic? x = default` was incorrectly transformed to `var x = default` instead of producing an error
- Implement `IsTargetTypedExpression()` helper method to detect target-typed expressions, correctly handling parenthesized expressions

## Issues Fixed
- #798 - Template compiler: 'dynamic? x = default' is transformed to 'var x = default'

— Claude for @gfraiteur