### PR TITLE
Fix compile-time variables in switch case statements

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/MetaSyntaxRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/MetaSyntaxRewriter.cs
@@ -210,6 +210,10 @@ internal partial class MetaSyntaxRewriter : SafeSyntaxRewriter
     [UsedImplicitly]
     protected ExpressionSyntax Transform<T>( SyntaxList<T> list )
         where T : SyntaxNode
+        => this.TransformList( list );
+
+    private ExpressionSyntax TransformList<T>( SyntaxList<T> list )
+        where T : SyntaxNode
     {
         if ( list.Count == 0 )
         {
@@ -232,6 +236,9 @@ internal partial class MetaSyntaxRewriter : SafeSyntaxRewriter
                                     SyntaxKind.ArrayInitializerExpression,
                                     SeparatedList( list.SelectAsReadOnlyList( this.Transform ) ) ) ) ) ) ) );
     }
+
+    [UsedImplicitly]
+    protected virtual ExpressionSyntax Transform( SyntaxList<StatementSyntax> list ) => this.TransformList( list );
 
     protected virtual ExpressionSyntax Transform( SyntaxToken token )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -174,8 +174,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
     private void DeclareMetaVariable( string hint, SyntaxToken metaVariableIdentifier )
     {
-        var callGetUniqueIdentifier =
-            this._templateMetaSyntaxFactory.GetUniqueIdentifier( hint );
+        var callGetUniqueIdentifier = this._templateMetaSyntaxFactory.GetUniqueIdentifier( hint );
 
         var localDeclaration =
             LocalDeclarationStatement(
@@ -816,8 +815,10 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 }
 
                 // Try to find a serializer for this type. If the object type is simply 'object', we will resolve it at expansion time.
-                if ( expressionType.SpecialType == SpecialType.System_Object ||
-                     this._serializableTypes.IsSerializable( expressionType, this._syntaxTreeAnnotationMap.GetLocation( expression ), this ) )
+                if ( expressionType.SpecialType == SpecialType.System_Object || this._serializableTypes.IsSerializable(
+                        expressionType,
+                        this._syntaxTreeAnnotationMap.GetLocation( expression ),
+                        this ) )
                 {
                     return InvocationExpression(
                         this._templateMetaSyntaxFactory.GenericTemplateSyntaxFactoryMember(
@@ -906,8 +907,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     {
         var transformationKind = this.GetTransformationKind( node.Expression );
 
-        if ( transformationKind != TransformationKind.Transform &&
-             this._syntaxTreeAnnotationMap.GetExpressionType( node.Expression ) is IDynamicTypeSymbol )
+        if ( transformationKind != TransformationKind.Transform && this._syntaxTreeAnnotationMap.GetExpressionType( node.Expression ) is IDynamicTypeSymbol )
         {
             return InvocationExpression(
                 this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.ConditionalAccessExpression) ),
@@ -1433,8 +1433,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     {
         var transformedNode = base.VisitArgument( node ).AssertNotNull();
 
-        if ( this.GetTransformationKind( node ) == TransformationKind.None &&
-             this.GetTransformationKind( node.Expression ) == TransformationKind.Transform &&
+        if ( this.GetTransformationKind( node ) == TransformationKind.None && this.GetTransformationKind( node.Expression ) == TransformationKind.Transform &&
              node.TargetRequiresUserExpression() )
         {
             var transformedArgument = (ArgumentSyntax) transformedNode;
@@ -1905,7 +1904,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     private SyntaxNode BuildRunTimeBlock(
         SyntaxList<StatementSyntax> statements,
         bool generateExpression,
-        FunctionLikeRunTimeBlockInfo? localFunctionInfo = null )
+        FunctionLikeRunTimeBlockInfo? localFunctionInfo = null,
+        bool generateStatementList = false )
     {
         var blockId = ++this._nextStatementListId;
 
@@ -1986,20 +1986,27 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                 this._currentMetaContext.Statements.Add( returnStatementSyntax );
 
                 // Block( Func<SyntaxList<StatementSyntax>>( delegate { ... } )
-                return this.DeepIndent(
-                    this.MetaSyntaxFactory.Block(
-                        SyntaxFactoryEx.Default,
-                        InvocationExpression(
-                            ObjectCreationExpression( this.MetaSyntaxFactory.Type( typeof(Func<SyntaxList<StatementSyntax>>) ) )
-                                .NormalizeWhitespace()
-                                .WithArgumentList(
-                                    ArgumentList(
-                                        SingletonSeparatedList(
-                                            Argument(
-                                                AnonymousMethodExpression()
-                                                    .WithBody(
-                                                        Block( this._currentMetaContext.Statements )
-                                                            .AddNoDeepIndentAnnotation() ) ) ) ) ) ) ) );
+
+                var statementList = InvocationExpression(
+                    ObjectCreationExpression( this.MetaSyntaxFactory.Type( typeof(Func<SyntaxList<StatementSyntax>>) ) )
+                        .NormalizeWhitespace()
+                        .WithArgumentList(
+                            ArgumentList(
+                                SingletonSeparatedList(
+                                    Argument(
+                                        AnonymousMethodExpression()
+                                            .WithBody(
+                                                Block( this._currentMetaContext.Statements )
+                                                    .AddNoDeepIndentAnnotation() ) ) ) ) ) );
+
+                if ( generateStatementList )
+                {
+                    return this.DeepIndent( statementList );
+                }
+                else
+                {
+                    return this.DeepIndent( this.MetaSyntaxFactory.Block( SyntaxFactoryEx.Default, statementList ) );
+                }
             }
             else
             {
@@ -2162,17 +2169,16 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                         var trailingTrivia = TriviaList( eol, eol );
 
                         // TemplateSyntaxFactory.Add( __s, expression )
-                        StatementSyntax add =
-                            this.DeepIndent(
-                                ExpressionStatement(
-                                    InvocationExpression(
-                                        this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.AddStatement) ),
-                                        ArgumentList(
-                                            SeparatedList(
-                                            [
-                                                Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.StatementListVariableName ) ),
-                                                Argument( expressionSyntax )
-                                            ] ) ) ) ) );
+                        StatementSyntax add = this.DeepIndent(
+                            ExpressionStatement(
+                                InvocationExpression(
+                                    this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.AddStatement) ),
+                                    ArgumentList(
+                                        SeparatedList(
+                                        [
+                                            Argument( SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.StatementListVariableName ) ),
+                                            Argument( expressionSyntax )
+                                        ] ) ) ) ) );
 
                         add = add.WithLeadingTrivia( leadingTrivia ).WithTrailingTrivia( trailingTrivia );
 
@@ -2398,6 +2404,11 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         }
     }
 
