### PR TITLE
Fix compile-time variable scoping after early return in compile-time conditional (#1275)

### DIFF
--- a/DockerBuild.ps1
+++ b/DockerBuild.ps1
@@ -136,6 +136,10 @@ function New-ClaudeEnvJson
     {
         $claudeEnv["ANTHROPIC_API_KEY"] = $env:ANTHROPIC_API_KEY
     }
+    if ($env:CLAUDE_CODE_OAUTH_TOKEN)
+    {
+        $claudeEnv["CLAUDE_CODE_OAUTH_TOKEN"] = $env:CLAUDE_CODE_OAUTH_TOKEN
+    }
     if ($env:IS_POSTSHARP_OWNED)
     {
         $claudeEnv["IS_POSTSHARP_OWNED"] = $env:IS_POSTSHARP_OWNED
@@ -264,14 +268,44 @@ function Copy-McpServerToTemp
     # Create temporary directory using hash of source directory
     # This ensures the same repo always uses the same temp path (avoiding firewall prompts)
     # but different repos won't conflict
+    # IMPORTANT: We cannot use a unique directory per invocation (e.g., with timestamp/GUID)
+    # because Windows Firewall authorization is tied to the executable path. Using a different
+    # path each time would trigger firewall prompts on every run.
     $hashBytes = (New-Object -TypeName System.Security.Cryptography.SHA256Managed).ComputeHash([System.Text.Encoding]::UTF8.GetBytes($SourceRootDir))
     $directoryHash = [System.BitConverter]::ToString($hashBytes, 0, 4).Replace("-", "").ToLower()
     $tempDir = Join-Path $env:TEMP "mcp-server-$directoryHash"
 
     # Clean up old temp directory if it exists
+    # Use retry logic because files may be locked by a previous MCP server process
     if (Test-Path $tempDir)
     {
-        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        $maxRetries = 3
+        $retryCount = 0
+        $cleaned = $false
+
+        while (-not $cleaned -and $retryCount -lt $maxRetries)
+        {
+            try
+            {
+                Remove-Item $tempDir -Recurse -Force -ErrorAction Stop
+                $cleaned = $true
+                Write-Host "Successfully cleaned up old MCP server directory" -ForegroundColor Cyan
+            }
+            catch
+            {
+                $retryCount++
+                if ($retryCount -lt $maxRetries)
+                {
+                    Write-Host "Failed to clean up temp directory (attempt $retryCount/$maxRetries). Retrying in 1 second..." -ForegroundColor Yellow
+                    Start-Sleep -Seconds 1
+                }
+                else
+                {
+                    Write-Error "Failed to clean up temp directory after $maxRetries attempts: $_`nPlease close any processes using files in: $tempDir"
+                    throw
+                }
+            }
+        }
     }
 
     New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
@@ -840,39 +874,9 @@ if (-not $BuildImage)
         # Run Claude mode
         Write-Host "Running Claude in the container." -ForegroundColor Green
 
-        # Add Claude-specific volume mounts for auth and settings
+        # Container will have its own Claude profile (no mount, no copy from host)
         $hostUserProfile = $env:USERPROFILE
         $containerUserProfile = "C:\Users\ContainerUser"
-
-        # Mount .claude directory (settings and credentials)
-        if (Test-Path "$hostUserProfile\.claude")
-        {
-            $VolumeMappings += "${hostUserProfile}\.claude:${containerUserProfile}\.claude"
-        }
-
-        # Copy .claude.json to docker-context (cannot mount files on Windows Docker)
-        # Also fix installMethod to match container's npm installation
-        $claudeJsonSource = "$hostUserProfile\.claude.json"
-        $claudeJsonDest = Join-Path $dockerContextDirectory "claude.json"
-        $copyClaudeJsonScript = ""
-        if (Test-Path $claudeJsonSource)
-        {
-            $claudeConfig = Get-Content $claudeJsonSource -Raw | ConvertFrom-Json
-            # Change installMethod to npm since that's how Claude is installed in container
-            if ($claudeConfig.installMethod)
-            {
-                $claudeConfig.installMethod = "npm"
-            }
-            $claudeConfig | ConvertTo-Json -Depth 10 | Set-Content $claudeJsonDest -Encoding UTF8
-            # Will copy from mounted source dir to user profile in container
-            $copyClaudeJsonScript = "Copy-Item '$ContainerSourceDir\eng\docker-context\claude.json' '$containerUserProfile\.claude.json' -Force; "
-        }
-
-        # Mount .cache\claude (cache)
-        if (Test-Path "$hostUserProfile\.cache\claude")
-        {
-            $VolumeMappings += "${hostUserProfile}\.cache\claude:${containerUserProfile}\.cache\claude"
-        }
 
         # Convert volume mappings to docker args format (interleave "-v" flags)
         $volumeArgs = @()
@@ -880,6 +884,17 @@ if (-not $BuildImage)
         {
             $volumeArgs += @("-v", $mapping)
         }
+
+        # Mount Claude sessions directory to preserve history (but not plugins)
+        $hostClaudeSessions = Join-Path $hostUserProfile ".claude\.sessions"
+        $containerClaudeSessions = Join-Path $containerUserProfile ".claude\.sessions"
+        if (-not (Test-Path $hostClaudeSessions))
+        {
+            New-Item -ItemType Directory -Path $hostClaudeSessions -Force | Out-Null
+        }
+        $volumeArgs += @("-v", "${hostClaudeSessions}:${containerClaudeSessions}")
+        Write-Host "Mounting Claude sessions directory: $hostClaudeSessions" -ForegroundColor Cyan
+
         $VolumeMappingsAsString = ($VolumeMappings | ForEach-Object { "-v $_" }) -join " "
 
         # Extract Claude prompt from remaining arguments if present
@@ -903,7 +918,7 @@ if (-not $BuildImage)
             {
                 ""
             }
-            $inlineScript = "${substCommandsInline}& c:\Init.g.ps1; ${copyClaudeJsonScript}cd '$SourceDirName'; & .\eng\RunClaude.ps1 -Prompt `"$ClaudePrompt`"$mcpArg"
+            $inlineScript = "${substCommandsInline}& c:\Init.g.ps1; cd '$SourceDirName'; & .\eng\RunClaude.ps1 -Prompt `"$ClaudePrompt`"$mcpArg"
         }
         else
         {
@@ -917,7 +932,7 @@ if (-not $BuildImage)
             {
                 ""
             }
-            $inlineScript = "${substCommandsInline}& c:\Init.g.ps1; ${copyClaudeJsonScript}cd '$SourceDirName'; & .\eng\RunClaude.ps1$mcpArg"
+            $inlineScript = "${substCommandsInline}& c:\Init.g.ps1; cd '$SourceDirName'; & .\eng\RunClaude.ps1$mcpArg"
         }
 
         $dockerArgsAsString = $dockerArgs -join " "

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,10 @@ ENV PATH="C:\Program Files\dotnet;${PATH}"
 RUN & .\dotnet-install.ps1 -Version 8.0.414 -InstallDir 'C:\Program Files\dotnet'
 
 
+# Install .NET DotNetRuntime 9.0.9
+RUN & .\dotnet-install.ps1 -Version 9.0.9 -Runtime dotnet -InstallDir 'C:\Program Files\dotnet'
+
+
 # Install .NET Sdk 10.0.100
 RUN & .\dotnet-install.ps1 -Version 10.0.100 -InstallDir 'C:\Program Files\dotnet'
 

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -65,6 +65,10 @@ ENV PATH="C:\Program Files\dotnet;${PATH}"
 RUN & .\dotnet-install.ps1 -Version 8.0.414 -InstallDir 'C:\Program Files\dotnet'
 
 
+# Install .NET DotNetRuntime 9.0.9
+RUN & .\dotnet-install.ps1 -Version 9.0.9 -Runtime dotnet -InstallDir 'C:\Program Files\dotnet'
+
+
 # Install .NET Sdk 10.0.100
 RUN & .\dotnet-install.ps1 -Version 10.0.100 -InstallDir 'C:\Program Files\dotnet'
 
@@ -111,17 +115,14 @@ ENV PATH="C:\Program Files\GitHub CLI;${PATH}"
 ENV NPM_CONFIG_PREFIX=C:\\npm
 ENV PATH="C:\\npm;${PATH}"
 
-# Install Claude CLI using cmd shell to avoid HCS issues with PowerShell
-SHELL ["cmd", "/S", "/C"]
-RUN C:\\nodejs\\npm.cmd install --global @anthropic-ai/claude-code
-
 # Set HOME/USERPROFILE so Claude CLI finds credentials during build
 ENV HOME=C:\\Users\\ContainerUser
 ENV USERPROFILE=C:\\Users\\ContainerUser
 ENV CLAUDE_CODE_SHELL=pwsh
 
-# Create Claude config directory (credentials are mounted at runtime)
-RUN mkdir C:\Users\ContainerUser\.claude
+# Install Claude CLI and configure plugins using cmd shell to avoid HCS issues with PowerShell
+SHELL ["cmd", "/S", "/C"]
+RUN C:\nodejs\npm.cmd install --global @anthropic-ai/claude-code && mkdir C:\Users\ContainerUser\.claude && echo {"hasCompletedOnboarding": true} > C:\Users\ContainerUser\.claude.json && C:\npm\claude plugin marketplace add https://github.com/metalama/Metalama.AI.Skills && C:\npm\claude plugin marketplace add https://github.com/postsharp/PostSharp.Engineering.AISkills && C:\npm\claude plugin install metalama && C:\npm\claude plugin install metalama-dev && C:\npm\claude plugin install eng
 
 # Restore PowerShell shell using full path
 SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command"]

--- a/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/Metalama.Framework.CompileTimeContracts.csproj
+++ b/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/Metalama.Framework.CompileTimeContracts.csproj
@@ -10,7 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(RoslynApiMinVersion)" />
-      <ProjectReference Include="../Metalama.Framework/Metalama.Framework.csproj" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+        <ProjectReference Include="../Metalama.Framework/Metalama.Framework.csproj" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="Metalama.Framework.Engine.4.8.0" />

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/StatementCompileTimeVariableFinder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/StatementCompileTimeVariableFinder.cs
@@ -1,0 +1,184 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.Utilities.Roslyn;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Metalama.Framework.Engine.Templating
+{
+    /// <summary>
+    /// Finds compile-time local variables assigned in a single statement (non-recursively).
+    /// This includes declarations, assignments, out parameters, tuple assignments, etc.
+    /// Used to determine which variables need Unsafe.SkipInit after goto labels.
+    /// </summary>
+    internal sealed class StatementCompileTimeVariableFinder : CSharpSyntaxWalker
+    {
+        private readonly SyntaxTreeAnnotationMap _syntaxTreeAnnotationMap;
+        private readonly StatementSyntax _statement;
+        
+        public StatementCompileTimeVariableFinder( SyntaxTreeAnnotationMap syntaxTreeAnnotationMap, StatementSyntax statement )
+        {
+            this._syntaxTreeAnnotationMap = syntaxTreeAnnotationMap;
+            this._statement = statement;
+        }
+
+        public void Visit() => this.Visit( this._statement );
+
+        public HashSet<ILocalSymbol> AssignedVariables { get; } = new( SymbolEqualityComparer.Default );
+
+        public override void VisitLocalDeclarationStatement( LocalDeclarationStatementSyntax node )
+        {
+            // Check the scope annotation on the variable declaration itself
+            var scope = node.GetScopeFromAnnotation();
+
+            // Only collect compile-time-only variables that are visible after the statement
+            if ( scope == TemplatingScope.CompileTimeOnly )
+            {
+                foreach ( var declarator in node.Declaration.Variables )
+                {
+                    this.TryAddDeclaredSymbol( declarator );
+                }
+            }
+
+            base.VisitLocalDeclarationStatement( node );
+        }
+
+        public override void VisitAssignmentExpression( AssignmentExpressionSyntax node )
+        {
+            // Handle regular assignments (=, +=, -=, etc.) to local variables
+            if ( node.Left is IdentifierNameSyntax identifier )
+            {
+                this.TryAddReferencedSymbol( identifier );
+            }
+            else if ( node.Left is TupleExpressionSyntax tupleExpression )
+            {
+                // Handle tuple assignments: (x, y) = tuple;
+                this.VisitTupleElements( tupleExpression );
+            }
+
+            base.VisitAssignmentExpression( node );
+        }
+
+        private void VisitTupleElements( TupleExpressionSyntax tupleExpression )
+        {
+            foreach ( var argument in tupleExpression.Arguments )
+            {
+                if ( argument.Expression is IdentifierNameSyntax identifier )
+                {
+                    this.TryAddReferencedSymbol( identifier );
+                }
+                else if ( argument.Expression is TupleExpressionSyntax nestedTuple )
+                {
+                    // Handle nested tuples
+                    this.VisitTupleElements( nestedTuple );
+                }
+            }
+        }
+
+        public override void VisitSingleVariableDesignation( SingleVariableDesignationSyntax node )
+        {
+            // This handles 'out var' declarations and pattern matching
+            if ( node.Parent is DeclarationExpressionSyntax declarationExpression )
+            {
+                var scope = declarationExpression.GetScopeFromAnnotation();
+
+                if ( scope == TemplatingScope.CompileTimeOnly )
+                {
+                    this.TryAddDeclaredSymbol( node );
+                }
+            }
+            else if ( node.Parent is DeclarationPatternSyntax declarationPattern )
+            {
+                var scope = declarationPattern.GetScopeFromAnnotation();
+
+                if ( scope == TemplatingScope.CompileTimeOnly )
+                {
+                    this.TryAddDeclaredSymbol( node );
+                }
+            }
+
+            base.VisitSingleVariableDesignation( node );
+        }
+
+        private bool IsVisibleAfterStatement( ILocalSymbol localSymbol )
+        {
+            var declaringSyntax = localSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+
+            if ( declaringSyntax == null )
+            {
+                return false;
+            }
+
+            // `declaringSyntax` is defined in the non-annotated syntax tree. We must find the same node in the annotated syntax tree.
+            // Find the ancestor declaration (method, property, etc.) as the root for the search.
+            var sourceRoot = declaringSyntax.FindMemberDeclaration();
+            var targetRoot = this._statement.FindMemberDeclaration();
+
+            if ( !Utilities.Roslyn.SyntaxExtensions.TryFindNodeByPosition( declaringSyntax, sourceRoot, targetRoot, out var annotatedDeclaringSyntax )
+                 || annotatedDeclaringSyntax == null )
+            {
+                return false;
+            }
+
+            // If the variable is declared in this statement at the top level, it's visible after
+            if ( this._statement.Contains( annotatedDeclaringSyntax ) )
+            {
+                // Make sure it's not declared inside a nested block within the statement
+                for ( var currentNode = annotatedDeclaringSyntax.Parent; currentNode != null && currentNode != this._statement; currentNode = currentNode.Parent )
+                {
+                    // If we encounter a block before reaching the statement, the variable is nested
+                    if ( currentNode is BlockSyntax )
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            // If the variable is declared in an outer scope (before this statement), it's visible after
+            for ( var statementParent = this._statement.Parent; statementParent != null; statementParent = statementParent.Parent )
+            {
+                if ( statementParent.Contains( annotatedDeclaringSyntax ) )
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void TryAddDeclaredSymbol( SyntaxNode node )
+        {
+            var symbol = this._syntaxTreeAnnotationMap.GetDeclaredSymbol( node );
+
+            this.TryAddReferencedSymbol( symbol );
+        }
+
+        private void TryAddReferencedSymbol( SyntaxNode node )
+        {
+            var scope = node.GetScopeFromAnnotation();
+
+            if ( scope == TemplatingScope.CompileTimeOnly )
+            {
+                var symbol = this._syntaxTreeAnnotationMap.GetSymbol( node );
+
+                this.TryAddReferencedSymbol( symbol );
+            }
+        }
+
+        private void TryAddReferencedSymbol( ISymbol? symbol )
+        {
+            if ( symbol is ILocalSymbol localSymbol && this.IsVisibleAfterStatement( localSymbol ) )
+            {
+                this.AssignedVariables.Add( localSymbol );
+            }
+        }
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/StatementCompileTimeVariableFinder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/StatementCompileTimeVariableFinder.cs
@@ -84,23 +84,55 @@ namespace Metalama.Framework.Engine.Templating
         public override void VisitSingleVariableDesignation( SingleVariableDesignationSyntax node )
         {
             // This handles 'out var' declarations and pattern matching
-            if ( node.Parent is DeclarationExpressionSyntax declarationExpression )
+            switch ( node.Parent )
             {
-                var scope = declarationExpression.GetScopeFromAnnotation();
+                case DeclarationExpressionSyntax declarationExpression:
+                    {
+                        var scope = declarationExpression.GetScopeFromAnnotation();
 
-                if ( scope == TemplatingScope.CompileTimeOnly )
-                {
-                    this.TryAddDeclaredSymbol( node );
-                }
-            }
-            else if ( node.Parent is DeclarationPatternSyntax declarationPattern )
-            {
-                var scope = declarationPattern.GetScopeFromAnnotation();
+                        if ( scope == TemplatingScope.CompileTimeOnly )
+                        {
+                            this.TryAddDeclaredSymbol( node );
+                        }
 
-                if ( scope == TemplatingScope.CompileTimeOnly )
-                {
-                    this.TryAddDeclaredSymbol( node );
-                }
+                        break;
+                    }
+
+                case ParenthesizedVariableDesignationSyntax parenthesizedDesignation:
+                    {
+                        // Handle tuple deconstruction: var (x, y) = tuple; or nested: var (a, (b, c)) = tuple;
+                        // Walk up the parent chain through ParenthesizedVariableDesignation nodes to find the DeclarationExpression
+                        var current = parenthesizedDesignation.Parent;
+
+                        while ( current is ParenthesizedVariableDesignationSyntax nestedParenthesized )
+                        {
+                            current = nestedParenthesized.Parent;
+                        }
+
+                        if ( current is DeclarationExpressionSyntax tupleDeclaration )
+                        {
+                            var scope = tupleDeclaration.GetScopeFromAnnotation();
+
+                            if ( scope == TemplatingScope.CompileTimeOnly )
+                            {
+                                this.TryAddDeclaredSymbol( node );
+                            }
+                        }
+
+                        break;
+                    }
+
+                case DeclarationPatternSyntax declarationPattern:
+                    {
+                        var scope = declarationPattern.GetScopeFromAnnotation();
+
+                        if ( scope == TemplatingScope.CompileTimeOnly )
+                        {
+                            this.TryAddDeclaredSymbol( node );
+                        }
+
+                        break;
+                    }
             }
 
             base.VisitSingleVariableDesignation( node );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
@@ -1964,16 +1964,58 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
                 // The rest of the analysis should be ok anyway.
             }
 
-            // The scope of a classical assignment is determined by the left side.
-            var transformedLeft = this.Visit( node.Left );
+            // Check if the left side is a tuple with var declarations
+            if ( node.Left is TupleExpressionSyntax tupleLeft )
+            {
+                var varStatus = CheckTupleVarDeclarations( tupleLeft );
 
-            var leftScope = this.GetAssignmentScope( transformedLeft );
-            ExpressionSyntax? transformedRight;
+                if ( varStatus == TupleVarStatus.AllVar )
+                {
+                    // All elements are var declarations, so the scope is determined by the right side
+                    // (similar to local variable declaration with assignment)
+                    var declarationTransformedRight = this.Visit( node.Right );
+                    var declarationRightScope = this.GetNodeScope( declarationTransformedRight ).GetExpressionValueScope( true ).ReplaceIndeterminate( RunTimeOnly );
+
+                    ExpressionSyntax declarationTransformedLeft;
+                    ScopeContext? declarationLeftNodeContext = null;
+
+                    if ( declarationRightScope == CompileTimeOnly )
+                    {
+                        // The right side is compile-time, so the variables should be compile-time
+                        declarationLeftNodeContext = this._currentScopeContext.CompileTimeOnly( "a tuple deconstruction from a compile-time expression" );
+                    }
+
+                    using ( this.WithScopeContext( declarationLeftNodeContext ) )
+                    {
+                        declarationTransformedLeft = this.Visit( node.Left );
+                    }
+
+                    // The assignment scope is determined by the right side when all are var declarations
+                    return node.Update( declarationTransformedLeft, node.OperatorToken, declarationTransformedRight ).AddScopeAnnotation( declarationRightScope );
+                }
+                else if ( varStatus == TupleVarStatus.Mixed )
+                {
+                    // Mixed var and non-var declarations are not supported
+                    this.ReportUnsupportedLanguageFeature( node.Left, "tuple deconstruction with a mix of var and non-var declarations" );
+
+                    // Fall through to default handling
+                }
+                else
+                {
+                    // For TupleVarStatus.None (no var declarations), fall through to classical assignment handling
+                }
+            }
+
+            // The scope of a classical assignment is determined by the left side.
+            var classicalTransformedLeft = this.Visit( node.Left );
+
+            var classicalLeftNodeScope = this.GetAssignmentScope( classicalTransformedLeft );
+            ExpressionSyntax? classicalTransformedRight;
 
             // If we are in a run-time-conditional block, we cannot assign compile-time variables.
-            ScopeContext? context = null;
+            ScopeContext? classicalRightNodeContext = null;
 
-            if ( leftScope.GetExpressionExecutionScope() == CompileTimeOnly )
+            if ( classicalLeftNodeScope.GetExpressionExecutionScope() == CompileTimeOnly )
             {
                 this.CheckForMutatingCompileTimeExpressionInRunTimeConditionalBlock( node.Left );
 
@@ -1985,24 +2027,96 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
                 else
                 {
                     // The right part must be compile-time.
-                    context = this._currentScopeContext.CompileTimeOnly( "the assignment of a compile-time expression" );
+                    classicalRightNodeContext = this._currentScopeContext.CompileTimeOnly( "the assignment of a compile-time expression" );
                 }
             }
 
-            using ( this.WithScopeContext( context ) )
+            using ( this.WithScopeContext( classicalRightNodeContext ) )
             {
-                transformedRight = this.Visit( node.Right );
+                classicalTransformedRight = this.Visit( node.Right );
             }
 
             // If we have a discard assignment, take the scope from the right.
-            if ( leftScope == RunTimeOrCompileTime
+            if ( classicalLeftNodeScope == RunTimeOrCompileTime
                  && this._syntaxTreeAnnotationMap.GetSymbol( node.Left ) is IDiscardSymbol )
             {
-                leftScope = this.GetNodeScope( transformedRight ).GetExpressionExecutionScope();
+                classicalLeftNodeScope = this.GetNodeScope( classicalTransformedRight ).GetExpressionExecutionScope();
             }
 
-            return node.Update( transformedLeft, node.OperatorToken, transformedRight ).AddScopeAnnotation( leftScope );
+            return node.Update( classicalTransformedLeft, node.OperatorToken, classicalTransformedRight ).AddScopeAnnotation( classicalLeftNodeScope );
         }
+    }
+
+    private enum TupleVarStatus
+    {
+        /// <summary>
+        /// No var declarations in the tuple.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// All elements are var declarations (possibly nested).
+        /// </summary>
+        AllVar,
+
+        /// <summary>
+        /// Mix of var and non-var declarations.
+        /// </summary>
+        Mixed
+    }
+
+    /// <summary>
+    /// Checks if a tuple expression contains var declarations and returns the status.
+    /// </summary>
+    private static TupleVarStatus CheckTupleVarDeclarations( TupleExpressionSyntax tuple )
+    {
+        var hasVar = false;
+        var hasNonVar = false;
+
+        foreach ( var argument in tuple.Arguments )
+        {
+            switch ( argument.Expression )
+            {
+                case DeclarationExpressionSyntax:
+                    hasVar = true;
+                    break;
+
+                case TupleExpressionSyntax nestedTuple:
+                    var nestedStatus = CheckTupleVarDeclarations( nestedTuple );
+
+                    if ( nestedStatus == TupleVarStatus.AllVar )
+                    {
+                        hasVar = true;
+                    }
+                    else if ( nestedStatus == TupleVarStatus.None )
+                    {
+                        hasNonVar = true;
+                    }
+                    else
+                    {
+                        // Nested tuple is mixed
+                        return TupleVarStatus.Mixed;
+                    }
+
+                    break;
+
+                default:
+                    hasNonVar = true;
+                    break;
+            }
+
+            if ( hasVar && hasNonVar )
+            {
+                return TupleVarStatus.Mixed;
+            }
+        }
+
+        if ( hasVar )
+        {
+            return TupleVarStatus.AllVar;
+        }
+
+        return TupleVarStatus.None;
     }
 
     private void CheckForMutatingCompileTimeExpressionInRunTimeConditionalBlock( ExpressionSyntax expression )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.BuildTimeOnlyRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.BuildTimeOnlyRewriter.cs
@@ -152,13 +152,16 @@ namespace Metalama.Framework.Engine.Templating
                             case SymbolKind.Event:
                             case SymbolKind.Method:
                                 // We have an access to a field or method with a "using static", or a non-qualified static member access.
+                                // Move leading trivia from the identifier to the type qualifier to avoid splitting comments
                                 return
                                     node.CopyAnnotationsTo(
-                                        MemberAccessExpression(
+                                            MemberAccessExpression(
                                                 SyntaxKind.SimpleMemberAccessExpression,
                                                 this._syntaxGenerator.TypeOrNamespace( symbol.ContainingType ),
-                                                SyntaxFactoryEx.WellKnownIdentifierName( node.Identifier ) )
-                                            .WithTriviaFrom( node ) );
+                                                SyntaxFactoryEx.WellKnownIdentifierName( node.Identifier )
+                                                    .WithoutLeadingTrivia()
+                                                    .WithTrailingTrivia( node.GetTrailingTrivia() ) ) )
+                                        .WithLeadingTrivia( node.GetLeadingTrivia() );
                         }
                     }
                 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -59,13 +60,15 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     private readonly TypeSyntax _dictionaryOfITypeType;
     private readonly TypeSyntax _dictionaryOfTypeSyntaxType;
     private readonly ITypeSymbol _iExpressionSymbol;
+    private readonly TypeSyntax _unsafeType;
 
     private TemplateMetaSyntaxFactoryImpl _templateMetaSyntaxFactory;
     private MetaContext? _currentMetaContext;
     private int _nextStatementListId;
     private int _nextLocalFunctionFactoryId;
+    private int _nextLabelId = 1;
     private ISymbol? _rootTemplateSymbol;
-
+    
     /// <summary>
     /// Set to true by <see cref="VisitReturnStatement"/> or <see cref="VisitThrowStatement"/> when the statement should terminate compile-time flow.
     /// Callers should check this flag and generate a skip flag assignment if needed.
@@ -115,6 +118,10 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
             syntaxGenerationContext.SyntaxGenerator.TypeSyntax( this.MetaSyntaxFactory.ReflectionMapper.GetTypeSymbol( typeof(Dictionary<string, IType>) ) );
 
         this._iExpressionSymbol = this._runTimeCompilation.GetTypeByMetadataName( typeof(IExpression).FullName! ).AssertSymbolNotNull();
+        
+        this._unsafeType =
+            syntaxGenerationContext.SyntaxGenerator.TypeSyntax(
+                this.MetaSyntaxFactory.ReflectionMapper.GetTypeSymbol( typeof(Unsafe) ) );
     }
 
     public bool Success { get; private set; } = true;
@@ -770,7 +777,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                      expressionType.ContainingNamespace.ToDisplayString() == "System.Collections.Generic":
 
                 return InvocationExpression( this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.GetDynamicSyntax) ) )
