### PR TITLE
Support DOTNET_ROOT environment variables in PlatformInfo

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
@@ -122,6 +122,7 @@ public static class RegisterServiceExtensions
             .AddSingleton( _ => new EarlyLoggerFactory() )
             .AddSingleton( _ => new RandomNumberGenerator() )
             .AddSingleton<IEnvironmentVariableProvider>( new EnvironmentVariableProvider() )
+            .AddSingleton<IRuntimeInformation>( _ => new RuntimeInformationProvider() )
             .AddSingleton<IRecoverableExceptionService>( serviceProvider => new RecoverableExceptionService( serviceProvider ) )
             .AddSingleton<IApplicationInfoProvider>( new ApplicationInfoProvider( applicationInfo ) )
             .AddSingleton<IUserDeviceDetectionService>( serviceProvider => new WindowsUserDeviceDetectionService( serviceProvider ) )

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IRuntimeInformation.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IRuntimeInformation.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Extensibility;
+using System.Runtime.InteropServices;
+
+namespace Metalama.Backstage.Infrastructure;
+
+/// <summary>
+/// Provides runtime information about the current platform and process.
+/// </summary>
+public interface IRuntimeInformation : IBackstageService
+{
+    /// <summary>
+    /// Gets the platform on which the application is running.
+    /// </summary>
+    /// <param name="osPlatform">The platform to check.</param>
+    /// <returns>True if the application is running on the specified platform; otherwise, false.</returns>
+    bool IsOSPlatform( OSPlatform osPlatform );
+
+    /// <summary>
+    /// Gets the architecture of the running process.
+    /// </summary>
+    Architecture ProcessArchitecture { get; }
+
+    /// <summary>
+    /// Gets the architecture of the operating system.
+    /// </summary>
+    Architecture OSArchitecture { get; }
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
@@ -44,25 +44,8 @@ namespace Metalama.Backstage.Infrastructure
             // We no longer look for the current process being dotnet because of Rider. Rider runs in dotnet.exe, but this
             // instance of dotnet.exe does not have an SDK installed. So, it is better to ignore the current process as a hint.
 
-            // Check DOTNET_ROOT environment variables first.
-            if ( this.TryGetDotNetRootFromEnvironment( out var dotnetRoot, out var variableName ) )
-            {
-                var dotnetPath = Path.Combine( dotnetRoot, dotnetFileName );
-
-                if ( this._fileSystem.FileExists( dotnetPath ) )
-                {
-                    logger?.Trace?.Log( $"{dotnetFileName} found via {variableName}: '{dotnetPath}'." );
-
-                    return dotnetPath;
-                }
-                else
-                {
-                    logger?.Trace?.Log( $"{variableName} is set to '{dotnetRoot}' but {dotnetFileName} was not found there." );
-                }
-            }
-
-            // Search in default installation locations.
-            foreach ( var directory in this.GetDefaultDotNetDirectories() )
+            // Search in installation locations.
+            foreach ( var directory in this.GetDotNetDirectories() )
             {
                 var dotnetPath = Path.Combine( directory, dotnetFileName );
 
@@ -80,7 +63,6 @@ namespace Metalama.Backstage.Infrastructure
 
             // Explicitly resolve PATH, because in the Rider process, "dotnet" alone would resolve to Rider's limited dotnet.
             // While doing so, ignore Rider's ReSharperHost paths, which contain that dotnet.
-
             var path = this._environmentVariableProvider.GetEnvironmentVariable( "PATH" );
 
             if ( path != null )
@@ -118,13 +100,23 @@ namespace Metalama.Backstage.Infrastructure
         }
 
         /// <summary>
-        /// Gets the default .NET installation directories for the current platform.
-        /// Returns directories in priority order.
+        /// Gets the .NET installation directories for the current platform.
+        /// Returns directories in priority order: first based on environment variables, then on default locations.
         /// Reference: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
         /// </summary>
-        /// <returns>An enumerable of directory paths to check for .NET installations.</returns>
-        private IEnumerable<string> GetDefaultDotNetDirectories()
+        /// <returns>A list of directory paths to check for .NET installations.</returns>
+        private IEnumerable<string> GetDotNetDirectories()
         {
+            foreach ( var environmentVariableName in this.GetDotNetRootEnvironmentVariables() )
+            {
+                var environmentVariableValue = this._environmentVariableProvider.GetEnvironmentVariable( environmentVariableName );
+
+                if ( !string.IsNullOrWhiteSpace( environmentVariableValue ) )
+                {
+                    yield return environmentVariableValue!;
+                }
+            }
+
             if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) )
             {
                 // On Windows, %ProgramFiles% expands to the correct directory for the current architecture.
@@ -145,7 +137,7 @@ namespace Metalama.Backstage.Infrastructure
             }
             else if ( this._runtimeInformation.IsOSPlatform( OSPlatform.OSX ) )
             {
-                var baseDirectory = "/usr/local/share/dotnet";
+                const string baseDirectory = "/usr/local/share/dotnet";
 
                 // On ARM64 macOS running x64 process, check the x64 subfolder first.
                 if ( this._runtimeInformation.OSArchitecture == Architecture.Arm64 && this._runtimeInformation.ProcessArchitecture == Architecture.X64 )
@@ -158,11 +150,11 @@ namespace Metalama.Backstage.Infrastructure
             else if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Linux ) )
             {
                 // Common locations on Linux (priority order).
-                var linuxLocations = new[]
-                {
-                    "/usr/share/dotnet",  // packages.microsoft.com
-                    "/usr/lib/dotnet"     // Ubuntu Jammy feed
-                };
+                string[] linuxLocations =
+                [
+                    "/usr/share/dotnet", // packages.microsoft.com
+                    "/usr/lib/dotnet"    // Ubuntu Jammy feed
+                ];
 
                 // On ARM64 Linux running x64 process, check x64 subfolders first.
                 if ( this._runtimeInformation.OSArchitecture == Architecture.Arm64 && this._runtimeInformation.ProcessArchitecture == Architecture.X64 )
@@ -181,89 +173,40 @@ namespace Metalama.Backstage.Infrastructure
         }
 
         /// <summary>