+    protected override ExpressionSyntax Transform( SyntaxList<StatementSyntax> list )
+    {
+        return (ExpressionSyntax) this.BuildRunTimeBlock( list, true, generateStatementList: true );
+    }
+
     public override SyntaxNode VisitIfStatement( IfStatementSyntax node )
     {
         if ( this.GetTransformationKind( node ) == TransformationKind.Transform )
@@ -2436,11 +2447,10 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     public override SyntaxNode VisitConditionalExpression( ConditionalExpressionSyntax node )
     {
         // condition has to be preserved if one of the expressions is throw
-        var runTimeCondition =
-            this.GetTransformationKind( node.Condition ) == TransformationKind.Transform ||
-            node.Condition.GetScopeFromAnnotation().GetValueOrDefault().GetExpressionValueScope() == TemplatingScope.RunTimeOnly ||
-            node.WhenTrue is ThrowExpressionSyntax ||
-            node.WhenFalse is ThrowExpressionSyntax;
+        var runTimeCondition = this.GetTransformationKind( node.Condition ) == TransformationKind.Transform ||
+                               node.Condition.GetScopeFromAnnotation().GetValueOrDefault().GetExpressionValueScope() == TemplatingScope.RunTimeOnly ||
+                               node.WhenTrue is ThrowExpressionSyntax ||
+                               node.WhenFalse is ThrowExpressionSyntax;
 
         if ( runTimeCondition )
         {
@@ -2550,8 +2560,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         return expression.GetScopeFromAnnotation() == TemplatingScope.CompileTimeOnlyReturningRuntimeOnly
                && !this._templateMemberClassifier.IsTemplateParameter( expression )
                && this.GetTransformationKind( expression ) != TransformationKind.Transform
-               && (
-                   this._syntaxTreeAnnotationMap.GetExpressionType( expression ) is IDynamicTypeSymbol
+               && (this._syntaxTreeAnnotationMap.GetExpressionType( expression ) is IDynamicTypeSymbol
                    || this._syntaxTreeAnnotationMap.GetExpressionType( expression ) is INamedTypeSymbol
                    {
                        Name: "Task" or "ConfiguredTaskAwaitable" or "IEnumerable" or "IAsyncEnumerator", TypeArguments: [IDynamicTypeSymbol]
@@ -2864,8 +2873,9 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
     protected override ExpressionSyntax TransformYieldStatement( YieldStatementSyntax node )
     {
-        if ( node.Kind() == SyntaxKind.YieldReturnStatement && node.Expression is InvocationExpressionSyntax invocation &&
-             this._templateMemberClassifier.GetMetaMemberKind( invocation.Expression ) == MetaMemberKind.Proceed )
+        if ( node.Kind() == SyntaxKind.YieldReturnStatement && node.Expression is InvocationExpressionSyntax invocation
+                                                            && this._templateMemberClassifier.GetMetaMemberKind( invocation.Expression )
+                                                            == MetaMemberKind.Proceed )
         {
             // We have a 'yield return meta.Proceed()' statement.
 
@@ -2928,8 +2938,8 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
         {
             return this.TransformTypeOfExpression( node );
         }
-        else if ( this._syntaxTreeAnnotationMap.GetSymbol( node.Type ) is ITypeSymbol typeSymbol &&
-                  this._templateMemberClassifier.SymbolClassifier.GetTemplatingScope( typeSymbol ).GetExpressionValueScope() == TemplatingScope.RunTimeOnly )
+        else if ( this._syntaxTreeAnnotationMap.GetSymbol( node.Type ) is ITypeSymbol typeSymbol
+                  && this._templateMemberClassifier.SymbolClassifier.GetTemplatingScope( typeSymbol ).GetExpressionValueScope() == TemplatingScope.RunTimeOnly )
         {
             var typeOfString = this.MetaSyntaxFactory.SyntaxGenerationContext.SyntaxGenerator.TypeOfExpression( typeSymbol ).ToString();
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.AspectTests.Templating.LocalVariables.CompileTimeVariableInSwitch;
+
+[CompileTime]
+internal class Aspect
+{
+    [TestTemplate]
+    private dynamic? Template()
+    {
+        switch ( meta.Target.Parameters["x"].Value )
+        {
+            case 42:
+                var method = meta.Target.Method;
+                method.Invoke( 0 );
+
+                break;
+        }
+
+        return meta.Proceed();
+    }
+}
+
+internal class TargetCode
+{
+    private void Method( int x ) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.ct.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System;
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+namespace Metalama.Framework.Tests.AspectTests.Templating.LocalVariables.CompileTimeVariableInSwitch;
+[CompileTime]
+internal class Aspect
+{
+  private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+  {
+    List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+    bool __skip1 = false;
+    // switch (meta.Target.Parameters["x"].Value) { case 42: var method = meta.Target.Method; method.Invoke(0); break; }
+    templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.SwitchStatement(default(SyntaxList<AttributeListSyntax>), SyntaxFactory.Token(SyntaxKind.SwitchKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), templateSyntaxFactory.GetDynamicSyntax(meta.Target.Parameters["x"].Value), SyntaxFactory.Token(SyntaxKind.CloseParenToken), SyntaxFactory.Token(SyntaxKind.OpenBraceToken), default(SyntaxList<SwitchSectionSyntax>).AddRange(new SwitchSectionSyntax[] { SyntaxFactory.SwitchSection(default(SyntaxList<SwitchLabelSyntax>).AddRange(new SwitchLabelSyntax[] { SyntaxFactory.CaseSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal("42", 42)), SyntaxFactory.Token(SyntaxKind.ColonToken)) }), new Func<SyntaxList<StatementSyntax>>(delegate
+    {
+      List<StatementOrTrivia> __s2 = new List<StatementOrTrivia>();
+      bool __skip2 = false;
+      var method = meta.Target.Method;
+      // method.Invoke(0);
+      templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.ToStatement(templateSyntaxFactory.GetDynamicSyntax(method.Invoke(templateSyntaxFactory.RunTimeExpression(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal("0", 0)), "Y:global::System.Int32!")))));
+      // break;
+      templateSyntaxFactory.AddStatement(__s2, SyntaxFactory.BreakStatement(default(SyntaxList<AttributeListSyntax>), SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+      return templateSyntaxFactory.ToStatementList(__s2);
+    })()) }), SyntaxFactory.Token(SyntaxKind.CloseBraceToken)));
+    // return meta.Proceed();
+    templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+    return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+  }
+}
+internal class TargetCode
+{
+  private void Method(int x)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.ct.cs
@@ -17,13 +17,13 @@ internal class Aspect
   {
     List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
     bool __skip1 = false;
-    // switch (meta.Target.Parameters["x"].Value) { case 42: var method = meta.Target.Method; method.Invoke(0); break; }
+    // switch ( meta.Target.Parameters["x"].Value ) { case 42: var method = meta.Target.Method; method.Invoke( 0 ); break; }
     templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.SwitchStatement(default(SyntaxList<AttributeListSyntax>), SyntaxFactory.Token(SyntaxKind.SwitchKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), templateSyntaxFactory.GetDynamicSyntax(meta.Target.Parameters["x"].Value), SyntaxFactory.Token(SyntaxKind.CloseParenToken), SyntaxFactory.Token(SyntaxKind.OpenBraceToken), default(SyntaxList<SwitchSectionSyntax>).AddRange(new SwitchSectionSyntax[] { SyntaxFactory.SwitchSection(default(SyntaxList<SwitchLabelSyntax>).AddRange(new SwitchLabelSyntax[] { SyntaxFactory.CaseSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal("42", 42)), SyntaxFactory.Token(SyntaxKind.ColonToken)) }), new Func<SyntaxList<StatementSyntax>>(delegate
     {
       List<StatementOrTrivia> __s2 = new List<StatementOrTrivia>();
       bool __skip2 = false;
       var method = meta.Target.Method;
-      // method.Invoke(0);
+      // method.Invoke( 0 );
       templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.ToStatement(templateSyntaxFactory.GetDynamicSyntax(method.Invoke(templateSyntaxFactory.RunTimeExpression(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal("0", 0)), "Y:global::System.Int32!")))));
       // break;
       templateSyntaxFactory.AddStatement(__s2, SyntaxFactory.BreakStatement(default(SyntaxList<AttributeListSyntax>), SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken)));

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.t.cs
@@ -1,0 +1,12 @@
+private void Method(int x)
+{
+    switch (x)
+    {
+        case 42:
+            this.Method(0);
+            break;
+    }
+
+    this.Method(x);
+    return;
+}


### PR DESCRIPTION
Fixes #767

## Summary
- Fixed template compiler not properly handling compile-time variable declarations within switch case blocks
- Added Transform override for SyntaxList&lt;StatementSyntax&gt; in TemplateCompilerRewriter to wrap case statement lists in run-time blocks
- Added test case to verify the fix

## Test Plan
- Added CompileTimeVariableInSwitch test case that reproduces the issue
- Test verifies that compile-time variables declared in switch case statements are properly scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)