-                    .AddArgumentListArguments( Argument( expression ) );
+                    .AddArgumentListArguments( Argument( expression.WithoutTrivia() ) );
 
             case "String":
                 return CreateRunTimeExpressionForLiteralCreateExpressionFactory( SyntaxKind.StringLiteralExpression );
@@ -2141,16 +2148,18 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
                 case StatementSyntax statementSyntax:
                     // The statement is already build-time code so there is nothing to transform.
-                    var stmtWithTrivia = statementSyntax.WithLeadingTrivia( this.GetIndentation() );
+                    var statementWithTrivia = statementSyntax.WithLeadingTrivia( this.GetIndentation() );
 
                     // If the skip flag was set and this is not a local function, wrap it in a condition.
                     // Local functions must always be defined so they can be referenced.
                     if ( skipFlagWasSetBeforeVisit && !isLocalFunction )
                     {
-                        stmtWithTrivia = this.WrapInSkipCompileTimeLogicCheck( stmtWithTrivia );
+                        newContext.Statements.AddRange( this.WrapInSkipCompileTimeLogicCheck( statementWithTrivia, singleStatement ) );
                     }
-
-                    newContext.Statements.Add( stmtWithTrivia );
+                    else
+                    {
+                        newContext.Statements.Add( statementWithTrivia );
+                    }
 
                     break;
 
