### PR TITLE
Fix partial constructor parameter introduction (#1143)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RestorePrerelease>true</RestorePrerelease>
   </PropertyGroup>
   <PropertyGroup>
-    <PostSharpEngineeringVersion Condition="'$(PostSharpEngineeringVersion)'==''">2023.2.312</PostSharpEngineeringVersion>
+    <PostSharpEngineeringVersion Condition="'$(PostSharpEngineeringVersion)'==''">2023.2.313</PostSharpEngineeringVersion>
 
     <!-- We must match the version used by the lowest version of Visual Studio supported by the VSX, i.e. VS 17.12. -->
     <NewtonsoftJsonMinVersion>13.0.3</NewtonsoftJsonMinVersion>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -1146,9 +1146,10 @@ internal sealed partial class LinkerInjectionStep
             var semanticModel = this._semanticModelProvider.GetSemanticModel( originalNode.SyntaxTree );
             var symbol = semanticModel.GetDeclaredSymbol( originalNode );
 
+            // Transformations are keyed by the original syntax node, so we use originalNode for the lookup.
             // For partial constructor definitions, transformations are stored under the implementation part's syntax,
             // so we need to look up using the implementation syntax instead.
-            SyntaxNode lookupNode = node;
+            SyntaxNode lookupNode = originalNode;
 #if ROSLYN_5_0_0_OR_GREATER
             if ( symbol is { IsPartialDefinition: true, PartialImplementationPart: { } implementationPart } )
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -565,8 +565,7 @@ internal sealed partial class LinkerInjectionStep
                                 injectedExtensionBlockMembers,
                                 syntaxGenerationContext );
 
-                            injectedNode = extensionBlockDeclaration.WithMembers(
-                                extensionBlockDeclaration.Members.AddRange( injectedExtensionBlockMembers ) );
+                            injectedNode = extensionBlockDeclaration.WithMembers( extensionBlockDeclaration.Members.AddRange( injectedExtensionBlockMembers ) );
 
                             // Extension blocks don't implement interfaces.
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -1144,14 +1144,37 @@ internal sealed partial class LinkerInjectionStep
 
             node = (ConstructorDeclarationSyntax) this.VisitConstructorDeclaration( node )!;
 
-            if ( this._transformationCollection.TryGetMemberLevelTransformations( node, out var memberLevelTransformations ) )
-            {
-                var syntaxGenerationContext = this.CompilationContext.GetSyntaxGenerationContext( this.SyntaxGenerationOptions, node );
-                node = this.ApplyMemberLevelTransformations( node, memberLevelTransformations, syntaxGenerationContext );
-            }
-
             var semanticModel = this._semanticModelProvider.GetSemanticModel( originalNode.SyntaxTree );
             var symbol = semanticModel.GetDeclaredSymbol( originalNode );
+
+            // For partial constructor definitions, transformations are stored under the implementation part's syntax,
+            // so we need to look up using the implementation syntax instead.
+            SyntaxNode lookupNode = node;
+#if ROSLYN_5_0_0_OR_GREATER
+            if ( symbol is { IsPartialDefinition: true, PartialImplementationPart: { } implementationPart } )
+            {
+                lookupNode = implementationPart.GetPrimaryDeclarationSyntax()!;
+            }
+#endif
+
+            if ( this._transformationCollection.TryGetMemberLevelTransformations( lookupNode, out var memberLevelTransformations ) )
+            {
+                var syntaxGenerationContext = this.CompilationContext.GetSyntaxGenerationContext( this.SyntaxGenerationOptions, node );
+
+#if ROSLYN_5_0_0_OR_GREATER
+                if ( symbol is { IsPartialDefinition: true } )
+                {
+                    // For partial constructor definitions, only apply parameter transformations (not initializer arguments,
+                    // since the definition doesn't have an initializer).
+                    node = node.WithParameterList(
+                        this.AppendParameters( node.ParameterList, memberLevelTransformations.Parameters, syntaxGenerationContext ) );
+                }
+                else
+#endif
+                {
+                    node = this.ApplyMemberLevelTransformations( node, memberLevelTransformations, syntaxGenerationContext );
+                }
+            }
 
 #if ROSLYN_5_0_0_OR_GREATER
             if ( symbol is { PartialImplementationPart: null } )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
@@ -12,7 +12,6 @@ using Metalama.Framework.Engine.AdviceImpl.Introduction;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Abstractions;
 using Metalama.Framework.Engine.CodeModel.Helpers;
-using ModifierCategories = Metalama.Framework.Engine.CodeModel.Helpers.ModifierCategories;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.Introductions.Introduced;
 using Metalama.Framework.Engine.CodeModel.References;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
@@ -12,6 +12,7 @@ using Metalama.Framework.Engine.AdviceImpl.Introduction;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Abstractions;
 using Metalama.Framework.Engine.CodeModel.Helpers;
+using ModifierCategories = Metalama.Framework.Engine.CodeModel.Helpers.ModifierCategories;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.Introductions.Introduced;
 using Metalama.Framework.Engine.CodeModel.References;