-        /// Tries to get the .NET root directory from environment variables.
+        /// Gets the DOTNET_ROOT environment variable names to check in priority order.
         /// Precedence order follows the official .NET SDK specification:
         /// https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
         /// </summary>
-        /// <param name="path">The directory path of the .NET root, if found.</param>
-        /// <param name="variableName">The name of the environment variable that was matched.</param>
-        /// <returns>True if a DOTNET_ROOT environment variable was found; otherwise, false.</returns>
-        private bool TryGetDotNetRootFromEnvironment( [System.Diagnostics.CodeAnalysis.NotNullWhen( true )] out string? path, [System.Diagnostics.CodeAnalysis.NotNullWhen( true )] out string? variableName )
+        /// <returns>An enumerable of environment variable names in priority order.</returns>
+        private IEnumerable<string> GetDotNetRootEnvironmentVariables()
         {
-            string? dotnetRoot;
-
             // 1. Check architecture-specific variables first (highest priority).
             switch ( this._runtimeInformation.ProcessArchitecture )
             {
                 case Architecture.X64:
-                    dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT_X64" );
-
-                    if ( !string.IsNullOrEmpty( dotnetRoot ) )
-                    {
-                        path = dotnetRoot!;
-                        variableName = "DOTNET_ROOT_X64";
-
-                        return true;
-                    }
+                    yield return "DOTNET_ROOT_X64";
 
                     break;
 
                 case Architecture.X86:
-                    dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT_X86" );
-
-                    if ( !string.IsNullOrEmpty( dotnetRoot ) )
-                    {
-                        path = dotnetRoot!;
-                        variableName = "DOTNET_ROOT_X86";
-
-                        return true;
-                    }
+                    yield return "DOTNET_ROOT_X86";
 
                     // 2. For x86 on 64-bit Windows, check DOTNET_ROOT(x86) next.
                     if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) )
                     {
-                        dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT(x86)" );
-
-                        if ( !string.IsNullOrEmpty( dotnetRoot ) )
-                        {
-                            path = dotnetRoot!;
-                            variableName = "DOTNET_ROOT(x86)";
-
-                            return true;
-                        }
+                        yield return "DOTNET_ROOT(x86)";
                     }
 
                     break;
 
                 case Architecture.Arm64:
-                    dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT_ARM64" );
-
-                    if ( !string.IsNullOrEmpty( dotnetRoot ) )
-                    {
-                        path = dotnetRoot!;
-                        variableName = "DOTNET_ROOT_ARM64";
-
-                        return true;
-                    }
+                    yield return "DOTNET_ROOT_ARM64";
 
                     break;
             }
 
             // 3. Check generic DOTNET_ROOT as fallback (lowest priority).
-            dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT" );
-
-            if ( !string.IsNullOrEmpty( dotnetRoot ) )
-            {
-                path = dotnetRoot!;
-                variableName = "DOTNET_ROOT";
-
-                return true;
-            }
-
-            path = null;
-            variableName = null;
-
-            return false;
+            yield return "DOTNET_ROOT";
         }
     }
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
@@ -5,6 +5,7 @@
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -13,6 +14,9 @@ namespace Metalama.Backstage.Infrastructure
     internal sealed class PlatformInfo : IPlatformInfo
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly IEnvironmentVariableProvider _environmentVariableProvider;
+        private readonly IFileSystem _fileSystem;
+        private readonly IRuntimeInformation _runtimeInformation;
         private readonly Lazy<string> _dotNetExePath;
 
         public string DotNetExePath => this._dotNetExePath.Value;
@@ -20,6 +24,9 @@ namespace Metalama.Backstage.Infrastructure
         public PlatformInfo( IServiceProvider serviceProvider )
         {
             this._serviceProvider = serviceProvider;
+            this._environmentVariableProvider = serviceProvider.GetRequiredBackstageService<IEnvironmentVariableProvider>();
+            this._fileSystem = serviceProvider.GetRequiredBackstageService<IFileSystem>();
+            this._runtimeInformation = serviceProvider.GetRequiredBackstageService<IRuntimeInformation>();
 
             this._dotNetExePath = new Lazy<string>( this.GetDotNetPath );
         }