@@ -2186,10 +2195,12 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
                         // Local functions must always be defined so they can be referenced.
                         if ( skipFlagWasSetBeforeVisit && !isLocalFunction )
                         {
-                            add = this.WrapInSkipCompileTimeLogicCheck( add );
+                            newContext.Statements.AddRange( this.WrapInSkipCompileTimeLogicCheck( add, singleStatement ) );
                         }
-
-                        newContext.Statements.Add( add );
+                        else
+                        {
+                            newContext.Statements.Add( add );
+                        }
 
                         break;
                     }
@@ -2245,17 +2256,48 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
 
     /// <summary>
     /// Wraps a statement in a condition that checks if compile-time logic should be skipped.
-    /// Generates: <c>if (!__skipN) { statement }</c> where N is the block ID.
+    /// Generates: <c>if (__skipN) goto __nextN; statement; __nextN:; Unsafe.SkipInit(out variables);</c> where N is the block ID.
+    /// Compile-time variables declared in the statement are hoisted and fake-initialized with Unsafe.SkipInit after the label.
     /// </summary>
-    private StatementSyntax WrapInSkipCompileTimeLogicCheck( StatementSyntax statement )
+    private IEnumerable<StatementSyntax> WrapInSkipCompileTimeLogicCheck( StatementSyntax statement, StatementSyntax originalStatement )
     {
-        return IfStatement(
-                PrefixUnaryExpression(
-                    SyntaxKind.LogicalNotExpression,
-                    SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.SkipCompileTimeLogicVariableName ) ),
-                Block( statement ) )
+        var labelName = $"__next{this._nextLabelId++}";
+
+        // if (__skip) goto __next;
+        yield return IfStatement(
+                SyntaxFactoryEx.WellKnownIdentifierName( this._currentMetaContext!.SkipCompileTimeLogicVariableName ),
+                GotoStatement( SyntaxKind.GotoStatement, SyntaxFactoryEx.SafeIdentifierName( labelName ) ) )
             .WithLeadingTrivia( this.GetIndentation() )
             .NormalizeWhitespace();