@@ -407,10 +408,12 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                     continue;
                 }
 
+                // For generated constructors, exclude the Partial modifier. C# 14 partial constructors require matching
+                // definition and implementation parts, but design-time generated constructors are standalone.
                 constructors.Add(
                     ConstructorDeclaration(
                         List<AttributeListSyntax>(),
-                        finalConstructor.GetSyntaxModifierList(),
+                        finalConstructor.GetSyntaxModifierList( ModifierCategories.All & ~ModifierCategories.Partial ),
                         SyntaxFactoryEx.SafeIdentifier( finalConstructor.DeclaringType.Name ),
                         syntaxGenerationContext.SyntaxGenerator.ParameterList( finalParameters, initialCompilationModel ),
                         initialConstructor.IsImplicitlyDeclared
@@ -447,7 +450,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                         constructors.Add(
                             ConstructorDeclaration(
                                 List<AttributeListSyntax>(),
-                                initialConstructor.GetSyntaxModifierList(),
+                                initialConstructor.GetSyntaxModifierList( ModifierCategories.All & ~ModifierCategories.Partial ),
                                 SyntaxFactoryEx.SafeIdentifier( initialConstructor.DeclaringType.Name ),
                                 syntaxGenerationContext.SyntaxGenerator.ParameterList( nonOptionalParameters, initialCompilationModel ),
                                 ConstructorInitializer(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/WithParameterAttributeModification.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/WithParameterAttributeModification.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Code.DeclarationBuilders;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.AppendParameter.WithParameterAttributeModification;
+
+/*
+ * Regression test: When an aspect both modifies parameter attributes AND introduces a parameter,
+ * the IntroduceParameter transformation should still be applied. This tests that the transformation
+ * lookup uses the original syntax node, not the rewritten node after visiting children.
+ */
+
+public class MyAttribute : Attribute { }
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        foreach ( var constructor in builder.Target.Constructors )
+        {
+            // First, add an attribute to the existing parameter.
+            // This will cause the parameter node to change during VisitParameter.
+            foreach ( var parameter in constructor.Parameters )
+            {
+                builder.With( parameter ).IntroduceAttribute( AttributeConstruction.Create( typeof(MyAttribute) ) );
+            }
+
+            // Then, introduce a new parameter.
+            // If the bug exists, this transformation will be lost because the constructor node changed.
+            builder.With( constructor ).IntroduceParameter( "introduced", typeof(int), TypedConstant.Create( 42 ) );
+        }
+    }
+}
+
+// <target>
+[MyAspect]
+internal class C
+{
+    public C( int x )
+    {
+        Console.WriteLine( $"x={x}" );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/WithParameterAttributeModification.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/AppendParameter/WithParameterAttributeModification.t.cs
@@ -1,0 +1,8 @@
+[MyAspect]
+internal class C
+{
+  public C([global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.AppendParameter.WithParameterAttributeModification.MyAttribute] int x, global::System.Int32 introduced = 42)
+  {
+    Console.WriteLine($"x={x}");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter.cs
@@ -18,7 +18,7 @@ public class TheAspect : TypeAspect
 {
     public override void BuildAspect( IAspectBuilder<INamedType> builder )
     {
-        foreach (var constructor in builder.Target.Constructors)
+        foreach ( var constructor in builder.Target.Constructors )
         {
             builder.With( constructor ).IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_5_0_0_OR_GREATER)
+#endif
+
+#if ROSLYN_5_0_0_OR_GREATER
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.PartialConstructor_IntroduceParameter;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        foreach (var constructor in builder.Target.Constructors)
+        {
+            builder.With( constructor ).IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
+        }
+    }
+}
+
+// <target>
+[TheAspect]
+internal partial class ClassWithPartialConstructor
+{
+    public partial ClassWithPartialConstructor( int x );
+
+    public partial ClassWithPartialConstructor( int x )
+    {
+        Console.WriteLine( $"x={x}" );
+    }
+}
+
+// <target>
+[TheAspect]
+internal partial class ClassWithTwoPartialConstructors
+{
+    public partial ClassWithTwoPartialConstructors();
+
+    public partial ClassWithTwoPartialConstructors()
+    {
+        Console.WriteLine( "Default" );
+    }
+
+    public partial ClassWithTwoPartialConstructors( string s );
+
+    public partial ClassWithTwoPartialConstructors( string s )
+    {
+        Console.WriteLine( s );
+    }
+}
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter.t.cs
@@ -1,0 +1,26 @@
+// Warning CS1066 on `p`: `The default value specified for parameter 'p' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments`
+// Warning CS1066 on `p`: `The default value specified for parameter 'p' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments`
+// Warning CS1066 on `p`: `The default value specified for parameter 'p' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments`
+[TheAspect]
+internal partial class ClassWithPartialConstructor
+{
+  public partial ClassWithPartialConstructor(int x, global::System.Int32 p = 42);
+  public partial ClassWithPartialConstructor(int x, global::System.Int32 p = 42)
+  {
+    Console.WriteLine($"x={x}");
+  }
+}
+[TheAspect]
+internal partial class ClassWithTwoPartialConstructors
+{
+  public partial ClassWithTwoPartialConstructors(global::System.Int32 p = 42);
+  public partial ClassWithTwoPartialConstructors(global::System.Int32 p = 42)
+  {
+    Console.WriteLine("Default");
+  }
+  public partial ClassWithTwoPartialConstructors(string s, global::System.Int32 p = 42);
+  public partial ClassWithTwoPartialConstructors(string s, global::System.Int32 p = 42)
+  {
+    Console.WriteLine(s);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_5_0_0_OR_GREATER)
+#endif
+
+#if ROSLYN_5_0_0_OR_GREATER
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.PartialConstructor_IntroduceParameter_DefinitionOnly;
+
+/// <summary>
+/// Aspect that overrides the constructor (providing implementation) and introduces a parameter.
+/// </summary>
+public class TheAspect : ConstructorAspect
+{
+    public override void BuildAspect( IAspectBuilder<IConstructor> builder )
+    {
+        builder.Override( nameof( this.ConstructorTemplate ) );
+        builder.IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
+    }
+
+    [Template]
+    public void ConstructorTemplate()
+    {
+        Console.WriteLine( "Aspect implementation." );
+    }
+}
+
+// <target>
+internal partial class C
+{
+#if TESTRUNNER
+    [TheAspect]
+    public partial C( int x );
+#endif
+}
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly.t.cs
@@ -1,0 +1,10 @@
+// Warning CS1066 on `p`: `The default value specified for parameter 'p' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments`
+internal partial class C
+{
+  [TheAspect]
+  public partial C(int x, global::System.Int32 p = 42);
+  public partial C(int x, global::System.Int32 p = 42)
+  {
+    global::System.Console.WriteLine("Aspect implementation.");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime.0.i.cs
@@ -1,0 +1,9 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime
+{
+  partial class C
+  {
+    public C(global::System.Int32 x, global::System.Int32 p = 42) : this(x)
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_5_0_0_OR_GREATER)
+// @TestScenario(DesignTime)
+#endif
+
+#if ROSLYN_5_0_0_OR_GREATER
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime;
+
+/// <summary>
+/// Aspect that overrides the constructor (providing implementation) and introduces a parameter.
+/// </summary>
+public class TheAspect : ConstructorAspect
+{
+    public override void BuildAspect( IAspectBuilder<IConstructor> builder )
+    {
+        builder.Override( nameof( this.ConstructorTemplate ) );
+        builder.IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
+    }
+
+    [Template]
+    public void ConstructorTemplate()
+    {
+        Console.WriteLine( "Aspect implementation." );
+    }
+}
+
+// <target>
+internal partial class C
+{
+#if TESTRUNNER
+    [TheAspect]
+    public partial C( int x );
+#endif
+}
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DefinitionOnly_DesignTime.t.cs
@@ -1,0 +1,6 @@
+// Error CS9275 on `C`: `Partial member 'C.C(int)' must have an implementation part.`
+internal partial class C
+{
+  [TheAspect]
+  public partial C(int x);
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.0.i.cs
@@ -1,0 +1,9 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.PartialConstructor_IntroduceParameter_DesignTime
+{
+  partial class ClassWithPartialConstructor
+  {
+    public ClassWithPartialConstructor(global::System.Int32 x, global::System.Int32 p = 42) : this(x)
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.cs
@@ -19,7 +19,7 @@ public class TheAspect : TypeAspect
 {
     public override void BuildAspect( IAspectBuilder<INamedType> builder )
     {
-        foreach (var constructor in builder.Target.Constructors)
+        foreach ( var constructor in builder.Target.Constructors )
         {
             builder.With( constructor ).IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_5_0_0_OR_GREATER)
+// @TestScenario(DesignTime)
+#endif
+
+#if ROSLYN_5_0_0_OR_GREATER
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.CSharp14.PartialConstructor_IntroduceParameter_DesignTime;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        foreach (var constructor in builder.Target.Constructors)
+        {
+            builder.With( constructor ).IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
+        }
+    }
+}
+
+// <target>
+[TheAspect]
+internal partial class ClassWithPartialConstructor
+{
+    public partial ClassWithPartialConstructor( int x );
+
+    public partial ClassWithPartialConstructor( int x )
+    {
+        Console.WriteLine( $"x={x}" );
+    }
+}
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/CSharp14/PartialConstructor_IntroduceParameter_DesignTime.t.cs
@@ -1,0 +1,9 @@
+[TheAspect]
+internal partial class ClassWithPartialConstructor
+{
+  public partial ClassWithPartialConstructor(int x);
+  public partial ClassWithPartialConstructor(int x)
+  {
+    Console.WriteLine($"x={x}");
+  }
+}


### PR DESCRIPTION
## Summary
- Fix parameter introduction for C# 14 partial constructors to update both definition and implementation signatures
- Fix design-time generated constructors to not use `partial` modifier

## Issues Fixed
- #1143