### PR TITLE
Add extension member invoker tests (#1036)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/ExtensionMembers_Invoker.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/ExtensionMembers_Invoker.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_5_0_0_OR_GREATER)
+// @RequiredConstant(NET8_0_OR_GREATER)
+// @FormatOutput
+#endif
+
+#if ROSLYN_5_0_0_OR_GREATER
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.ExtensionMembers_Invoker;
+
+/// <summary>
+/// Tests invoking extension members from an aspect template using the invoker API.
+/// </summary>
+internal class InvokeExtensionMemberAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var declaringType = meta.Target.Method.DeclaringType;
+
+        // Find the extension block and invoke its members.
+        foreach ( var extensionBlock in declaringType.ExtensionBlocks )
+        {
+            foreach ( var method in extensionBlock.Methods )
+            {
+                if ( !method.IsStatic && method.Parameters.Count == 0 )
+                {
+                    // Invoke instance extension method with the receiver from meta.Target.Parameters.
+                    method.WithObject( meta.Target.Parameters[0] ).Invoke();
+                }
+                else if ( method.IsStatic && method.Parameters.Count == 0 )
+                {
+                    // Invoke static extension method.
+                    method.Invoke();
+                }
+            }
+
+            foreach ( var property in extensionBlock.Properties )
+            {
+                if ( !property.IsStatic )
+                {
+                    // Access instance extension property.
+                    var value = property.WithObject( meta.Target.Parameters[0] ).Value;
+                    Console.WriteLine( value );
+                }
+                else
+                {
+                    // Access static extension property.
+                    var value = property.Value;
+                    Console.WriteLine( value );
+                }
+            }
+        }
+
+        return default;
+    }
+}
+
+// <target>
+internal static class C
+{
+    extension( TestClass receiver )
+    {
+        public void InstanceMethod() => Console.WriteLine( "Instance method called" );
+
+        public static void StaticMethod() => Console.WriteLine( "Static method called" );
+
+        public string InstanceProperty => "Instance property value";
+
+        public static string StaticProperty => "Static property value";
+    }
+
+    [InvokeExtensionMemberAspect]
+    public static void TestMethod( TestClass target )
+    {
+    }
+}
+
+internal class TestClass { }
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/ExtensionMembers_Invoker.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/ExtensionMembers_Invoker.cs
@@ -11,7 +11,6 @@
 #if ROSLYN_5_0_0_OR_GREATER
 
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
 using System;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.ExtensionMembers_Invoker;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/ExtensionMembers_Invoker.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/ExtensionMembers_Invoker.t.cs