+
+        // statement;
+        yield return statement;
+
+        // __next:;
+        yield return LabeledStatement( labelName, EmptyStatement() )
+            .WithLeadingTrivia( this.GetIndentation() )
+            .NormalizeWhitespace();
+
+        // Find compile-time variables declared in this statement that need Unsafe.SkipInit
+        var variableFinder = new StatementCompileTimeVariableFinder( this._syntaxTreeAnnotationMap, originalStatement );
+        variableFinder.Visit();
+
+        foreach ( var localSymbol in variableFinder.AssignedVariables )
+        {
+            // System.Runtime.CompilerServices.Unsafe.SkipInit(out variable);
+            yield return ExpressionStatement(
+                    InvocationExpression(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            this._unsafeType,
+                            SyntaxFactoryEx.WellKnownIdentifierName( "SkipInit" ) ),
+                        ArgumentList(
+                            SingletonSeparatedList(
+                                Argument( SyntaxFactoryEx.SafeIdentifierName( localSymbol.Name ) )
+                                    .WithRefOrOutKeyword( Token( SyntaxKind.OutKeyword ) ) ) ) ) )
+                .WithLeadingTrivia( this.GetIndentation() )
+                .NormalizeWhitespace();
+        }
     }
 
     protected override ExpressionSyntax TransformInterpolatedStringExpression( InterpolatedStringExpressionSyntax node )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -323,7 +323,7 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
     private TupleExpressionSyntax AddTupleNames( TupleExpressionSyntax node )
     {
         // Tuples can be initialized from variables and then items take names from variable name
-        // but variable name is not safe and could be renamed because of target variables 
+        // but variable name is not safe and could be renamed because of target variables
         // in this case we initialize tuple with explicit names.
         var tupleType = (INamedTypeSymbol?) this._syntaxTreeAnnotationMap.GetExpressionType( node );
 
@@ -342,8 +342,14 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
             var tupleElement = tupleType.TupleElements[i];
             ArgumentSyntax arg;
 
+            // Skip adding NameColon for DeclarationExpression (e.g., var first) because the name is already in the declaration.
+            // Tuple element names are not permitted on the left side of a deconstruction.
+            if ( node.Arguments[i].Expression is DeclarationExpressionSyntax )
+            {
+                arg = node.Arguments[i];
+            }
             // If the tuple element has a name (i.e. it's not just ItemX), set it explicitly.
-            if ( !tupleElement.Name.Equals( tupleElement.CorrespondingTupleField!.Name, StringComparison.Ordinal ) )
+            else if ( !tupleElement.Name.Equals( tupleElement.CorrespondingTupleField!.Name, StringComparison.Ordinal ) )
             {
                 arg = node.Arguments[i].WithNameColon( NameColon( tupleElement.Name ) );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxExtensions.cs
@@ -393,4 +393,104 @@ public static class SyntaxExtensions
             PostfixUnaryExpressionSyntax postfix when postfix.IsKind( SyntaxKind.SuppressNullableWarningExpression ) => postfix.Operand,
             _ => expression
         };
+
+    /// <summary>
+    /// Finds a corresponding node in a different syntax tree based on its position in the child collection of parents.
+    /// This works by building a path from the source node to the source root, then navigating the same path
+    /// from the target root to find the equivalent node.
+    /// </summary>
+    /// <param name="sourceNode">The node to find an equivalent for in the target tree.</param>
+    /// <param name="sourceRoot">The root of the source tree (must be an ancestor of sourceNode).</param>
+    /// <param name="targetRoot">The root of the target tree to search in.</param>
+    /// <param name="targetNode">When this method returns, contains the equivalent node in the target tree if found; otherwise, null.</param>
+    /// <returns>True if the equivalent node was found; otherwise, false.</returns>
+    internal static bool TryFindNodeByPosition(
+        SyntaxNode sourceNode,
+        SyntaxNode sourceRoot,
+        SyntaxNode targetRoot,
+        out SyntaxNode? targetNode )
+    {
+        // Build a path from sourceNode to sourceRoot as a stack of (child index, syntax kind) pairs
+        var path = new Stack<(int ChildIndex, SyntaxKind Kind)>();
+        var current = sourceNode;
+
+        while ( current != sourceRoot )
+        {
+            var parent = current.Parent;
+
+            if ( parent == null )
+            {
+                // sourceNode is not a descendant of sourceRoot
+                targetNode = null;
+
+                return false;
+            }
+
+            // Find the index of current node in its parent's children
+            var children = parent.ChildNodesAndTokens();
+            var childIndex = -1;
+
+            for ( var i = 0; i < children.Count; i++ )
+            {
+                if ( children[i].AsNode() == current )
+                {
+                    childIndex = i;
+
+                    break;
+                }
+            }
+
+            if ( childIndex < 0 )
+            {
+                // This should never happen, but handle it gracefully
+                targetNode = null;
+
+                return false;
+            }
+
+            path.Push( (childIndex, current.Kind()) );
+            current = parent;
+        }
+
+        // Now navigate from targetRoot using the path in reverse order
+        current = targetRoot;
+
+        while ( path.Count > 0 )
+        {
+            var (childIndex, expectedKind) = path.Pop();
+            var children = current.ChildNodesAndTokens();
+
+            if ( childIndex >= children.Count )
+            {
+                // The target tree structure doesn't match
+                targetNode = null;
+
+                return false;
+            }
+
+            var childNodeOrToken = children[childIndex];
+
+            if ( !childNodeOrToken.IsNode )
+            {
+                // Expected a node but found a token
+                targetNode = null;
+
+                return false;
+            }
+
+            current = childNodeOrToken.AsNode()!;
+
+            if ( !current.IsKind( expectedKind ) )
+            {
+                // The syntax kind doesn't match - trees are structurally different
+                targetNode = null;
+
+                return false;
+            }
+        }
+
+        targetNode = current;
+
+        return true;
+    }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/CompileTimeVariableInSwitch.t.cs
@@ -1,12 +1,11 @@
 private void Method(int x)
 {
-    switch (x)
-    {
-        case 42:
-            this.Method(0);
-            break;
-    }
-
-    this.Method(x);
-    return;
+  switch (x)
+  {
+    case 42:
+      this.Method(0);
+      break;
+  }
+  this.Method(x);
+  return;
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionCompileTimeType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionCompileTimeType.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstructionCompileTimeType
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with compile-time types
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // The right-hand side is compile-time, types are explicit (compile-time types)
+            (IMethod method, int paramCount) = GetMethodInfo();
+
+            Console.WriteLine( $"Method: {method.Name}, Parameters: {paramCount}" );
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static (IMethod, int) GetMethodInfo()
+        {
+            return (meta.Target.Method, meta.Target.Method.Parameters.Count);
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private int Method( int a, int b )
+        {
+            return a + b;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionCompileTimeType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionCompileTimeType.cs
@@ -17,7 +17,9 @@ namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstruct
         private dynamic? Template()
         {
             // The right-hand side is compile-time, types are explicit (compile-time types)
+#pragma warning disable IDE0007 // Use 'var' instead of explicit type - explicit types are intentional in this test
             (IMethod method, int paramCount) = GetMethodInfo();
+#pragma warning restore IDE0007
 
             Console.WriteLine( $"Method: {method.Name}, Parameters: {paramCount}" );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionCompileTimeType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionCompileTimeType.t.cs
@@ -1,0 +1,5 @@
+private int Method(int a, int b)
+{
+  global::System.Console.WriteLine("Method: Method, Parameters: 2");
+  return this.Method(a, b);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionConstant.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionConstant.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstructionConstant
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with constant/neutral right-hand side
+        // Constants are treated as run-time in templates
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // The right-hand side is a constant literal tuple
+            (var first, var second) = ("Hello", "World");
+
+            Console.WriteLine( $"{first} {second}" );
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private int Method( int a, int b )
+        {
+            return a + b;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionConstant.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionConstant.t.cs
@@ -1,0 +1,6 @@
+private int Method(int a, int b)
+{
+  (var first, var second) = ("Hello", "World");
+  global::System.Console.WriteLine($"{first} {second}");
+  return this.Method(a, b);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitType.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstructionExplicitType
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with explicit types
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // The right-hand side is compile-time, types are explicit (run-time types)
+            (string first, string second) = GetTuple();
+
+            Console.WriteLine( $"{first} {second}" );
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static (string, string) GetTuple()
+        {
+            return ("Hello", "World");
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private int Method( int a, int b )
+        {
+            return a + b;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitType.cs
@@ -16,7 +16,9 @@ namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstruct
         private dynamic? Template()
         {
             // The right-hand side is compile-time, types are explicit (run-time types)
+#pragma warning disable IDE0007 // Use 'var' instead of explicit type - explicit types are intentional in this test
             (string first, string second) = GetTuple();
+#pragma warning restore IDE0007
 
             Console.WriteLine( $"{first} {second}" );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitType.t.cs
@@ -1,0 +1,5 @@
+private int Method(int a, int b)
+{
+  global::System.Console.WriteLine("Hello World");
+  return this.Method(a, b);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitTypeRunTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitTypeRunTime.cs
@@ -16,7 +16,9 @@ namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstruct
         private dynamic? Template()
         {
             // The right-hand side is run-time (parameter values), types are explicit
+#pragma warning disable IDE0007 // Use 'var' instead of explicit type - explicit types are intentional in this test
             (int first, int second) = (meta.Target.Parameters[0].Value, meta.Target.Parameters[1].Value);
+#pragma warning restore IDE0007
 
             Console.WriteLine( $"a={first}, b={second}" );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitTypeRunTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitTypeRunTime.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstructionExplicitTypeRunTime
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with explicit types and run-time right-hand side
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // The right-hand side is run-time (parameter values), types are explicit
+            (int first, int second) = (meta.Target.Parameters[0].Value, meta.Target.Parameters[1].Value);
+
+            Console.WriteLine( $"a={first}, b={second}" );
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private int Method( int a, int b )
+        {
+            return a + b;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitTypeRunTime.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionExplicitTypeRunTime.t.cs
@@ -1,0 +1,6 @@
+private int Method(int a, int b)
+{
+  (int first, int second) = (a, b);
+  global::System.Console.WriteLine($"a={first}, b={second}");
+  return this.Method(a, b);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionRunTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionRunTime.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+namespace Metalama.Framework.Tests.TemplateTests.LocalVariables.TupleDeconstructionRunTime
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with run-time right-hand side
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // The right-hand side is run-time (parameter values at runtime)
+            (var first, var second) = (meta.Target.Parameters[0].Value, meta.Target.Parameters[1].Value);
+
+            Console.WriteLine( $"a={first}, b={second}" );
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private int Method( int a, int b )
+        {
+            return a + b;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionRunTime.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/LocalVariables/TupleDeconstructionRunTime.t.cs
@@ -1,0 +1,6 @@
+private int Method(int a, int b)
+{
+  (var first, var second) = (a, b);
+  global::System.Console.WriteLine($"a={first}, b={second}");
+  return this.Method(a, b);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ForeachVariableAfterReturnInCompileTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ForeachVariableAfterReturnInCompileTimeIf.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.ForeachVariableAfterReturnInCompileTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test: Foreach loop variables declared after an early return
+        // should work correctly (though foreach variables have their own scope).
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Name.Length < 0 )
+            {
+                return null;
+            }
+
+            foreach ( var parameter in meta.Target.Method.Parameters )
+            {
+                meta.InsertComment( parameter.Name );
+            }
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method( int x, string y )
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ForeachVariableAfterReturnInCompileTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ForeachVariableAfterReturnInCompileTimeIf.t.cs
@@ -1,0 +1,6 @@
+private object? Method(int x, string y)
+{
+  // x
+  // y
+  return this.Method(x, y);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterNestedCompileTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterNestedCompileTimeIf.ct.cs
@@ -30,11 +30,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionAfterNested
           __skip1 = true;
         }
       }
-      if (!__skip1)
-      {
-        // return null;
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-      }
+      if (__skip1)
+        goto __next1;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next1:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? LocalFunc( object? input ) { Console.WriteLine( "LocalFunc called" ); return input; }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(LocalFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeElse.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeElse.ct.cs
@@ -29,18 +29,20 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionAfterReturn
       }
       else
       {
-        if (!__skip1)
-        {
-          // return LocalFunc( meta.Proceed() );
-          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
-        }
+        if (__skip1)
+          goto __next1;
+        // return LocalFunc( meta.Proceed() );
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
+        __next1:
+          ;
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        // return null;
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-      }
+      if (__skip1)
+        goto __next2;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next2:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? LocalFunc( object? input ) { Console.WriteLine( "LocalFunc called" ); return input; }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(LocalFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeForeach.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeForeach.ct.cs
@@ -28,11 +28,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionAfterReturn
           templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
           __skip1 = true;
         }
-      if (!__skip1)
-      {
-        // return meta.Proceed();
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      }
+      if (__skip1)
+        goto __next1;
+      // return meta.Proceed();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+      __next1:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? LocalFunc( object? input ) { Console.WriteLine( "LocalFunc called" ); return input; }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(LocalFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeIf.ct.cs
@@ -28,11 +28,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionAfterReturn
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        // return null;
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-      }
+      if (__skip1)
+        goto __next1;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next1:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? LocalFunc( object? input ) { Console.WriteLine( "LocalFunc called" ); return input; }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(LocalFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeIfInRunTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeIfInRunTimeIf.ct.cs
@@ -36,11 +36,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionAfterReturn
           // return LocalFunc( meta.Proceed() );
           templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
           __skip2 = true;
-          if (!__skip2)
-          {
-            // return null;
-            templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-          }
+          if (__skip2)
+            goto __next1;
+          // return null;
+          templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __next1:
+            ;
           __skip2 = true;
         }
         return templateSyntaxFactory.ToStatementList(__s2);

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeSwitch.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionAfterReturnInCompileTimeSwitch.ct.cs
@@ -29,19 +29,21 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionAfterReturn
           __skip1 = true;
           break;
         case 1:
-          if (!__skip1)
-          {
-            // return LocalFunc( meta.Proceed() );
-            templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
-          }
+          if (__skip1)
+            goto __next1;
+          // return LocalFunc( meta.Proceed() );
+          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
+          __next1:
+            ;
           __skip1 = true;
           break;
         default:
-          if (!__skip1)
-          {
-            // return null;
-            templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-          }
+          if (__skip1)
+            goto __next2;
+          // return null;
+          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __next2:
+            ;
           __skip1 = true;
           break;
       }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionCallingAnotherAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionCallingAnotherAfterReturn.ct.cs
@@ -28,11 +28,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionCallingAnot
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(OuterName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        // return null;
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-      }
+      if (__skip1)
+        goto __next1;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next1:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? Outer( object? input ) { Console.WriteLine( "Outer called" ); return Inner( input ); }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(OuterName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionInsideNestedCompileTimeConditions.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionInsideNestedCompileTimeConditions.ct.cs
@@ -29,11 +29,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionInsideNeste
           // return LocalFunc( meta.Proceed() );
           templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
           __skip1 = true;
-          if (!__skip1)
-          {
-            // return null;
-            templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-          }
+          if (__skip1)
+            goto __next1;
+          // return null;
+          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __next1:
+            ;
           __skip1 = true;
           SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
           // object? LocalFunc( object? input ) { global::System.Console.WriteLine( "LocalFunc called" ); return input; }
@@ -50,11 +51,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionInsideNeste
           })()), null, default(SyntaxToken)));
         }
       }
-      if (!__skip1)
-      {
-        // return meta.Proceed();
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      }
+      if (__skip1)
+        goto __next2;
+      // return meta.Proceed();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+      __next2:
+        ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
   }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionInsideRunTimeElse.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionInsideRunTimeElse.ct.cs
@@ -39,11 +39,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionInsideRunTi
           // return LocalFunc( "null input" );
           templateSyntaxFactory.AddStatement(__s3, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal("\"null input\"", "null input"))))))))));
           __skip3 = true;
