### PR TITLE
Fix InterfaceMember with oblivious nullability (#817)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/InterfaceImplementation/ImplementInterfaceAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/InterfaceImplementation/ImplementInterfaceAdvice.cs
@@ -477,7 +477,8 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
                                     isIteratorMethod,
                                     isExplicit,
                                     isVirtual,
-                                    isOverride );
+                                    isOverride,
+                                    templateMethodDeclaration );
 
                                 CopyAttributes( interfaceMethod, methodBuilder );
                                 methodBuilder.Freeze();
@@ -702,7 +703,8 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
                                     isExplicit,
                                     isVirtual,
                                     isOverride,
-                                    hasImplicitSetter );
+                                    hasImplicitSetter,
+                                    templatePropertyDeclaration );
 
                                 if ( templateProperty != null )
                                 {
@@ -884,7 +886,8 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
                                     isEventField,
                                     isExplicit,
                                     isVirtual,
-                                    isOverride );
+                                    isOverride,
+                                    templateEventDeclaration );
 
                                 if ( templateEvent != null )
                                 {
@@ -981,28 +984,61 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
             diagnostics.ToImmutableArray() );
     }
 
+    /// <summary>
+    /// If the interface type has oblivious nullability and the template type has explicit nullability,
+    /// returns the interface type with the template's nullability applied. Otherwise returns the interface type unchanged.
+    /// </summary>
+    private static IType ResolveNullability( IType interfaceType, IType? templateType )
+    {
+        if ( templateType != null && interfaceType.IsNullable == null && templateType.IsNullable != null )
+        {
+            return templateType.IsNullable == true ? interfaceType.ToNullable() : interfaceType.ToNonNullable();
+        }
+
+        return interfaceType;
+    }
+
+    private static INamedType ResolveNullability( INamedType interfaceType, INamedType? templateType )
+    {
+        if ( templateType != null && interfaceType.IsNullable == null && templateType.IsNullable != null )
+        {
+            // For named types (e.g. delegate types for events), ToNullable always returns INamedType.
+            // ToNonNullable can return a non-INamedType for Nullable<T>, but event delegate types are always reference types.
+            return templateType.IsNullable == true ? interfaceType.ToNullable() : (INamedType) interfaceType.ToNonNullable();
+        }
+
+        return interfaceType;
+    }
+
     private MethodBuilder GetImplMethodBuilder(
         INamedType declaringType,
         IMethod interfaceMethod,
         bool isIteratorMethod,
         bool isExplicit,
         bool isVirtual,
-        bool isOverride )
+        bool isOverride,
+        IMethod? templateMethod = null )
     {
         var name = GetInterfaceMemberName( interfaceMethod, isExplicit );
 
+        var returnType = ResolveNullability( interfaceMethod.ReturnParameter.Type, templateMethod?.ReturnParameter.Type );
+
         var methodBuilder = new MethodBuilder( this.AspectLayerInstance, declaringType, name )
         {
-            ReturnParameter = { Type = interfaceMethod.ReturnParameter.Type, RefKind = interfaceMethod.ReturnParameter.RefKind }
+            ReturnParameter = { Type = returnType, RefKind = interfaceMethod.ReturnParameter.RefKind }
         };
 
         methodBuilder.SetIsIteratorMethod( isIteratorMethod );
 
-        foreach ( var interfaceParameter in interfaceMethod.Parameters )
+        for ( var i = 0; i < interfaceMethod.Parameters.Count; i++ )
         {
+            var interfaceParameter = interfaceMethod.Parameters[i];
+            var templateParameter = templateMethod != null && i < templateMethod.Parameters.Count ? templateMethod.Parameters[i] : null;
+            var parameterType = ResolveNullability( interfaceParameter.Type, templateParameter?.Type );
+
             _ = methodBuilder.AddParameter(
                 interfaceParameter.Name,
-                interfaceParameter.Type,
+                parameterType,
                 interfaceParameter.RefKind,
                 interfaceParameter.DefaultValue );
         }
@@ -1049,9 +1085,12 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
         bool isExplicit,
         bool isVirtual,
         bool isOverride,
-        bool hasImplicitSetter )
+        bool hasImplicitSetter,
+        IProperty? templateProperty = null )
     {
         var name = GetInterfaceMemberName( interfaceProperty, isExplicit );
+
+        var propertyType = ResolveNullability( interfaceProperty.Type, templateProperty?.Type );
 
         var propertyBuilder = new PropertyBuilder(
             this.AspectLayerInstance,
@@ -1062,7 +1101,7 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
             isAutoProperty,
             interfaceProperty.Writeability == Writeability.InitOnly,
             false,
-            hasImplicitSetter ) { Type = interfaceProperty.Type };
+            hasImplicitSetter ) { Type = propertyType };
 
         if ( isExplicit )
         {
@@ -1106,11 +1145,14 @@ internal sealed partial class ImplementInterfaceAdvice : Advice<ImplementInterfa
         bool isEventField,
         bool isExplicit,
         bool isVirtual,
-        bool isOverride )
+        bool isOverride,
+        IEvent? templateEvent = null )
     {
         var name = GetInterfaceMemberName( interfaceEvent, isExplicit );
 
-        var eventBuilder = new EventBuilder( this.AspectLayerInstance, declaringType, name, isEventField ) { Type = interfaceEvent.Type };
+        var eventType = ResolveNullability( interfaceEvent.Type, templateEvent?.Type );
+
+        var eventBuilder = new EventBuilder( this.AspectLayerInstance, declaringType, name, isEventField ) { Type = eventType };
 
         if ( isExplicit )
         {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.Dependency.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+// This file simulates an assembly compiled without nullable annotations (e.g. .NET Framework),
+// where types have oblivious nullability.
+
+#nullable disable
+
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ObliviousNullability
+{
+    public delegate void ObliviousHandler( object sender, EventArgs e );
+
+    public interface IObliviousInterface
+    {
+        event ObliviousHandler PropertyChanged;
+
+        string ObliviousProperty { get; set; }
+
+        string ObliviousMethod( string x );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.Dependency.cs
@@ -20,5 +20,13 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Inter
         string ObliviousProperty { get; set; }
 
         string ObliviousMethod( string x );
+
+        int ValueTypeProperty { get; set; }
+
+        int ValueTypeMethod( int x );
+
+        int? NullableValueTypeProperty { get; set; }
+
+        int? NullableValueTypeMethod( int? x );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.cs
@@ -33,6 +33,24 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Inter
         {
             return x;
         }
+
+        [InterfaceMember]
+        public int ValueTypeProperty { get; set; }
+
+        [InterfaceMember]
+        public int ValueTypeMethod( int x )
+        {
+            return x;
+        }
+
+        [InterfaceMember]
+        public int? NullableValueTypeProperty { get; set; }
+
+        [InterfaceMember]
+        public int? NullableValueTypeMethod( int? x )
+        {
+            return x;
+        }
     }
 
     // <target>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+/*
+ * Tests that when an interface member has oblivious nullability (e.g., from a .NET Framework assembly),
+ * the [InterfaceMember] template's explicit nullable annotation is preserved in the generated code.
+ * Regression test for https://github.com/metalama/Metalama/issues/817.
+ */
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+#pragma warning disable CS0067
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ObliviousNullability
+{
+    public class IntroductionAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> aspectBuilder )
+        {
+            aspectBuilder.ImplementInterface( typeof(IObliviousInterface) );
+        }
+
+        [InterfaceMember]
+        public event ObliviousHandler? PropertyChanged;
+
+        [InterfaceMember]
+        public string? ObliviousProperty { get; set; }
+
+        [InterfaceMember]
+        public string? ObliviousMethod( string? x )
+        {
+            return x;
+        }
+    }
+
+    // <target>
+    [Introduction]
+    public class TargetClass { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.t.cs
@@ -1,0 +1,10 @@
+[Introduction]
+public class TargetClass : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ObliviousNullability.IObliviousInterface
+{
+  public global::System.String? ObliviousProperty { get; set; }
+  public global::System.String? ObliviousMethod(global::System.String? x)
+  {
+    return x;
+  }
+  public event global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ObliviousNullability.ObliviousHandler? PropertyChanged;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ObliviousNullability.t.cs
@@ -1,8 +1,18 @@
 [Introduction]
 public class TargetClass : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ObliviousNullability.IObliviousInterface
 {
+  public global::System.Int32? NullableValueTypeProperty { get; set; }
   public global::System.String? ObliviousProperty { get; set; }
+  public global::System.Int32 ValueTypeProperty { get; set; }
+  public global::System.Int32? NullableValueTypeMethod(global::System.Int32? x)
+  {
+    return x;
+  }
   public global::System.String? ObliviousMethod(global::System.String? x)
+  {
+    return x;
+  }
+  public global::System.Int32 ValueTypeMethod(global::System.Int32 x)
   {
     return x;
   }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Samples/NotifyPropertyChanged_NetFramework.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Samples/NotifyPropertyChanged_NetFramework.t.cs
@@ -39,5 +39,5 @@ internal class Car : INotifyPropertyChanged
   {
     this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
   }
-  public event PropertyChangedEventHandler PropertyChanged;
+  public event PropertyChangedEventHandler? PropertyChanged;
 }


### PR DESCRIPTION
## Summary

Fixes #817 - When an interface member has oblivious nullability (e.g., from a .NET Framework assembly without nullable annotations), the `[InterfaceMember]` template's explicit nullable annotation should be preserved in the generated code.

**Current behavior:** The nullability is taken from the interface definition, which has oblivious nullability under .NET Framework. The generated code drops the `?` annotation even though the aspect template explicitly declares it as nullable.

**Expected behavior:** When the interface member's type has oblivious nullability, Metalama should respect the nullable annotation declared in the `[InterfaceMember]` template.

## Changes

- Added regression test `ObliviousNullability` in InterfaceImplementation tests with:
  - A dependency file defining an interface with `#nullable disable` (oblivious nullability)
  - An aspect using `[InterfaceMember]` with explicit nullable annotations
  - Expected output preserving the nullable annotations

## Status

- [x] Regression test added (currently failing)
- [x] Fix implemented
- [x] All tests passing

— Claude for @PostSharpAgent