@@ -1,0 +1,20 @@
+internal static class C
+{
+  extension(TestClass receiver)
+  {
+    public void InstanceMethod() => Console.WriteLine("Instance method called");
+    public static void StaticMethod() => Console.WriteLine("Static method called");
+    public string InstanceProperty => "Instance property value";
+    public static string StaticProperty => "Static property value";
+  }
+  [InvokeExtensionMemberAspect]
+  public static void TestMethod(TestClass target)
+  {
+    InstanceMethod(target);
+    StaticMethod();
+    var value = get_InstanceProperty(target);
+    Console.WriteLine(value);
+    var value_1 = get_StaticProperty();
+    Console.WriteLine(value_1);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/InvokerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/InvokerTests.cs
@@ -532,5 +532,291 @@ class TargetCode
                     """ );
             }
         }
+
+#if ROSLYN_5_0_0_OR_GREATER && NET7_0_OR_GREATER
+        [Fact]
+        public void ExtensionMethods()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension(int receiver)
+                                    {
+                                        public void InstanceMethod(string arg) { }
+                                        public int InstanceMethodWithReturn() => 0;
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var instanceMethod = extensionBlock.Methods.OfName( "InstanceMethod" ).Single();
+            var instanceMethodWithReturn = extensionBlock.Methods.OfName( "InstanceMethodWithReturn" ).Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, instanceMethod );
+            var generator = syntaxSerializationContext.SyntaxGenerationContext.SyntaxGenerator;
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                var receiverExpr = new TypedExpressionSyntaxImpl( generator.IdentifierName( "receiver" ), compilation );
+                var argExpr = new TypedExpressionSyntaxImpl( SyntaxFactoryEx.LiteralExpression( "x" ), compilation );
+
+                // Instance method with argument.
+                AssertEx.DynamicEquals(
+                    instanceMethod.WithObject( receiverExpr ).Invoke( argExpr ),
+                    @"global::C.InstanceMethod((global::System.Int32)receiver, (global::System.String)""x"")" );
+
+                // Instance method without arguments.
+                AssertEx.DynamicEquals(
+                    instanceMethodWithReturn.WithObject( receiverExpr ).Invoke(),
+                    @"global::C.InstanceMethodWithReturn((global::System.Int32)receiver)" );
+            }
+        }
+
+        [Fact]
+        public void ExtensionMethods_Static()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension(int receiver)
+                                    {
+                                        public static void StaticMethod(string arg) { }
+                                        public static int StaticMethodNoArgs() => 42;
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var staticMethod = extensionBlock.Methods.OfName( "StaticMethod" ).Single();
+            var staticMethodNoArgs = extensionBlock.Methods.OfName( "StaticMethodNoArgs" ).Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, staticMethod );
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                var argExpr = new TypedExpressionSyntaxImpl( SyntaxFactoryEx.LiteralExpression( "x" ), compilation );
+
+                // Static method with argument (no receiver needed).
+                AssertEx.DynamicEquals(
+                    staticMethod.Invoke( argExpr ),
+                    @"global::C.StaticMethod((global::System.String)""x"")" );
+
+                // Static method without arguments.
+                AssertEx.DynamicEquals(
+                    staticMethodNoArgs.Invoke(),
+                    @"global::C.StaticMethodNoArgs()" );
+            }
+        }
+
+        [Fact]
+        public void ExtensionProperties()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension(int receiver)
+                                    {
+                                        public string Prop { get => null; set { } }
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var property = extensionBlock.Properties.Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, property );
+            var generator = syntaxSerializationContext.SyntaxGenerationContext.SyntaxGenerator;
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                var receiverExpr = new TypedExpressionSyntaxImpl( generator.IdentifierName( "receiver" ), compilation );
+
+                // Getter.
+                AssertEx.DynamicEquals(
+                    property.WithObject( receiverExpr ).Value,
+                    @"global::C.get_Prop((global::System.Int32)receiver)" );
+
+                // Setter.
+                AssertEx.DynamicEquals(
+                    ((FieldOrPropertyInvoker) property.WithObject( receiverExpr )).SetValue( SyntaxFactoryEx.SafeIdentifierName( "value" ) ),
+                    @"global::C.set_Prop((global::System.Int32)receiver, (global::System.String)value)" );
+            }
+        }
+
+        [Fact]
+        public void ExtensionProperties_Static()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension(int receiver)
+                                    {
+                                        public static string StaticProp { get => null; set { } }
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var property = extensionBlock.Properties.Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, property );
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                // Static property getter (no receiver needed).
+                AssertEx.DynamicEquals(
+                    property.Value,
+                    @"global::C.get_StaticProp()" );
+
+                // Static property setter (no receiver needed).
+                // Must use WithObject(null) to get the invoker for a static property.
+                AssertEx.DynamicEquals(
+                    ((FieldOrPropertyInvoker) property.WithObject( null )).SetValue( SyntaxFactoryEx.SafeIdentifierName( "value" ) ),
+                    @"global::C.set_StaticProp((global::System.String)value)" );
+            }
+        }
+
+        [Fact]
+        public void ExtensionMethods_Generics()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension<T>(T receiver) where T : class
+                                    {
+                                        public void GenericMethod() { }
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var method = extensionBlock.Methods.Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, method );
+            var generator = syntaxSerializationContext.SyntaxGenerationContext.SyntaxGenerator;
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                var receiverExpr = new TypedExpressionSyntaxImpl( generator.IdentifierName( "receiver" ), compilation );
+
+                // Generic extension method.
+                AssertEx.DynamicEquals(
+                    method.WithObject( receiverExpr ).Invoke(),
+                    @"global::C.GenericMethod<T>((T)receiver)" );
+            }
+        }
+
+        [Fact]
+        public void ExtensionMethods_WithRefParameters()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension(int receiver)
+                                    {
+                                        public void ByRefMethod(out int o, ref string s) { o = 0; }
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var method = extensionBlock.Methods.Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, method );
+            var generator = syntaxSerializationContext.SyntaxGenerationContext.SyntaxGenerator;
+            var intType = compilation.Factory.GetTypeByReflectionType( typeof(int) );
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                var receiverExpr = new TypedExpressionSyntaxImpl( generator.IdentifierName( "receiver" ), compilation );
+
+                // Extension method with out/ref parameters.
+                AssertEx.DynamicEquals(
+                    method.WithObject( receiverExpr ).Invoke(
+                        new TypedExpressionSyntaxImpl( generator.IdentifierName( "x" ), intType, compilation, isReferenceable: true ),
+                        new TypedExpressionSyntaxImpl( generator.IdentifierName( "y" ), intType, compilation, isReferenceable: true ) ),
+                    @"global::C.ByRefMethod((global::System.Int32)receiver, out x, ref y)" );
+            }
+        }
+
+        [Fact]
+        public void ExtensionPropertyAccessors()
+        {
+            const string code = """
+                                static class C
+                                {
+                                    extension(int receiver)
+                                    {
+                                        public string Prop { get => null; set { } }
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+            var serviceProvider = testContext.ServiceProvider;
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single();
+            var extensionBlock = type.ExtensionBlocks.Single();
+            var property = extensionBlock.Properties.Single();
+
+            var syntaxSerializationContext = new SyntaxSerializationContext( compilation, SyntaxGenerationOptions.Formatted, property );
+            var generator = syntaxSerializationContext.SyntaxGenerationContext.SyntaxGenerator;
+
+            using ( TemplateExpansionContext.WithTestingContext(
+                       syntaxSerializationContext,
+                       serviceProvider ) )
+            {
+                var receiverExpr = new TypedExpressionSyntaxImpl( generator.IdentifierName( "receiver" ), compilation );
+
+                // Invoke getter as method - matches the PropertyAccessors test pattern.
+                AssertEx.DynamicEquals(
+                    property.GetMethod!.WithObject( receiverExpr ).Invoke(),
+                    @"global::C.get_Prop((global::System.Int32)receiver)" );
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
## Summary

- Add 7 unit tests for C# 14 extension member invocation in `InvokerTests.cs`
- Add aspect test demonstrating extension member invoker behavior with formatting
- Tests verify correct syntax generation for extension implementation method calls

## Tests Added

**Unit tests** (`InvokerTests.cs`):
- `ExtensionMethods`: instance extension method invocation
- `ExtensionMethods_Static`: static extension method invocation
- `ExtensionProperties`: extension property get/set
- `ExtensionProperties_Static`: static extension property get/set
- `ExtensionMethods_Generics`: generic extension block methods
- `ExtensionMethods_WithRefParameters`: out/ref parameter handling
- `ExtensionPropertyAccessors`: property getter accessor invocation

**Aspect test** (`ExtensionMembers_Invoker.cs`):
- Demonstrates invoking extension members from aspect templates
- Verifies Roslyn Simplifier removes unnecessary qualification

## Issues Fixed

- #1036 - Extension member invoker tests

---
*— Claude for @gfraiteur*