-          if (!__skip3)
-          {
-            // return null;
-            templateSyntaxFactory.AddStatement(__s3, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-          }
+          if (__skip3)
+            goto __next1;
+          // return null;
+          templateSyntaxFactory.AddStatement(__s3, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __next1:
+            ;
           __skip3 = true;
         }
         SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionInsideRunTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionInsideRunTimeIf.ct.cs
@@ -33,11 +33,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionInsideRunTi
           // return LocalFunc( meta.Proceed() );
           templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
           __skip2 = true;
-          if (!__skip2)
-          {
-            // return null;
-            templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-          }
+          if (__skip2)
+            goto __next1;
+          // return null;
+          templateSyntaxFactory.AddStatement(__s2, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __next1:
+            ;
           __skip2 = true;
         }
         SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionReferencingVariableWithEarlyReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalFunctionReferencingVariableWithEarlyReturn.ct.cs
@@ -31,11 +31,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.LocalFunctionReferencing
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(LocalFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        // return null;
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-      }
+      if (__skip1)
+        goto __next1;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next1:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? LocalFunc( object? input ) { Console.WriteLine( message ); return input; }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(LocalFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalVariableAfterReturnInCompileTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalVariableAfterReturnInCompileTimeIf.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.LocalVariableAfterReturnInCompileTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Bug: When a local variable is declared after a return in a compile-time if,
+        // the variable declaration gets wrapped in if (__skip) but subsequent usage
+        // is also wrapped, making the variable invisible.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // Compile-time condition with a return that makes subsequent code conditional
+            if ( meta.Target.Method.Name.Length < 0 )
+            {
+                return null;
+            }
+
+            // COMPILE-TIME variable declaration - the bug is that this gets wrapped in `if (!__skip)`
+            var method = meta.Target.Method;
+
+            // This tries to use the compile-time variable, but it's in a separate `if (!__skip)` block
+            // so the variable is not visible here, causing a compilation error
+            method.Invoke();
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalVariableAfterReturnInCompileTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalVariableAfterReturnInCompileTimeIf.ct.cs
@@ -1,26 +1,27 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.LocalVariableAfterReturnInCompileTimeIf
 {
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Bug: When a local variable is declared after a return in a compile-time if,
+    // the variable declaration gets wrapped in if (__skip) but subsequent usage
+    // is also wrapped, making the variable invisible.
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Name.Length < 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
@@ -28,19 +29,24 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       }
       if (__skip1)
         goto __next1;
-      Aspect.ThrowIfReached();
+      var method = meta.Target.Method;
       __next1:
         ;
+      Unsafe.SkipInit(out method);
       if (__skip1)
         goto __next2;
+      // method.Invoke();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.ToStatement(templateSyntaxFactory.GetDynamicSyntax(method.Invoke())));
+      __next2:
+        ;
+      if (__skip1)
+        goto __next3;
       // return meta.Proceed();
       templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      __next2:
+      __next3:
         ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
-    [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalVariableAfterReturnInCompileTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/LocalVariableAfterReturnInCompileTimeIf.t.cs
@@ -1,0 +1,5 @@
+private object? Method()
+{
+  this.Method();
+  return this.Method();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleLocalFunctionsAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleLocalFunctionsAfterReturn.ct.cs
@@ -28,11 +28,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.MultipleLocalFunctionsAf
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(TransformName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(FormatName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed")))))))))))))));
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        // return null;
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-      }
+      if (__skip1)
+        goto __next1;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next1:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? Transform( object? input ) { Console.WriteLine( "Transform called" ); return input; }
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(TransformName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleOutVarsInIfAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleOutVarsInIfAfterReturn.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.MultipleOutVarsInIfAfterReturn
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test that multiple out variables declared in nested if statements after a compile-time return
+        // are properly handled with Unsafe.SkipInit
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // Multiple out variables in nested if statements
+            if ( TryGetFirst( out var first ) )
+            {
+                if ( TryGetSecond( out var second ) )
+                {
+                    return $"{first},{second}";
+                }
+            }
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static bool TryGetFirst( out string value )
+        {
+            value = "first";
+            return true;
+        }
+
+        [CompileTime]
+        private static bool TryGetSecond( out string value )
+        {
+            value = "second";
+            return true;
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleOutVarsInIfAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleOutVarsInIfAfterReturn.ct.cs
@@ -1,26 +1,26 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.MultipleOutVarsInIfAfterReturn
 {
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Test that multiple out variables declared in nested if statements after a compile-time return
+    // are properly handled with Unsafe.SkipInit
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Parameters.Count == 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
@@ -28,9 +28,18 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       }
       if (__skip1)
         goto __next1;
-      Aspect.ThrowIfReached();
+      if (Aspect.TryGetFirst(out var first))
+      {
+        if (Aspect.TryGetSecond(out var second))
+        {
+          // return $"{first},{second}";
+          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression($"{first},{second}"), "Y:global::System.String!"))));
+          __skip1 = true;
+        }
+      }
       __next1:
         ;
+      Unsafe.SkipInit(out first);
       if (__skip1)
         goto __next2;
       // return meta.Proceed();
@@ -40,7 +49,17 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
     [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
+    private static bool TryGetFirst(out string value)
+    {
+      value = "first";
+      return true;
+    }
+    [CompileTime]
+    private static bool TryGetSecond(out string value)
+    {
+      value = "second";
+      return true;
+    }
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleOutVarsInIfAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/MultipleOutVarsInIfAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NameCollisionInCompileTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NameCollisionInCompileTimeIf.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.NameCollisionInCompileTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test: When the same variable name is declared in separate if/else branches,
+        // the hoisting mechanism should handle them correctly by recognizing them as different symbols.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Name.Length < 0 )
+            {
+                return null;
+            }
+
+            if ( meta.Target.Method.Name.Length < 5 )
+            {
+                var method = meta.Target.Method;
+                method.Invoke();
+                return null;
+            }
+            else
+            {
+                var method = meta.Target.Method;
+                method.Invoke();
+            }
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NameCollisionInCompileTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NameCollisionInCompileTimeIf.ct.cs
@@ -1,46 +1,67 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.NameCollisionInCompileTimeIf
 {
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Test: When the same variable name is declared in separate if/else branches,
+    // the hoisting mechanism should handle them correctly by recognizing them as different symbols.
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Name.Length < 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
         __skip1 = true;
       }
       if (__skip1)
-        goto __next1;
-      Aspect.ThrowIfReached();
-      __next1:
+        goto __next3;
+      if (meta.Target.Method.Name.Length < 5)
+      {
+        var method = meta.Target.Method;
+        // method.Invoke();
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.ToStatement(templateSyntaxFactory.GetDynamicSyntax(method.Invoke())));
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      else
+      {
+        if (__skip1)
+          goto __next1;
+        var method = meta.Target.Method;
+        __next1:
+          ;
+        Unsafe.SkipInit(out method);
+        if (__skip1)
+          goto __next2;
+        // method.Invoke();
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.ToStatement(templateSyntaxFactory.GetDynamicSyntax(method.Invoke())));
+        __next2:
+          ;
+      }
+      __next3:
         ;
       if (__skip1)
-        goto __next2;
+        goto __next4;
       // return meta.Proceed();
       templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      __next2:
+      __next4:
         ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
-    [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NameCollisionInCompileTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NameCollisionInCompileTimeIf.t.cs
@@ -1,0 +1,5 @@
+private object? Method()
+{
+  this.Method();
+  return this.Method();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedLocalFunctionWithCompileTimeSkip.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedLocalFunctionWithCompileTimeSkip.ct.cs
@@ -27,18 +27,20 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.NestedLocalFunctionWithC
         // return OuterFunc( meta.Proceed() );
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(OuterFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, templateSyntaxFactory.GetDynamicSyntax(templateSyntaxFactory.Proceed("Proceed"))))))))));
         __skip1 = true;
-        if (!__skip1)
-        {
-          // return null;
-          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-        }
-        __skip1 = true;
-      }
-      if (!__skip1)
-      {
+        if (__skip1)
+          goto __next1;
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __next1:
+          ;
+        __skip1 = true;
       }
