### PR TITLE
Suppress duplicate LAMA0104 on member access chains (#826)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
@@ -654,6 +654,15 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
             if ( currentScope?.GetExpressionExecutionScope() is RunTimeOnly ||
                  this._templateMemberClassifier.IsNodeOfDynamicType( visitedNode ) )
             {
+                // Don't report the error on the Name part of a member access expression. The error will be
+                // reported on the Expression (left) part or the parent member access expression instead,
+                // avoiding redundant diagnostics on member access chains like AppDomain.CurrentDomain.GetAssemblies().
+                if ( node.Parent.IsKind( SyntaxKind.SimpleMemberAccessExpression )
+                     && node.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node )
+                {
+                    return visitedNode;
+                }
+
                 // The current expression is obliged to be compile-time-only by inference.
                 // Emit an error if the type of the expression is inferred to be runtime-only.
                 this.RequireScope(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Diagnostics/VarError.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Diagnostics/VarError.t.cs
@@ -1,3 +1,3 @@
 // CompileTimeAspectPipeline.ExecuteAsync failed.
-// Error LAMA0104 on `RunTime`: `The expression 'RunTime' is run-time but it is expected to be compile-time because the expression appears in a local variable of compile-time-only type 'Metalama.Framework.Code.IDeclaration?'.`
+// Error LAMA0104 on `meta.RunTime`: `The expression 'meta.RunTime' is run-time but it is expected to be compile-time because the expression appears in a local variable of compile-time-only type 'Metalama.Framework.Code.IDeclaration?'.`
 // Error LAMA0253 on `meta.Target.Declaration`: `Compile-time-only type 'IDeclaration' cannot be used in the invocation of run-time method 'meta.RunTime'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Misc/IndexAndRangeErrors.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Misc/IndexAndRangeErrors.t.cs
@@ -1,3 +1,3 @@
 // CompileTimeAspectPipeline.ExecuteAsync failed.
-// Error LAMA0104 on `RunTime`: `The expression 'RunTime' is run-time but it is expected to be compile-time because the expression appears in element of the compile-time collection 'compileTimeCollection'.`
-// Error LAMA0104 on `RunTime`: `The expression 'RunTime' is run-time but it is expected to be compile-time because the expression appears in element of the compile-time collection 'compileTimeCollection'.`
+// Error LAMA0104 on `meta.RunTime`: `The expression 'meta.RunTime' is run-time but it is expected to be compile-time because the expression appears in element of the compile-time collection 'compileTimeCollection'.`
+// Error LAMA0104 on `meta.RunTime`: `The expression 'meta.RunTime' is run-time but it is expected to be compile-time because the expression appears in element of the compile-time collection 'compileTimeCollection'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Pragma/InsertStatementErrorRunTimeValue.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Pragma/InsertStatementErrorRunTimeValue.t.cs
@@ -1,2 +1,2 @@
 // TestTemplateCompiler.TryCompile failed.
-// Error LAMA0104 on `This`: `The expression 'This' is run-time but it is expected to be compile-time because the expression appears in a compile-time expression 'meta.InsertStatement'.`
+// Error LAMA0104 on `meta.This`: `The expression 'meta.This' is run-time but it is expected to be compile-time because the expression appears in a compile-time expression 'meta.InsertStatement'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Cast/CompileTimeCastOfRunTimeValue.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Cast/CompileTimeCastOfRunTimeValue.t.cs
@@ -1,3 +1,3 @@
 // TestTemplateCompiler.TryCompile failed.
 // Error LAMA0255 on `IParameter`: `Cannot cast the run-time expression 'meta.Target.Parameters[0].Value!' to the compile-time type 'IParameter'.`
-// Error LAMA0104 on `Value`: `The expression 'Value' is run-time but it is expected to be compile-time because the expression appears in a local variable of compile-time-only type 'Metalama.Framework.Code.IParameter?'.`
+// Error LAMA0104 on `meta.Target.Parameters[0].Value`: `The expression 'meta.Target.Parameters[0].Value' is run-time but it is expected to be compile-time because the expression appears in a local variable of compile-time-only type 'Metalama.Framework.Code.IParameter?'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Misc/ScopeMismatchMemberAccessChain.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Misc/ScopeMismatchMemberAccessChain.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine.Templating;
+
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+
+namespace Metalama.Framework.Tests.AspectTests.Templating.Syntax.Misc.ScopeMismatchMemberAccessChain
+{
+    internal class Aspect
+    {
+        [TestTemplate]
+        private dynamic? Template()
+        {
+            // This should report a single LAMA0104 error on 'AppDomain' (the innermost run-time-only node),
+            // not three separate errors on 'AppDomain', 'CurrentDomain', and 'GetAssemblies'.
+            var assemblies = meta.CompileTime( AppDomain.CurrentDomain.GetAssemblies() );
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class TargetCode
+    {
+        private int Method( int a )
+        {
+            return a;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Misc/ScopeMismatchMemberAccessChain.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Misc/ScopeMismatchMemberAccessChain.t.cs
@@ -1,0 +1,2 @@
+// TestTemplateCompiler.TryCompile failed.
+// Error LAMA0104 on `AppDomain`: `The expression 'AppDomain' is run-time but it is expected to be compile-time because the expression appears in a compile-time expression 'meta.CompileTime'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/ObjectInitializer/NeutralObjectInitializers_RunTime_Error.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/ObjectInitializer/NeutralObjectInitializers_RunTime_Error.t.cs
@@ -1,3 +1,2 @@
 // TestTemplateCompiler.TryCompile failed.
-// Error LAMA0104 on `This`: `The expression 'This' is run-time but it is expected to be compile-time because the expression appears in on the right side of a 'with' initializer whose left side is compile-time.`
-// Error LAMA0104 on `Foo`: `The expression 'Foo' is run-time but it is expected to be compile-time because the expression appears in on the right side of a 'with' initializer whose left side is compile-time.`
+// Error LAMA0104 on `meta.This`: `The expression 'meta.This' is run-time but it is expected to be compile-time because the expression appears in on the right side of a 'with' initializer whose left side is compile-time.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/ObjectInitializer/With_Error.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/ObjectInitializer/With_Error.t.cs
@@ -1,3 +1,2 @@
 // TestTemplateCompiler.TryCompile failed.
-// Error LAMA0104 on `This`: `The expression 'This' is run-time but it is expected to be compile-time because the expression appears in on the right side of a 'with' initializer whose left side is compile-time.`
-// Error LAMA0104 on `Foo`: `The expression 'Foo' is run-time but it is expected to be compile-time because the expression appears in on the right side of a 'with' initializer whose left side is compile-time.`
+// Error LAMA0104 on `meta.This`: `The expression 'meta.This' is run-time but it is expected to be compile-time because the expression appears in on the right side of a 'with' initializer whose left side is compile-time.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Switch/MismatchScopeOldSwitch.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Switch/MismatchScopeOldSwitch.t.cs
@@ -1,5 +1,3 @@
 // TestTemplateCompiler.TryCompile failed.
 // Error LAMA0104 on `RunTimeEnum`: `The expression 'RunTimeEnum' is run-time but it is expected to be compile-time because the expression appears in the compile-time 'switch( (int) CompileTimeEnum.one )'.`
-// Error LAMA0104 on `one`: `The expression 'one' is run-time but it is expected to be compile-time because the expression appears in the compile-time 'switch( (int) CompileTimeEnum.one )'.`
 // Error LAMA0104 on `RunTimeEnum`: `The expression 'RunTimeEnum' is run-time but it is expected to be compile-time because the expression appears in the compile-time 'switch( (int) CompileTimeEnum.one )'.`
-// Error LAMA0104 on `two`: `The expression 'two' is run-time but it is expected to be compile-time because the expression appears in the compile-time 'switch( (int) CompileTimeEnum.one )'.`


### PR DESCRIPTION
## Summary

Fixes #826 — When `meta.CompileTime(AppDomain.CurrentDomain.GetAssemblies())` is used in a T# template, LAMA0104 is reported three times (once for each sub-expression). This PR makes it so only the innermost node gets the error.

## Approach

Per @gfraiteur's guidance:
1. Skip reporting LAMA0104 on the `Name` (right) part of `SimpleMemberAccessExpression` nodes — the error is already reported on the `Expression` (left) part
2. This prevents redundant diagnostics on member access chains like `AppDomain.CurrentDomain.GetAssemblies()`

## Checklist

- [x] Regression test `ScopeMismatchMemberAccessChain` passes (only 1 LAMA0104 on `AppDomain`)
- [x] Existing LAMA0104 tests continue to pass (8 `.t.cs` files updated)
- [x] Full `Build.ps1 build` passes with zero warnings
- [x] Full `Build.ps1 test` passes with zero failures

— Claude for @PostSharpAgent