@@ -28,7 +35,7 @@ namespace Metalama.Backstage.Infrastructure
         {
             var logger = this._serviceProvider.GetBackstageService<EarlyLoggerFactory>()?.GetLogger( "PlatformInfo" );
 
-            var dotnetFileName = RuntimeInformation.IsOSPlatform( OSPlatform.Windows )
+            var dotnetFileName = this._runtimeInformation.IsOSPlatform( OSPlatform.Windows )
                 ? "dotnet.exe"
                 : "dotnet";
 
@@ -37,33 +44,48 @@ namespace Metalama.Backstage.Infrastructure
             // We no longer look for the current process being dotnet because of Rider. Rider runs in dotnet.exe, but this
             // instance of dotnet.exe does not have an SDK installed. So, it is better to ignore the current process as a hint.
 
-            // Search dotnet.exe in well-known locations.
-            if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+            // Check DOTNET_ROOT environment variables first.
+            if ( this.TryGetDotNetRootFromEnvironment( out var dotnetRoot, out var variableName ) )
             {
-                // %ProgramFiles% is expanded to the correct directory according to the current processor architecture.
-                // This is good because we always want to get dotnet.exe for the current processor architecture.
-                var dotnetPath = Environment.ExpandEnvironmentVariables( "%ProgramFiles%\\dotnet\\dotnet.exe" );
+                var dotnetPath = Path.Combine( dotnetRoot, dotnetFileName );
 
-                if ( File.Exists( dotnetPath ) )
+                if ( this._fileSystem.FileExists( dotnetPath ) )
                 {
-                    logger?.Trace?.Log( $"dotnet.exe found in '{dotnetPath}'." );
+                    logger?.Trace?.Log( $"{dotnetFileName} found via {variableName}: '{dotnetPath}'." );
 
                     return dotnetPath;
                 }
                 else
                 {
-                    logger?.Trace?.Log( $"Looked for dotnet.exe in '{dotnetPath}' but it did not exist." );
+                    logger?.Trace?.Log( $"{variableName} is set to '{dotnetRoot}' but {dotnetFileName} was not found there." );
+                }
+            }
+
+            // Search in default installation locations.
+            foreach ( var directory in this.GetDefaultDotNetDirectories() )
+            {
+                var dotnetPath = Path.Combine( directory, dotnetFileName );
+
+                if ( this._fileSystem.FileExists( dotnetPath ) )
+                {
+                    logger?.Trace?.Log( $"{dotnetFileName} found in default location '{dotnetPath}'." );
+
+                    return dotnetPath;
+                }
+                else
+                {
+                    logger?.Trace?.Log( $"Looked for {dotnetFileName} in default location '{dotnetPath}' but it did not exist." );
                 }
             }
 
             // Explicitly resolve PATH, because in the Rider process, "dotnet" alone would resolve to Rider's limited dotnet.
             // While doing so, ignore Rider's ReSharperHost paths, which contain that dotnet.
 
-            var path = Environment.GetEnvironmentVariable( "PATH" );
+            var path = this._environmentVariableProvider.GetEnvironmentVariable( "PATH" );
 
             if ( path != null )
             {
-                var splitCharacter = RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) ? ';' : ':';
+                var splitCharacter = this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) ? ';' : ':';
 
                 foreach ( var directory in path.Split( splitCharacter ) )
                 {
@@ -76,7 +98,7 @@ namespace Metalama.Backstage.Infrastructure
 
                     var dotnetPath = Path.Combine( directory, dotnetFileName );
 
-                    if ( File.Exists( dotnetPath ) )
+                    if ( this._fileSystem.FileExists( dotnetPath ) )
                     {
                         logger?.Trace?.Log( $"{dotnetFileName} found in '{dotnetPath}'." );
 
@@ -93,6 +115,155 @@ namespace Metalama.Backstage.Infrastructure
             logger?.Trace?.Log( $"{dotnetFileName} was found nowhere. We hope it will be in the PATH." );
 
             return "dotnet";
+        }
+
+        /// <summary>
+        /// Gets the default .NET installation directories for the current platform.
+        /// Returns directories in priority order.
+        /// Reference: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
+        /// </summary>
+        /// <returns>An enumerable of directory paths to check for .NET installations.</returns>
+        private IEnumerable<string> GetDefaultDotNetDirectories()
+        {
+            if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+            {
+                // On Windows, %ProgramFiles% expands to the correct directory for the current architecture.
+                var programFiles = this._environmentVariableProvider.GetEnvironmentVariable( "ProgramFiles" );
+
+                if ( programFiles != null )
+                {
+                    var baseDirectory = Path.Combine( programFiles, "dotnet" );
+
+                    // On ARM64 OS running x64 process, check the x64 subfolder first.
+                    if ( this._runtimeInformation.OSArchitecture == Architecture.Arm64 && this._runtimeInformation.ProcessArchitecture == Architecture.X64 )
+                    {
+                        yield return Path.Combine( baseDirectory, "x64" );
+                    }
+
+                    yield return baseDirectory;
+                }
+            }
+            else if ( this._runtimeInformation.IsOSPlatform( OSPlatform.OSX ) )
+            {
+                var baseDirectory = "/usr/local/share/dotnet";
+
+                // On ARM64 macOS running x64 process, check the x64 subfolder first.
+                if ( this._runtimeInformation.OSArchitecture == Architecture.Arm64 && this._runtimeInformation.ProcessArchitecture == Architecture.X64 )
+                {
+                    yield return Path.Combine( baseDirectory, "x64" );
+                }
+
+                yield return baseDirectory;
+            }
+            else if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Linux ) )
+            {
+                // Common locations on Linux (priority order).
+                var linuxLocations = new[]
+                {
+                    "/usr/share/dotnet",  // packages.microsoft.com
+                    "/usr/lib/dotnet"     // Ubuntu Jammy feed
+                };
+
+                // On ARM64 Linux running x64 process, check x64 subfolders first.
+                if ( this._runtimeInformation.OSArchitecture == Architecture.Arm64 && this._runtimeInformation.ProcessArchitecture == Architecture.X64 )
+                {
+                    foreach ( var location in linuxLocations )
+                    {
+                        yield return Path.Combine( location, "x64" );
+                    }
+                }
+
+                foreach ( var location in linuxLocations )
+                {
+                    yield return location;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tries to get the .NET root directory from environment variables.
+        /// Precedence order follows the official .NET SDK specification:
+        /// https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
+        /// </summary>
+        /// <param name="path">The directory path of the .NET root, if found.</param>
+        /// <param name="variableName">The name of the environment variable that was matched.</param>
+        /// <returns>True if a DOTNET_ROOT environment variable was found; otherwise, false.</returns>
+        private bool TryGetDotNetRootFromEnvironment( [System.Diagnostics.CodeAnalysis.NotNullWhen( true )] out string? path, [System.Diagnostics.CodeAnalysis.NotNullWhen( true )] out string? variableName )
+        {
+            string? dotnetRoot;
+
+            // 1. Check architecture-specific variables first (highest priority).
+            switch ( this._runtimeInformation.ProcessArchitecture )
+            {
+                case Architecture.X64:
+                    dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT_X64" );
+
+                    if ( !string.IsNullOrEmpty( dotnetRoot ) )
+                    {
+                        path = dotnetRoot!;
+                        variableName = "DOTNET_ROOT_X64";
+
+                        return true;
+                    }
+
+                    break;
+
+                case Architecture.X86:
+                    dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT_X86" );
+
+                    if ( !string.IsNullOrEmpty( dotnetRoot ) )
+                    {
+                        path = dotnetRoot!;
+                        variableName = "DOTNET_ROOT_X86";
+
+                        return true;
+                    }
+
+                    // 2. For x86 on 64-bit Windows, check DOTNET_ROOT(x86) next.
+                    if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+                    {
+                        dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT(x86)" );
+
+                        if ( !string.IsNullOrEmpty( dotnetRoot ) )
+                        {
+                            path = dotnetRoot!;
+                            variableName = "DOTNET_ROOT(x86)";
+
+                            return true;
+                        }
+                    }
+
+                    break;
+
+                case Architecture.Arm64:
+                    dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT_ARM64" );
+
+                    if ( !string.IsNullOrEmpty( dotnetRoot ) )
+                    {
+                        path = dotnetRoot!;
+                        variableName = "DOTNET_ROOT_ARM64";
+
+                        return true;
+                    }
+
+                    break;
+            }
+
+            // 3. Check generic DOTNET_ROOT as fallback (lowest priority).
+            dotnetRoot = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_ROOT" );
+
+            if ( !string.IsNullOrEmpty( dotnetRoot ) )
+            {
+                path = dotnetRoot!;
+                variableName = "DOTNET_ROOT";
+
+                return true;
+            }
+
+            path = null;
+            variableName = null;
+
+            return false;
         }
     }
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
@@ -75,7 +75,7 @@ namespace Metalama.Backstage.Infrastructure
                 }
                 else
                 {
-                    logger?.Warning?.Log( $"Looked for {dotnetFileName} in default location '{dotnetPath}' but it did not exist." );
+                    logger?.Trace?.Log( $"Looked for {dotnetFileName} in default location '{dotnetPath}' but it did not exist." );
                 }
             }
 