+      if (__skip1)
+        goto __next2;
+      // return null;
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+      __next2:
+        ;
       SyntaxToken inputName = templateSyntaxFactory.GetUniqueIdentifier("input");
       // object? OuterFunc( object? input ) { // Inner local function NESTED inside OuterFunc object? InnerFunc( object? value...
       templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(OuterFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), templateSyntaxFactory.EscapeIdentifier(inputName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedLocalFunctionWithCompileTimeSkipInInner.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedLocalFunctionWithCompileTimeSkipInInner.ct.cs
@@ -47,18 +47,20 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.NestedLocalFunctionWithC
             // return value;
             localTemplateSyntaxFactory2.AddStatement(__s3, localTemplateSyntaxFactory2.AddSimplifierAnnotations(localTemplateSyntaxFactory2.ReturnStatement(SyntaxFactory.IdentifierName(localTemplateSyntaxFactory2.EscapeIdentifier(valueName)))));
             __skip3 = true;
-            if (!__skip3)
-            {
-              // return null;
-              localTemplateSyntaxFactory2.AddStatement(__s3, localTemplateSyntaxFactory2.AddSimplifierAnnotations(localTemplateSyntaxFactory2.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-            }
+            if (__skip3)
+              goto __next1;
+            // return null;
+            localTemplateSyntaxFactory2.AddStatement(__s3, localTemplateSyntaxFactory2.AddSimplifierAnnotations(localTemplateSyntaxFactory2.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+            __next1:
+              ;
             __skip3 = true;
           }
-          if (!__skip3)
-          {
-            // return value;
-            localTemplateSyntaxFactory2.AddStatement(__s3, localTemplateSyntaxFactory2.AddSimplifierAnnotations(localTemplateSyntaxFactory2.ReturnStatement(SyntaxFactory.IdentifierName(localTemplateSyntaxFactory2.EscapeIdentifier(valueName)))));
-          }
+          if (__skip3)
+            goto __next2;
+          // return value;
+          localTemplateSyntaxFactory2.AddStatement(__s3, localTemplateSyntaxFactory2.AddSimplifierAnnotations(localTemplateSyntaxFactory2.ReturnStatement(SyntaxFactory.IdentifierName(localTemplateSyntaxFactory2.EscapeIdentifier(valueName)))));
+          __next2:
+            ;
           return localTemplateSyntaxFactory1.ToStatementList(__s3);
         })()), null, default(SyntaxToken)));
         return templateSyntaxFactory.ToStatementList(__s2);

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedLocalFunctionWithCompileTimeSkipInOuter.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedLocalFunctionWithCompileTimeSkipInOuter.ct.cs
@@ -36,18 +36,20 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.NestedLocalFunctionWithC
           // return InnerFunc( input );
           localTemplateSyntaxFactory1.AddStatement(__s2, localTemplateSyntaxFactory1.AddSimplifierAnnotations(localTemplateSyntaxFactory1.ReturnStatement(localTemplateSyntaxFactory1.AddSimplifierAnnotations(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(localTemplateSyntaxFactory1.EscapeIdentifier(InnerFuncName)), SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.Argument(null, default, SyntaxFactory.IdentifierName(localTemplateSyntaxFactory1.EscapeIdentifier(inputName))))))))));
           __skip2 = true;
-          if (!__skip2)
-          {
-            // return null;
-            localTemplateSyntaxFactory1.AddStatement(__s2, localTemplateSyntaxFactory1.AddSimplifierAnnotations(localTemplateSyntaxFactory1.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-          }
+          if (__skip2)
+            goto __next1;
+          // return null;
+          localTemplateSyntaxFactory1.AddStatement(__s2, localTemplateSyntaxFactory1.AddSimplifierAnnotations(localTemplateSyntaxFactory1.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __next1:
+            ;
           __skip2 = true;
         }
-        if (!__skip2)
-        {
-          // return input;
-          localTemplateSyntaxFactory1.AddStatement(__s2, localTemplateSyntaxFactory1.AddSimplifierAnnotations(localTemplateSyntaxFactory1.ReturnStatement(SyntaxFactory.IdentifierName(localTemplateSyntaxFactory1.EscapeIdentifier(inputName)))));
-        }
+        if (__skip2)
+          goto __next2;
+        // return input;
+        localTemplateSyntaxFactory1.AddStatement(__s2, localTemplateSyntaxFactory1.AddSimplifierAnnotations(localTemplateSyntaxFactory1.ReturnStatement(SyntaxFactory.IdentifierName(localTemplateSyntaxFactory1.EscapeIdentifier(inputName)))));
+        __next2:
+          ;
         SyntaxToken valueName = localTemplateSyntaxFactory1.GetUniqueIdentifier("value");
         // object? InnerFunc( object? value ) { Console.WriteLine( "InnerFunc called" ); return value; }
         localTemplateSyntaxFactory1.AddStatement(__s2, SyntaxFactory.LocalFunctionStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), localTemplateSyntaxFactory1.EscapeIdentifier(InnerFuncName), null, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList<ParameterSyntax>(SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)), SyntaxFactory.Token(SyntaxKind.QuestionToken)), localTemplateSyntaxFactory1.EscapeIdentifier(valueName), null))), default(SyntaxList<TypeParameterConstraintClauseSyntax>), SyntaxFactory.Block(default, new Func<SyntaxList<StatementSyntax>>(delegate

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedTupleDeconstructionAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedTupleDeconstructionAfterReturn.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.NestedTupleDeconstructionAfterReturn
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test nested tuple deconstruction: var (x, (y, z)) = nested;
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // Nested tuple deconstruction
+            var (first, (second, third)) = GetNestedTuple();
+
+            return $"{first},{second},{third}";
+        }
+
+        [CompileTime]
+        private static (string, (string, string)) GetNestedTuple()
+        {
+            return ("a", ("b", "c"));
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedTupleDeconstructionAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedTupleDeconstructionAfterReturn.ct.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+#pragma warning disable CS0162 // Unreachable code detected
+namespace Metalama.Framework.Tests.TemplateTests.Return.NestedTupleDeconstructionAfterReturn
+{
+  [CompileTime]
+  internal class Aspect
+  {
+    // Test nested tuple deconstruction: var (x, (y, z)) = nested;
+    private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+    {
+      List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+      bool __skip1 = false;
+      if (meta.Target.Method.Parameters.Count == 0)
+      {
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      SyntaxToken firstName = templateSyntaxFactory.GetUniqueIdentifier("first");
+      SyntaxToken secondName = templateSyntaxFactory.GetUniqueIdentifier("second");
+      SyntaxToken thirdName = templateSyntaxFactory.GetUniqueIdentifier("third");
+      if (__skip1)
+        goto __next1;
+      // var (first, (second, third)) = GetNestedTuple();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.ToStatement(templateSyntaxFactory.RewriteAssignmentExpression(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.DeclarationExpression(SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("var")), SyntaxFactory.ParenthesizedVariableDesignation(SyntaxFactory.Token(SyntaxKind.OpenParenToken), SyntaxFactory.SeparatedList<VariableDesignationSyntax>(new VariableDesignationSyntax[] { SyntaxFactory.SingleVariableDesignation(templateSyntaxFactory.EscapeIdentifier(firstName)), SyntaxFactory.ParenthesizedVariableDesignation(SyntaxFactory.Token(SyntaxKind.OpenParenToken), SyntaxFactory.SeparatedList<VariableDesignationSyntax>(new VariableDesignationSyntax[] { SyntaxFactory.SingleVariableDesignation(templateSyntaxFactory.EscapeIdentifier(secondName)), SyntaxFactory.SingleVariableDesignation(templateSyntaxFactory.EscapeIdentifier(thirdName)) }), SyntaxFactory.Token(SyntaxKind.CloseParenToken)) }), SyntaxFactory.Token(SyntaxKind.CloseParenToken))), SyntaxFactory.Token(SyntaxKind.EqualsToken), templateSyntaxFactory.Serialize<(string, (string, string))>(Aspect.GetNestedTuple())))));
+      __next1:
+        ;
+      if (__skip1)
+        goto __next2;
+      // return $"{first},{second},{third}";
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RenderInterpolatedString(SyntaxFactory.InterpolatedStringExpression(SyntaxFactory.Token(SyntaxKind.InterpolatedStringStartToken), SyntaxFactory.List<InterpolatedStringContentSyntax>(new InterpolatedStringContentSyntax[] { templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(firstName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))), SyntaxFactory.InterpolatedStringText(SyntaxFactory.Token(default, SyntaxKind.InterpolatedStringTextToken, ",", ",", default)), templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(secondName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))), SyntaxFactory.InterpolatedStringText(SyntaxFactory.Token(default, SyntaxKind.InterpolatedStringTextToken, ",", ",", default)), templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(thirdName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))) }), SyntaxFactory.Token(SyntaxKind.InterpolatedStringEndToken))))));
+      __next2:
+        ;
+      return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+    }
+    [CompileTime]
+    private static (string, (string, string)) GetNestedTuple()
+    {
+      return ("a", ("b", "c"));
+    }
+  }
+  internal class TargetCode
+  {
+    // <target>
+    private object? Method()
+    {
+      return null;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedTupleDeconstructionAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/NestedTupleDeconstructionAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarAfterReturnInCompileTimeIf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarAfterReturnInCompileTimeIf.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.OutVarAfterReturnInCompileTimeIf
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test: Variables declared with 'out var' pattern after an early return
+        // should remain visible in subsequent statements.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Name.Length < 0 )
+            {
+                return null;
+            }
+
+            var dict = meta.CompileTime( new Dictionary<string, object>() );
+
+            dict.TryGetValue( "key", out var value );
+            meta.InsertComment( value?.ToString() ?? "null" );
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarAfterReturnInCompileTimeIf.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarAfterReturnInCompileTimeIf.ct.cs
@@ -1,26 +1,26 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.OutVarAfterReturnInCompileTimeIf
 {
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Test: Variables declared with 'out var' pattern after an early return
+    // should remain visible in subsequent statements.
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Name.Length < 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
@@ -28,19 +28,25 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       }
       if (__skip1)
         goto __next1;
-      Aspect.ThrowIfReached();
+      var dict = meta.CompileTime(new Dictionary<string, object>());
       __next1:
         ;
+      Unsafe.SkipInit(out dict);
       if (__skip1)
         goto __next2;
+      dict.TryGetValue("key", out var value);
+      __next2:
+        ;
+      Unsafe.SkipInit(out value); // meta.InsertComment( value?.ToString() ?? "null" );
+      templateSyntaxFactory.AddComments(__s1, value?.ToString() ?? "null");
+      if (__skip1)
+        goto __next3;
       // return meta.Proceed();
       templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      __next2:
+      __next3:
         ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
-    [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarAfterReturnInCompileTimeIf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarAfterReturnInCompileTimeIf.t.cs
@@ -1,0 +1,5 @@
+private object? Method()
+{
+  // null
+  return this.Method();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarInIfAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarInIfAfterReturn.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.OutVarInIfAfterReturn
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test that out variables declared in an if statement after a compile-time return
+        // are properly handled with Unsafe.SkipInit
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // This out variable is declared in an if statement
+            if ( TryGetValue( out var value ) )
+            {
+                return value;
+            }
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static bool TryGetValue( out object? value )
+        {
+            value = null;
+            return false;
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarInIfAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarInIfAfterReturn.ct.cs
@@ -1,26 +1,26 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.OutVarInIfAfterReturn
 {
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Test that out variables declared in an if statement after a compile-time return
+    // are properly handled with Unsafe.SkipInit
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Parameters.Count == 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
@@ -28,9 +28,15 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       }
       if (__skip1)
         goto __next1;
-      Aspect.ThrowIfReached();
+      if (Aspect.TryGetValue(out var value))
+      {
+        // return value;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.Serialize<object?>(value))));
+        __skip1 = true;
+      }
       __next1:
         ;
+      Unsafe.SkipInit(out value);
       if (__skip1)
         goto __next2;
       // return meta.Proceed();
@@ -40,7 +46,11 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
     [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
+    private static bool TryGetValue(out object? value)
+    {
+      value = null;
+      return false;
+    }
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarInIfAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/OutVarInIfAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.cs
@@ -6,6 +6,7 @@
 // @WriteCompiledTemplate
 #endif
 
+using System.Globalization;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Engine.Templating;
 
@@ -31,7 +32,7 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.PatternMatchingInIfAfter
 
             if ( obj is string s )
             {
-                return s.ToUpper();
+                return s.ToUpper( CultureInfo.InvariantCulture );
             }
 
             return meta.Proceed();

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.PatternMatchingInIfAfterReturn
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test that pattern matching variables declared in an if statement after a compile-time return
+        // are properly handled with Unsafe.SkipInit
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // This pattern matching variable is declared in an if statement.
+            var obj = GetObject();
+
+            if ( obj is string s )
+            {
+                return s.ToUpper();
+            }
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static object? GetObject()
+        {
+            return "test";
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.ct.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
@@ -36,8 +37,8 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.PatternMatchingInIfAfter
         goto __next2;
       if (obj is string s)
       {
-        // return s.ToUpper();
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression(s.ToUpper()), "Y:global::System.String!"))));
+        // return s.ToUpper( CultureInfo.InvariantCulture );
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression(s.ToUpper(CultureInfo.InvariantCulture)), "Y:global::System.String!"))));
         __skip1 = true;
       }
       __next2:

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.ct.cs
@@ -1,26 +1,26 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.PatternMatchingInIfAfterReturn
 {
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Test that pattern matching variables declared in an if statement after a compile-time return
+    // are properly handled with Unsafe.SkipInit
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Parameters.Count == 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
@@ -28,19 +28,34 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       }
       if (__skip1)
         goto __next1;