@@ -106,7 +106,7 @@ namespace Metalama.Backstage.Infrastructure
                     }
                     else
                     {
-                        logger?.Warning?.Log( $"Looked for {dotnetFileName} in '{dotnetPath}', but it did not exist." );
+                        logger?.Trace?.Log( $"Looked for {dotnetFileName} in '{dotnetPath}', but it did not exist." );
                     }
                 }
             }

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
@@ -44,7 +44,25 @@ namespace Metalama.Backstage.Infrastructure
             // We no longer look for the current process being dotnet because of Rider. Rider runs in dotnet.exe, but this
             // instance of dotnet.exe does not have an SDK installed. So, it is better to ignore the current process as a hint.
 
-            // Search in installation locations.
+            // 1. Check DOTNET_HOST_PATH first (highest priority).
+            // This is the absolute path to the dotnet host executable.
+            var dotnetHostPath = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_HOST_PATH" );
+
+            if ( !string.IsNullOrEmpty( dotnetHostPath ) )
+            {
+                if ( this._fileSystem.FileExists( dotnetHostPath ) )
+                {
+                    logger?.Trace?.Log( $"{dotnetFileName} found via DOTNET_HOST_PATH: '{dotnetHostPath}'." );
+
+                    return dotnetHostPath;
+                }
+                else
+                {
+                    logger?.Warning?.Log( $"DOTNET_HOST_PATH is set to '{dotnetHostPath}' but the file was not found." );
+                }
+            }
+
+            // 2. Search in installation locations.
             foreach ( var directory in this.GetDotNetDirectories() )
             {
                 var dotnetPath = Path.Combine( directory, dotnetFileName );
@@ -57,7 +75,7 @@ namespace Metalama.Backstage.Infrastructure
                 }
                 else
                 {
-                    logger?.Trace?.Log( $"Looked for {dotnetFileName} in default location '{dotnetPath}' but it did not exist." );
+                    logger?.Warning?.Log( $"Looked for {dotnetFileName} in default location '{dotnetPath}' but it did not exist." );
                 }
             }
 
@@ -88,20 +106,21 @@ namespace Metalama.Backstage.Infrastructure
                     }
                     else
                     {
-                        logger?.Trace?.Log( $"Looked for {dotnetFileName} in '{dotnetPath}', but it did not exist." );
+                        logger?.Warning?.Log( $"Looked for {dotnetFileName} in '{dotnetPath}', but it did not exist." );
                     }
                 }
             }
 
             // The file was not found.
-            logger?.Trace?.Log( $"{dotnetFileName} was found nowhere. We hope it will be in the PATH." );
+            logger?.Warning?.Log( $"{dotnetFileName} was found nowhere. We hope it will be in the PATH." );
 
             return "dotnet";
         }
 
         /// <summary>
         /// Gets the .NET installation directories for the current platform.
-        /// Returns directories in priority order: first based on environment variables, then on default locations.
+        /// Returns directories in priority order: first based on DOTNET_ROOT environment variables, then on default locations.
+        /// Note: DOTNET_HOST_PATH is checked separately before this method, as it specifies the full path to the executable.
         /// Reference: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
         /// </summary>
         /// <returns>A list of directory paths to check for .NET installations.</returns>

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/RuntimeInformationProvider.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/RuntimeInformationProvider.cs
@@ -6,6 +6,9 @@ using System.Runtime.InteropServices;
 
 namespace Metalama.Backstage.Infrastructure;
 
+/// <summary>
+/// Wraps the <see cref="RuntimeInformation"/> class as an <see cref="IRuntimeInformation"/>.
+/// </summary>
 internal sealed class RuntimeInformationProvider : IRuntimeInformation
 {
     public bool IsOSPlatform( OSPlatform osPlatform ) => RuntimeInformation.IsOSPlatform( osPlatform );

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/RuntimeInformationProvider.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/RuntimeInformationProvider.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Runtime.InteropServices;
+
+namespace Metalama.Backstage.Infrastructure;
+
+internal sealed class RuntimeInformationProvider : IRuntimeInformation
+{
+    public bool IsOSPlatform( OSPlatform osPlatform ) => RuntimeInformation.IsOSPlatform( osPlatform );
+
+    public Architecture ProcessArchitecture => RuntimeInformation.ProcessArchitecture;
+
+    public Architecture OSArchitecture => RuntimeInformation.OSArchitecture;
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestRuntimeInformation.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestRuntimeInformation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Infrastructure;
+using System.Runtime.InteropServices;
+
+namespace Metalama.Backstage.Testing;
+
+public sealed class TestRuntimeInformation : IRuntimeInformation
+{
+    public OSPlatform? Platform { get; set; }
+    public Architecture? TestProcessArchitecture { get; set; }
+    public Architecture? TestOSArchitecture { get; set; }
+
+    public bool IsOSPlatform( OSPlatform osPlatform )
+    {
+        if ( this.Platform == null )
+        {
+            return RuntimeInformation.IsOSPlatform( osPlatform );
+        }
+
+        return this.Platform.Value.Equals( osPlatform );
+    }
+
+    public Architecture ProcessArchitecture => this.TestProcessArchitecture ?? RuntimeInformation.ProcessArchitecture;
+
+    public Architecture OSArchitecture => this.TestOSArchitecture ?? RuntimeInformation.OSArchitecture;
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestRuntimeInformation.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestRuntimeInformation.cs
@@ -9,21 +9,26 @@ namespace Metalama.Backstage.Testing;
 
 public sealed class TestRuntimeInformation : IRuntimeInformation
 {
+    private readonly RuntimeInformationProvider _defaultValues = new();
+
     public OSPlatform? Platform { get; set; }
+
     public Architecture? TestProcessArchitecture { get; set; }
+
+    // ReSharper disable once InconsistentNaming
     public Architecture? TestOSArchitecture { get; set; }
 
     public bool IsOSPlatform( OSPlatform osPlatform )
     {
         if ( this.Platform == null )
         {
-            return RuntimeInformation.IsOSPlatform( osPlatform );
+            return this._defaultValues.IsOSPlatform( osPlatform );
         }
 
         return this.Platform.Value.Equals( osPlatform );
     }
 
-    public Architecture ProcessArchitecture => this.TestProcessArchitecture ?? RuntimeInformation.ProcessArchitecture;
+    public Architecture ProcessArchitecture => this.TestProcessArchitecture ?? this._defaultValues.ProcessArchitecture;
 
-    public Architecture OSArchitecture => this.TestOSArchitecture ?? RuntimeInformation.OSArchitecture;
+    public Architecture OSArchitecture => this.TestOSArchitecture ?? this._defaultValues.OSArchitecture;
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestsBase.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestsBase.cs
@@ -56,6 +56,8 @@ namespace Metalama.Backstage.Testing
 
         protected ITelemetryConfigurationService TelemetryConfigurationService => this._defaultTestContext.Value.TelemetryConfigurationService;
 
+        protected TestRuntimeInformation RuntimeInformation => this._defaultTestContext.Value.RuntimeInformation;
+
         protected virtual LicensingAuthority LicensingAuthority { get; } = LicensingAuthority.GetTestAuthority();
 
         private TestFileSystem? _uniqueFileSystem;
@@ -166,7 +168,8 @@ namespace Metalama.Backstage.Testing
             TestUserInterfaceService UserInterface,
             TestHttpClientFactory HttpClientFactory,
             ILicenseRegistrationService LicenseRegistrationService,
-            ITelemetryConfigurationService TelemetryConfigurationService );
+            ITelemetryConfigurationService TelemetryConfigurationService,
+            TestRuntimeInformation RuntimeInformation );
 
         private Services CreateServices( Action<ServiceProviderBuilder>? serviceBuilder = null, BackstageInitializationOptions? options = null )
         {
@@ -182,7 +185,8 @@ namespace Metalama.Backstage.Testing
                 (TestUserInterfaceService) serviceProvider.GetRequiredBackstageService<IUserInterfaceService>(),
                 (TestHttpClientFactory) serviceProvider.GetRequiredBackstageService<IHttpClientFactory>(),
                 serviceProvider.GetRequiredBackstageService<ILicenseRegistrationService>(),
-                serviceProvider.GetRequiredBackstageService<ITelemetryConfigurationService>() );
+                serviceProvider.GetRequiredBackstageService<ITelemetryConfigurationService>(),
+                (TestRuntimeInformation) serviceProvider.GetRequiredBackstageService<IRuntimeInformation>() );
         }
 
         private ServiceCollection CreateServiceCollection(
@@ -199,6 +203,7 @@ namespace Metalama.Backstage.Testing
                 .AddSingleton( new BackstageInitializationOptionsProvider( options ) )
                 .AddSingleton<IDateTimeProvider>( this.Time )
                 .AddSingleton<IProcessExecutor>( this.ProcessExecutor )
+                .AddSingleton<IRuntimeInformation>( _ => new TestRuntimeInformation() )
                 .AddSingleton<IPlatformInfo>( serviceProvider => new PlatformInfo( serviceProvider ) )
                 .AddSingleton( this.BackgroundTasks )
                 .AddSingleton<IHttpClientFactory>( _ => new TestHttpClientFactory() )

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
@@ -14,29 +14,22 @@ namespace Metalama.Backstage.Tests.Infrastructure;
 
 public sealed class PlatformInfoTests : TestsBase
 {
-    private readonly TestRuntimeInformation _runtime;
     private readonly IPlatformInfo _platformInfo;
 
     public PlatformInfoTests( ITestOutputHelper logger ) : base( logger )
     {
-        this._runtime = new TestRuntimeInformation();
         this._platformInfo = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>();
-    }
-
-    protected override void ConfigureServices( ServiceProviderBuilder services )
-    {
-        services.AddSingleton<IRuntimeInformation>( this._runtime );
     }
 
     [Fact]
     public void DOTNET_ROOT_X64_HasPrecedence_OnX64Process()
     {
         // Arrange
-        this._runtime.TestProcessArchitecture = Architecture.X64;
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var dotnetRootX64 = "C:\\custom\\dotnet64";
-        var dotnetRoot = "C:\\custom\\dotnet";
+        const string dotnetRootX64 = "C:\\custom\\dotnet64";
+        const string dotnetRoot = "C:\\custom\\dotnet";
         var dotnetExePath = Path.Combine( dotnetRootX64, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = dotnetRootX64;
@@ -56,11 +49,11 @@ public sealed class PlatformInfoTests : TestsBase
     public void DOTNET_ROOT_X86_HasPrecedence_OnX86Process()
     {
         // Arrange
-        this._runtime.TestProcessArchitecture = Architecture.X86;
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X86;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var dotnetRootX86 = "C:\\custom\\dotnet86";
-        var dotnetRoot = "C:\\custom\\dotnet";
+        const string dotnetRootX86 = "C:\\custom\\dotnet86";
+        const string dotnetRoot = "C:\\custom\\dotnet";
         var dotnetExePath = Path.Combine( dotnetRootX86, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X86"] = dotnetRootX86;
@@ -79,10 +72,10 @@ public sealed class PlatformInfoTests : TestsBase
     public void DOTNET_ROOT_Parentheses_X86_FallsBack_OnX86Windows()
     {
         // Arrange
-        this._runtime.TestProcessArchitecture = Architecture.X86;
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X86;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var dotnetRootX86Paren = "C:\\custom\\dotnet86paren";
+        const string dotnetRootX86Paren = "C:\\custom\\dotnet86paren";
         var dotnetExePath = Path.Combine( dotnetRootX86Paren, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT(x86)"] = dotnetRootX86Paren;
@@ -100,11 +93,11 @@ public sealed class PlatformInfoTests : TestsBase
     public void DOTNET_ROOT_ARM64_HasPrecedence_OnARM64Process()
     {
         // Arrange
-        this._runtime.TestProcessArchitecture = Architecture.Arm64;
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.Arm64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var dotnetRootArm64 = "C:\\custom\\dotnetarm64";
-        var dotnetRoot = "C:\\custom\\dotnet";
+        const string dotnetRootArm64 = "C:\\custom\\dotnetarm64";
+        const string dotnetRoot = "C:\\custom\\dotnet";
         var dotnetExePath = Path.Combine( dotnetRootArm64, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_ARM64"] = dotnetRootArm64;
@@ -123,10 +116,10 @@ public sealed class PlatformInfoTests : TestsBase
     public void DOTNET_ROOT_FallsBack_WhenArchSpecificNotSet()
     {
         // Arrange
-        this._runtime.TestProcessArchitecture = Architecture.X64;
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var dotnetRoot = "C:\\fallback\\dotnet";
+        const string dotnetRoot = "C:\\fallback\\dotnet";
         var dotnetExePath = Path.Combine( dotnetRoot, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
@@ -144,10 +137,10 @@ public sealed class PlatformInfoTests : TestsBase
     public void Windows_DefaultLocation_UsedWhenNoDOTNET_ROOT()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Windows;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
-        var programFiles = "C:\\Program Files";
+        const string programFiles = "C:\\Program Files";
         var dotnetExePath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
@@ -165,11 +158,11 @@ public sealed class PlatformInfoTests : TestsBase
     public void Windows_ARM64_X64Subfolder_CheckedFirst()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Windows;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
-        this._runtime.TestOSArchitecture = Architecture.Arm64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.TestOSArchitecture = Architecture.Arm64;
 
-        var programFiles = "C:\\Program Files";
+        const string programFiles = "C:\\Program Files";
         var x64DotnetPath = Path.Combine( programFiles, "dotnet", "x64", "dotnet.exe" );
         var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
 
@@ -191,8 +184,8 @@ public sealed class PlatformInfoTests : TestsBase
     public void MacOS_DefaultLocation_Used()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.OSX;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.OSX;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
         var dotnetPath = Path.Combine( "/usr/local/share/dotnet", "dotnet" );
         this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetPath )! );
@@ -209,9 +202,9 @@ public sealed class PlatformInfoTests : TestsBase
     public void MacOS_ARM64_X64Subfolder_CheckedFirst()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.OSX;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
-        this._runtime.TestOSArchitecture = Architecture.Arm64;
+        this.RuntimeInformation.Platform = OSPlatform.OSX;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.TestOSArchitecture = Architecture.Arm64;
 
         var x64DotnetPath = Path.Combine( "/usr/local/share/dotnet", "x64", "dotnet" );
         var defaultDotnetPath = Path.Combine( "/usr/local/share/dotnet", "dotnet" );
@@ -232,8 +225,8 @@ public sealed class PlatformInfoTests : TestsBase
     public void Linux_MicrosoftPackages_LocationCheckedFirst()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Linux;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Linux;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
         var microsoftPath = Path.Combine( "/usr/share/dotnet", "dotnet" );
         var ubuntuPath = Path.Combine( "/usr/lib/dotnet", "dotnet" );
@@ -254,8 +247,8 @@ public sealed class PlatformInfoTests : TestsBase
     public void Linux_UbuntuJammy_LocationUsedAsFallback()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Linux;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Linux;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
         var ubuntuPath = Path.Combine( "/usr/lib/dotnet", "dotnet" );
         this.FileSystem.CreateDirectory( Path.GetDirectoryName( ubuntuPath )! );
@@ -272,9 +265,9 @@ public sealed class PlatformInfoTests : TestsBase
     public void Linux_ARM64_X64Subfolder_CheckedFirst()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Linux;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
-        this._runtime.TestOSArchitecture = Architecture.Arm64;
+        this.RuntimeInformation.Platform = OSPlatform.Linux;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.TestOSArchitecture = Architecture.Arm64;
 
         var x64Path = Path.Combine( "/usr/share/dotnet", "x64", "dotnet" );
         var defaultPath = Path.Combine( "/usr/share/dotnet", "dotnet" );
@@ -295,9 +288,9 @@ public sealed class PlatformInfoTests : TestsBase
     public void PATH_Variable_UsedWhenNoDOTNET_ROOTOrDefaultLocation()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var customPath = "C:\\custom\\bin";
+        const string customPath = "C:\\custom\\bin";
         var dotnetExePath = Path.Combine( customPath, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["PATH"] = customPath;
@@ -315,10 +308,10 @@ public sealed class PlatformInfoTests : TestsBase
     public void ReSharperHost_DirectoriesExcluded_FromPATH()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        var riderPath = "C:\\Users\\test\\AppData\\Local\\JetBrains\\Installations\\ReSharperHost";
-        var validPath = "C:\\dotnet\\bin";
+        const string riderPath = "C:\\Users\\test\\AppData\\Local\\JetBrains\\Installations\\ReSharperHost";
+        const string validPath = "C:\\dotnet\\bin";
         var dotnetExePath = Path.Combine( validPath, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["PATH"] = $"{riderPath};{validPath}";
@@ -336,7 +329,7 @@ public sealed class PlatformInfoTests : TestsBase
     public void FallsBackTo_DotnetCommand_WhenNotFound()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -349,11 +342,11 @@ public sealed class PlatformInfoTests : TestsBase
     public void DOTNET_ROOT_PrecedesDefaultLocations()
     {
         // Arrange
-        this._runtime.Platform = OSPlatform.Windows;
-        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
-        var dotnetRoot = "C:\\custom\\dotnet";
-        var programFiles = "C:\\Program Files";
+        const string dotnetRoot = "C:\\custom\\dotnet";
+        const string programFiles = "C:\\Program Files";
         var customDotnetPath = Path.Combine( dotnetRoot, "dotnet.exe" );
         var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
 

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
@@ -22,6 +22,30 @@ public sealed class PlatformInfoTests : TestsBase
     }
 
     [Fact]
+    public void DOTNET_HOST_PATH_HasHighestPrecedence()
+    {
+        // Arrange
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+
+        const string dotnetHostPath = "C:\\host\\dotnet.exe";
+        const string dotnetRootX64 = "C:\\custom\\dotnet64";
+        const string dotnetRoot = "C:\\custom\\dotnet";
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_HOST_PATH"] = dotnetHostPath;
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = dotnetRootX64;
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetHostPath )! );
+        this.FileSystem.WriteAllText( dotnetHostPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetHostPath, result );
+    }
+
+    [Fact]
     public void DOTNET_ROOT_X64_HasPrecedence_OnX64Process()
     {
         // Arrange

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
@@ -1,0 +1,373 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Infrastructure;
+using Metalama.Backstage.Testing;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.Infrastructure;
+
+public sealed class PlatformInfoTests : TestsBase
+{
+    private readonly TestRuntimeInformation _runtime;
+    private readonly IPlatformInfo _platformInfo;
+
+    public PlatformInfoTests( ITestOutputHelper logger ) : base( logger )
+    {
+        this._runtime = new TestRuntimeInformation();
+        this._platformInfo = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>();
+    }
+
+    protected override void ConfigureServices( ServiceProviderBuilder services )
+    {
+        services.AddSingleton<IRuntimeInformation>( this._runtime );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_X64_HasPrecedence_OnX64Process()
+    {
+        // Arrange
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var dotnetRootX64 = "C:\\custom\\dotnet64";
+        var dotnetRoot = "C:\\custom\\dotnet";
+        var dotnetExePath = Path.Combine( dotnetRootX64, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = dotnetRootX64;
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
+        this.FileSystem.CreateDirectory( dotnetRootX64 );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_X86_HasPrecedence_OnX86Process()
+    {
+        // Arrange
+        this._runtime.TestProcessArchitecture = Architecture.X86;
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var dotnetRootX86 = "C:\\custom\\dotnet86";
+        var dotnetRoot = "C:\\custom\\dotnet";
+        var dotnetExePath = Path.Combine( dotnetRootX86, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X86"] = dotnetRootX86;
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_Parentheses_X86_FallsBack_OnX86Windows()
+    {
+        // Arrange
+        this._runtime.TestProcessArchitecture = Architecture.X86;
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var dotnetRootX86Paren = "C:\\custom\\dotnet86paren";
+        var dotnetExePath = Path.Combine( dotnetRootX86Paren, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT(x86)"] = dotnetRootX86Paren;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_ARM64_HasPrecedence_OnARM64Process()
+    {
+        // Arrange
+        this._runtime.TestProcessArchitecture = Architecture.Arm64;
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var dotnetRootArm64 = "C:\\custom\\dotnetarm64";
+        var dotnetRoot = "C:\\custom\\dotnet";
+        var dotnetExePath = Path.Combine( dotnetRootArm64, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_ARM64"] = dotnetRootArm64;
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_FallsBack_WhenArchSpecificNotSet()
+    {
+        // Arrange
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var dotnetRoot = "C:\\fallback\\dotnet";
+        var dotnetExePath = Path.Combine( dotnetRoot, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void Windows_DefaultLocation_UsedWhenNoDOTNET_ROOT()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Windows;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+
+        var programFiles = "C:\\Program Files";
+        var dotnetExePath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void Windows_ARM64_X64Subfolder_CheckedFirst()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Windows;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this._runtime.TestOSArchitecture = Architecture.Arm64;
+
+        var programFiles = "C:\\Program Files";
+        var x64DotnetPath = Path.Combine( programFiles, "dotnet", "x64", "dotnet.exe" );
+        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64DotnetPath )! );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
+        this.FileSystem.WriteAllText( x64DotnetPath, string.Empty );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
+        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( x64DotnetPath, result );
+    }
+
+    [Fact]
+    public void MacOS_DefaultLocation_Used()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.OSX;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+
+        var dotnetPath = Path.Combine( "/usr/local/share/dotnet", "dotnet" );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetPath )! );
+        this.FileSystem.WriteAllText( dotnetPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetPath, result );
+    }
+
+    [Fact]
+    public void MacOS_ARM64_X64Subfolder_CheckedFirst()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.OSX;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this._runtime.TestOSArchitecture = Architecture.Arm64;
+
+        var x64DotnetPath = Path.Combine( "/usr/local/share/dotnet", "x64", "dotnet" );
+        var defaultDotnetPath = Path.Combine( "/usr/local/share/dotnet", "dotnet" );
+
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64DotnetPath )! );
+        this.FileSystem.WriteAllText( x64DotnetPath, string.Empty );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
+        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( x64DotnetPath, result );
+    }
+
+    [Fact]
+    public void Linux_MicrosoftPackages_LocationCheckedFirst()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Linux;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+
+        var microsoftPath = Path.Combine( "/usr/share/dotnet", "dotnet" );
+        var ubuntuPath = Path.Combine( "/usr/lib/dotnet", "dotnet" );
+
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( microsoftPath )! );
+        this.FileSystem.WriteAllText( microsoftPath, string.Empty );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( ubuntuPath )! );
+        this.FileSystem.WriteAllText( ubuntuPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( microsoftPath, result );
+    }
+
+    [Fact]
+    public void Linux_UbuntuJammy_LocationUsedAsFallback()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Linux;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+
+        var ubuntuPath = Path.Combine( "/usr/lib/dotnet", "dotnet" );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( ubuntuPath )! );
+        this.FileSystem.WriteAllText( ubuntuPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( ubuntuPath, result );
+    }
+
+    [Fact]
+    public void Linux_ARM64_X64Subfolder_CheckedFirst()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Linux;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+        this._runtime.TestOSArchitecture = Architecture.Arm64;
+
+        var x64Path = Path.Combine( "/usr/share/dotnet", "x64", "dotnet" );
+        var defaultPath = Path.Combine( "/usr/share/dotnet", "dotnet" );
+
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64Path )! );
+        this.FileSystem.WriteAllText( x64Path, string.Empty );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultPath )! );
+        this.FileSystem.WriteAllText( defaultPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( x64Path, result );
+    }
+
+    [Fact]
+    public void PATH_Variable_UsedWhenNoDOTNET_ROOTOrDefaultLocation()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var customPath = "C:\\custom\\bin";
+        var dotnetExePath = Path.Combine( customPath, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["PATH"] = customPath;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void ReSharperHost_DirectoriesExcluded_FromPATH()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Windows;
+
+        var riderPath = "C:\\Users\\test\\AppData\\Local\\JetBrains\\Installations\\ReSharperHost";
+        var validPath = "C:\\dotnet\\bin";
+        var dotnetExePath = Path.Combine( validPath, "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["PATH"] = $"{riderPath};{validPath}";
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( dotnetExePath, result );
+    }
+
+    [Fact]
+    public void FallsBackTo_DotnetCommand_WhenNotFound()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Windows;
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( "dotnet", result );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_PrecedesDefaultLocations()
+    {
+        // Arrange
+        this._runtime.Platform = OSPlatform.Windows;
+        this._runtime.TestProcessArchitecture = Architecture.X64;
+
+        var dotnetRoot = "C:\\custom\\dotnet";
+        var programFiles = "C:\\Program Files";
+        var customDotnetPath = Path.Combine( dotnetRoot, "dotnet.exe" );
+        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( customDotnetPath )! );
+        this.FileSystem.WriteAllText( customDotnetPath, string.Empty );
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
+        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert
+        Assert.Equal( customDotnetPath, result );
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
@@ -58,7 +58,6 @@ public sealed class PlatformInfoTests : TestsBase
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = dotnetRootX64;
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
-        this.FileSystem.CreateDirectory( dotnetRootX64 );
         this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
         this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
 
@@ -194,7 +193,6 @@ public sealed class PlatformInfoTests : TestsBase
         this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64DotnetPath )! );
         this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
         this.FileSystem.WriteAllText( x64DotnetPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
         this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
 
         // Act


### PR DESCRIPTION
## Summary
- Add support for DOTNET_ROOT environment variables (DOTNET_ROOT, DOTNET_ROOT_X64, DOTNET_ROOT_X86, DOTNET_ROOT_ARM64, DOTNET_ROOT(x86))
- Implement correct precedence order per .NET SDK specification
- Improve platform-specific default location detection for Windows, macOS, and Linux
- Add ARM64 OS with x64 process subfolder support
- Make PlatformInfo fully testable with dependency injection (IRuntimeInformation, IEnvironmentVariableProvider, IFileSystem)
- Add comprehensive test coverage with 16 tests

## Issues Fixed
- #1285 - Build error in Azure DevOps: dotnet.exe cannot be found

— Claude for Gael