-      Aspect.ThrowIfReached();
+      var obj = Aspect.GetObject();
       __next1:
         ;
+      Unsafe.SkipInit(out obj);
       if (__skip1)
         goto __next2;
+      if (obj is string s)
+      {
+        // return s.ToUpper();
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression(s.ToUpper()), "Y:global::System.String!"))));
+        __skip1 = true;
+      }
+      __next2:
+        ;
+      Unsafe.SkipInit(out s);
+      if (__skip1)
+        goto __next3;
       // return meta.Proceed();
       templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      __next2:
+      __next3:
         ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
     [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
+    private static object? GetObject()
+    {
+      return "test";
+    }
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PatternMatchingInIfAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PropertyPatternAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PropertyPatternAfterReturn.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.PropertyPatternAfterReturn
+{
+    [CompileTime]
+    internal class Person
+    {
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+    }
+
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test property pattern matching: if (obj is { Property: var value })
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            var person = GetPerson();
+
+            // Property pattern matching
+            if ( person is { Name: var name, Age: var age } )
+            {
+                return $"{name} is {age} years old";
+            }
+
+            return meta.Proceed();
+        }
+
+        [CompileTime]
+        private static Person GetPerson()
+        {
+            return new Person { Name = "John", Age = 30 };
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PropertyPatternAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PropertyPatternAfterReturn.ct.cs
@@ -1,26 +1,31 @@
 // Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
-using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.Templating;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 #pragma warning disable CS0162 // Unreachable code detected
-namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTrue
+namespace Metalama.Framework.Tests.TemplateTests.Return.PropertyPatternAfterReturn
 {
+  [CompileTime]
+  internal class Person
+  {
+    public string Name { get; set; } = "";
+    public int Age { get; set; }
+  }
   [CompileTime]
   internal class Aspect
   {
-    // Bug #1125: When the compile-time condition is true, the return should stop
-    // the compile-time control flow.
+    // Test property pattern matching: if (obj is { Property: var value })
     private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
     {
       List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
       bool __skip1 = false;
-      if (meta.Target.Method.Name.Length > 0)
+      if (meta.Target.Method.Parameters.Count == 0)
       {
         // return null;
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
@@ -28,19 +33,37 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfTru
       }
       if (__skip1)
         goto __next1;
-      Aspect.ThrowIfReached();
+      var person = Aspect.GetPerson();
       __next1:
         ;
+      Unsafe.SkipInit(out person);
       if (__skip1)
         goto __next2;
+      if (person is { Name: var name, Age: var age })
+      {
+        // return $"{name} is {age} years old";
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression($"{name} is {age} years old"), "Y:global::System.String!"))));
+        __skip1 = true;
+      }
+      __next2:
+        ;
+      if (__skip1)
+        goto __next3;
       // return meta.Proceed();
       templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      __next2:
+      __next3:
         ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
     [CompileTime]
-    private static void ThrowIfReached() => throw new InvalidOperationException("Compile-time flow should have stopped at return.");
+    private static Person GetPerson()
+    {
+      return new Person
+      {
+        Name = "John",
+        Age = 30
+      };
+    }
   }
   internal class TargetCode
   {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PropertyPatternAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/PropertyPatternAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeElse.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeElse.ct.cs
@@ -28,23 +28,25 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeElse
       }
       else
       {
-        if (!__skip1)
-        {
-          // return null;
-          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
-        }
+        if (__skip1)
+          goto __next1;
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __next1:
+          ;
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        Aspect. // This code should NOT be reached at compile time.
-        ThrowIfReached();
-      }
-      if (!__skip1)
-      {
-        // return meta.Proceed();
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      }
+      if (__skip1)
+        goto __next2;
+      Aspect.ThrowIfReached();
+      __next2:
+        ;
+      if (__skip1)
+        goto __next3;
+      // return meta.Proceed();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+      __next3:
+        ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
     [CompileTime]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfFalse.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeIfFalse.ct.cs
@@ -25,11 +25,12 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeIfFal
         templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
         __skip1 = true;
       }
-      if (!__skip1)
-      {
-        // return meta.Proceed();
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      }
+      if (__skip1)
+        goto __next1;
+      // return meta.Proceed();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+      __next1:
+        ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
   }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeSwitch.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/ReturnInCompileTimeSwitch.ct.cs
@@ -28,22 +28,24 @@ namespace Metalama.Framework.Tests.TemplateTests.Return.ReturnInCompileTimeSwitc
           break;
         // Compile-time flow should stop here.
         default:
-          if (!__skip1)
-          {
-            break;
-          }
+          if (__skip1)
+            goto __next1;
+          break;
+          __next1:
+            ;
           break;
       }
-      if (!__skip1)
-      {
-        Aspect. // This code should NOT be reached when parameter count is 0.
-        ThrowIfReached();
-      }
-      if (!__skip1)
-      {
-        // return meta.Proceed();
-        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
-      }
+      if (__skip1)
+        goto __next2;
+      Aspect.ThrowIfReached();
+      __next2:
+        ;
+      if (__skip1)
+        goto __next3;
+      // return meta.Proceed();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+      __next3:
+        ;
       return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
     }
     [CompileTime]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/SameVariableNameInDifferentBranches.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/SameVariableNameInDifferentBranches.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.SameVariableNameInDifferentBranches
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test: When the same variable name is used in multiple if/else if/else branches,
+        // the hoisting mechanism should handle them correctly as different symbols.
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Name.Length < 0 )
+            {
+                return null;
+            }
+
+            if ( meta.Target.Method.Name.Length < 5 )
+            {
+                var result = meta.CompileTime( "short" );
+                meta.InsertComment( result );
+                return null;
+            }
+            else if ( meta.Target.Method.Name.Length > 10 )
+            {
+                var result = meta.CompileTime( "long" );
+                meta.InsertComment( result );
+                return null;
+            }
+            else
+            {
+                var result = meta.CompileTime( "medium" );
+                meta.InsertComment( result );
+            }
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/SameVariableNameInDifferentBranches.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/SameVariableNameInDifferentBranches.ct.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+#pragma warning disable CS0162 // Unreachable code detected
+namespace Metalama.Framework.Tests.TemplateTests.Return.SameVariableNameInDifferentBranches
+{
+  [CompileTime]
+  internal class Aspect
+  {
+    // Test: When the same variable name is used in multiple if/else if/else branches,
+    // the hoisting mechanism should handle them correctly as different symbols.
+    private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+    {
+      List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+      bool __skip1 = false;
+      if (meta.Target.Method.Name.Length < 0)
+      {
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      if (__skip1)
+        goto __next3;
+      if (meta.Target.Method.Name.Length < 5)
+      {
+        var result = meta.CompileTime("short");
+        // meta.InsertComment( result );
+        templateSyntaxFactory.AddComments(__s1, result);
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      else
+      {
+        if (__skip1)
+          goto __next2;
+        if (meta.Target.Method.Name.Length > 10)
+        {
+          var result = meta.CompileTime("long");
+          // meta.InsertComment( result );
+          templateSyntaxFactory.AddComments(__s1, result);
+          // return null;
+          templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+          __skip1 = true;
+        }
+        else
+        {
+          if (__skip1)
+            goto __next1;
+          var result = meta.CompileTime("medium");
+          __next1:
+            ;
+          Unsafe.SkipInit(out result); // meta.InsertComment( result );
+          templateSyntaxFactory.AddComments(__s1, result);
+        }
+        __next2:
+          ;
+      }
+      __next3:
+        ;
+      if (__skip1)
+        goto __next4;
+      // return meta.Proceed();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.DynamicReturnStatement(templateSyntaxFactory.GetUserExpression(templateSyntaxFactory.Proceed("Proceed")), false)));
+      __next4:
+        ;
+      return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+    }
+  }
+  internal class TargetCode
+  {
+    // <target>
+    private object? Method()
+    {
+      return null;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/SameVariableNameInDifferentBranches.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/SameVariableNameInDifferentBranches.t.cs
@@ -1,0 +1,5 @@
+private object? Method()
+{
+  // medium
+  return this.Method();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleAssignmentAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleAssignmentAfterReturn.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleAssignmentAfterReturn
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple assignment to existing variables: (x, y) = tuple;
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // Declare variables first
+            var first = "initial";
+            var second = "initial";
+
+            // Then assign via tuple
+            (first, second) = GetTuple();
+
+            return $"{first},{second}";
+        }
+
+        [CompileTime]
+        private static (string, string) GetTuple()
+        {
+            return ("a", "b");
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleAssignmentAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleAssignmentAfterReturn.ct.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+#pragma warning disable CS0162 // Unreachable code detected
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleAssignmentAfterReturn
+{
+  [CompileTime]
+  internal class Aspect
+  {
+    // Test tuple assignment to existing variables: (x, y) = tuple;
+    private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+    {
+      List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+      bool __skip1 = false;
+      if (meta.Target.Method.Parameters.Count == 0)
+      {
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      SyntaxToken firstName = templateSyntaxFactory.GetUniqueIdentifier("first");
+      if (__skip1)
+        goto __next1;
+      // var first = "initial";
+      templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalDeclarationStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxToken), default(SyntaxToken), default(SyntaxTokenList), SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("var")), SyntaxFactory.SingletonSeparatedList<VariableDeclaratorSyntax>(SyntaxFactory.VariableDeclarator(templateSyntaxFactory.EscapeIdentifier(firstName), default(BracketedArgumentListSyntax), SyntaxFactory.EqualsValueClause(SyntaxFactory.Token(SyntaxKind.EqualsToken), SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal("\"initial\"", "initial")))))), SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+      __next1:
+        ;
+      SyntaxToken secondName = templateSyntaxFactory.GetUniqueIdentifier("second");
+      if (__skip1)
+        goto __next2;
+      // var second = "initial";
+      templateSyntaxFactory.AddStatement(__s1, SyntaxFactory.LocalDeclarationStatement(default(SyntaxList<AttributeListSyntax>), default(SyntaxToken), default(SyntaxToken), default(SyntaxTokenList), SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("var")), SyntaxFactory.SingletonSeparatedList<VariableDeclaratorSyntax>(SyntaxFactory.VariableDeclarator(templateSyntaxFactory.EscapeIdentifier(secondName), default(BracketedArgumentListSyntax), SyntaxFactory.EqualsValueClause(SyntaxFactory.Token(SyntaxKind.EqualsToken), SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal("\"initial\"", "initial")))))), SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+      __next2:
+        ;
+      if (__skip1)
+        goto __next3;
+      // (first, second) = GetTuple();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.ToStatement(templateSyntaxFactory.RewriteAssignmentExpression(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.TupleExpression(SyntaxFactory.Token(SyntaxKind.OpenParenToken), SyntaxFactory.SeparatedList<ArgumentSyntax>(new ArgumentSyntax[] { SyntaxFactory.Argument(null, default, SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(firstName))).WithNameColon(SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("first")), SyntaxFactory.Token(SyntaxKind.ColonToken))), SyntaxFactory.Argument(null, default, SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(secondName))).WithNameColon(SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("second")), SyntaxFactory.Token(SyntaxKind.ColonToken))) }), SyntaxFactory.Token(SyntaxKind.CloseParenToken)), SyntaxFactory.Token(SyntaxKind.EqualsToken), templateSyntaxFactory.Serialize<(string, string)>(Aspect.GetTuple())))));
+      __next3:
+        ;
+      if (__skip1)
+        goto __next4;
+      // return $"{first},{second}";
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RenderInterpolatedString(SyntaxFactory.InterpolatedStringExpression(SyntaxFactory.Token(SyntaxKind.InterpolatedStringStartToken), SyntaxFactory.List<InterpolatedStringContentSyntax>(new InterpolatedStringContentSyntax[] { templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(firstName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))), SyntaxFactory.InterpolatedStringText(SyntaxFactory.Token(default, SyntaxKind.InterpolatedStringTextToken, ",", ",", default)), templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(secondName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))) }), SyntaxFactory.Token(SyntaxKind.InterpolatedStringEndToken))))));
+      __next4:
+        ;
+      return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+    }
+    [CompileTime]
+    private static (string, string) GetTuple()
+    {
+      return ("a", "b");
+    }
+  }
+  internal class TargetCode
+  {
+    // <target>
+    private object? Method()
+    {
+      return null;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleAssignmentAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleAssignmentAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionAfterReturn.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionAfterReturn.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleDeconstructionAfterReturn
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with ParenthesizedVariableDesignation: var (x, y) = tuple;
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // Tuple deconstruction
+            var (first, second) = GetTuple();
+
+            return $"{first},{second}";
+        }
+
+        [CompileTime]
+        private static (string, string) GetTuple()
+        {
+            return ("a", "b");
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method()
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionAfterReturn.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionAfterReturn.ct.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+#pragma warning disable CS0162 // Unreachable code detected
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleDeconstructionAfterReturn
+{
+  [CompileTime]
+  internal class Aspect
+  {
+    // Test tuple deconstruction with ParenthesizedVariableDesignation: var (x, y) = tuple;
+    private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+    {
+      List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+      bool __skip1 = false;
+      if (meta.Target.Method.Parameters.Count == 0)
+      {
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      SyntaxToken firstName = templateSyntaxFactory.GetUniqueIdentifier("first");
+      SyntaxToken secondName = templateSyntaxFactory.GetUniqueIdentifier("second");
+      if (__skip1)
+        goto __next1;
+      // var (first, second) = GetTuple();
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.ToStatement(templateSyntaxFactory.RewriteAssignmentExpression(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.DeclarationExpression(SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("var")), SyntaxFactory.ParenthesizedVariableDesignation(SyntaxFactory.Token(SyntaxKind.OpenParenToken), SyntaxFactory.SeparatedList<VariableDesignationSyntax>(new VariableDesignationSyntax[] { SyntaxFactory.SingleVariableDesignation(templateSyntaxFactory.EscapeIdentifier(firstName)), SyntaxFactory.SingleVariableDesignation(templateSyntaxFactory.EscapeIdentifier(secondName)) }), SyntaxFactory.Token(SyntaxKind.CloseParenToken))), SyntaxFactory.Token(SyntaxKind.EqualsToken), templateSyntaxFactory.Serialize<(string, string)>(Aspect.GetTuple())))));
+      __next1:
+        ;
+      if (__skip1)
+        goto __next2;
+      // return $"{first},{second}";
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RenderInterpolatedString(SyntaxFactory.InterpolatedStringExpression(SyntaxFactory.Token(SyntaxKind.InterpolatedStringStartToken), SyntaxFactory.List<InterpolatedStringContentSyntax>(new InterpolatedStringContentSyntax[] { templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(firstName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))), SyntaxFactory.InterpolatedStringText(SyntaxFactory.Token(default, SyntaxKind.InterpolatedStringTextToken, ",", ",", default)), templateSyntaxFactory.FixInterpolationSyntax(SyntaxFactory.Interpolation(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), SyntaxFactory.IdentifierName(templateSyntaxFactory.EscapeIdentifier(secondName)), null, null, SyntaxFactory.Token(SyntaxKind.CloseBraceToken))) }), SyntaxFactory.Token(SyntaxKind.InterpolatedStringEndToken))))));
+      __next2:
+        ;
+      return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+    }
+    [CompileTime]
+    private static (string, string) GetTuple()
+    {
+      return ("a", "b");
+    }
+  }
+  internal class TargetCode
+  {
+    // <target>
+    private object? Method()
+    {
+      return null;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionAfterReturn.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionAfterReturn.t.cs
@@ -1,0 +1,4 @@
+private object? Method()
+{
+  return null;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionExplicitVarTest.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionExplicitVarTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleDeconstructionExplicitVarTest
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test tuple deconstruction with explicit var for each element: (var x, var y) = tuple;
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // Tuple deconstruction with TupleExpressionSyntax: (var first, var second) = tuple;
+            (var first, var second) = GetTuple();
+
+            return $"{first},{second}";
+        }
+
+        [CompileTime]
+        private static (string, string) GetTuple()
+        {
+            return ("a", "b");
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method(int x)
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionExplicitVarTest.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionExplicitVarTest.ct.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+#pragma warning disable CS0162 // Unreachable code detected
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleDeconstructionExplicitVarTest
+{
+  [CompileTime]
+  internal class Aspect
+  {
+    // Test tuple deconstruction with explicit var for each element: (var x, var y) = tuple;
+    private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+    {
+      List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+      bool __skip1 = false;
+      if (meta.Target.Method.Parameters.Count == 0)
+      {
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      if (__skip1)
+        goto __next1;
+      (var first, var second) = Aspect.GetTuple();
+      __next1:
+        ;
+      Unsafe.SkipInit(out first);
+      Unsafe.SkipInit(out second);
+      if (__skip1)
+        goto __next2;
+      // return $"{first},{second}";
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression($"{first},{second}"), "Y:global::System.String!"))));
+      __next2:
+        ;
+      return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+    }
+    [CompileTime]
+    private static (string, string) GetTuple()
+    {
+      return ("a", "b");
+    }
+  }
+  internal class TargetCode
+  {
+    // <target>
+    private object? Method(int x)
+    {
+      return null;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionExplicitVarTest.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleDeconstructionExplicitVarTest.t.cs
@@ -1,0 +1,4 @@
+private object? Method(int x)
+{
+  return "a,b";
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleMixedDeconstructionTest.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleMixedDeconstructionTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @WriteCompiledTemplate
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0162 // Unreachable code detected
+
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleMixedDeconstructionTest
+{
+    [CompileTime]
+    internal class Aspect
+    {
+        // Test mixed tuple deconstruction: (var first, var (second, third))
+        // This combines TupleExpression syntax with nested ParenthesizedVariableDesignation
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            if ( meta.Target.Method.Parameters.Count == 0 )
+            {
+                return null;
+            }
+
+            // Mixed tuple deconstruction: (var first, var (second, third)) = tuple;
+            (var first, var (second, third)) = GetNestedTuple();
+
+            return $"{first},{second},{third}";
+        }
+
+        [CompileTime]
+        private static (string, (string, string)) GetNestedTuple()
+        {
+            return ("a", ("b", "c"));
+        }
+    }
+
+    internal class TargetCode
+    {
+        // <target>
+        private object? Method(int x)
+        {
+            return null;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleMixedDeconstructionTest.ct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleMixedDeconstructionTest.ct.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.CompileTimeContracts;
+using Metalama.Framework.Engine.Templating;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+#pragma warning disable CS0162 // Unreachable code detected
+namespace Metalama.Framework.Tests.TemplateTests.Return.TupleMixedDeconstructionTest
+{
+  [CompileTime]
+  internal class Aspect
+  {
+    // Test mixed tuple deconstruction: (var first, var (second, third))
+    // This combines TupleExpression syntax with nested ParenthesizedVariableDesignation
+    private SyntaxNode __Template(ITemplateSyntaxFactory templateSyntaxFactory)
+    {
+      List<StatementOrTrivia> __s1 = new List<StatementOrTrivia>();
+      bool __skip1 = false;
+      if (meta.Target.Method.Parameters.Count == 0)
+      {
+        // return null;
+        templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression, SyntaxFactory.Token(SyntaxKind.NullKeyword)))));
+        __skip1 = true;
+      }
+      if (__skip1)
+        goto __next1;
+      (var first, var(second, third)) = Aspect.GetNestedTuple();
+      __next1:
+        ;
+      Unsafe.SkipInit(out first);
+      Unsafe.SkipInit(out second);
+      Unsafe.SkipInit(out third);
+      if (__skip1)
+        goto __next2;
+      // return $"{first},{second},{third}";
+      templateSyntaxFactory.AddStatement(__s1, templateSyntaxFactory.AddSimplifierAnnotations(templateSyntaxFactory.ReturnStatement(templateSyntaxFactory.RunTimeExpression(templateSyntaxFactory.StringLiteralExpression($"{first},{second},{third}"), "Y:global::System.String!"))));
+      __next2:
+        ;
+      return SyntaxFactory.Block(default, templateSyntaxFactory.ToStatementList(__s1));
+    }
+    [CompileTime]
+    private static (string, (string, string)) GetNestedTuple()
+    {
+      return ("a", ("b", "c"));
+    }
+  }
+  internal class TargetCode
+  {
+    // <target>
+    private object? Method(int x)
+    {
+      return null;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleMixedDeconstructionTest.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Return/TupleMixedDeconstructionTest.t.cs
@@ -1,0 +1,4 @@
+private object? Method(int x)
+{
+  return "a,b,c";
+}


### PR DESCRIPTION
## Summary
- Fixed scoping bug where compile-time local variables declared after a compile-time early return were not visible to subsequent statements
- Implemented variable hoisting for compile-time variables (including out vars, tuple deconstruction, pattern matching) when they appear after conditional returns
- Added StatementCompileTimeVariableFinder to detect and hoist compile-time variable declarations outside of if (!__skip) blocks

## Issues Fixed
- #1275 
- #1277 

— Claude for gfraiteur