### PR TITLE
Add regression test for private generic template cross-assembly (#788)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.Dependency.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.TemplateTypeParameter.OverrideMethod_CrossAssembly;
+
+public class Aspect : MethodAspect
+{
+    public override void BuildAspect( IAspectBuilder<IMethod> builder )
+    {
+        builder.Override( nameof(Template), args: new { T = builder.Target.ReturnType } );
+    }
+
+    [Template]
+    private T Template<[CompileTime] T>()
+    {
+        return default;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.Dependency.cs
@@ -17,6 +17,6 @@ public class Aspect : MethodAspect
     [Template]
     private T Template<[CompileTime] T>()
     {
-        return default;
+        return default!;
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.TemplateTypeParameter.OverrideMethod_CrossAssembly;
+
+// <target>
+internal class TargetCode
+{
+    [Aspect]
+    private int M() { return 0; }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.t.cs
@@ -1,0 +1,8 @@
+internal class TargetCode
+{
+  [Aspect]
+  private int M()
+  {
+    return default;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateTypeParameter/OverrideMethod_CrossAssembly.t.cs
@@ -3,6 +3,6 @@ internal class TargetCode
   [Aspect]
   private int M()
   {
-    return default;
+    return default !;
   }
 }


### PR DESCRIPTION
## Summary
- Added a regression test (`OverrideMethod_CrossAssembly`) in the `TemplateTypeParameter` test category to verify that private generic templates with `[CompileTime]` type parameters work correctly when used from another assembly.
- The bug described in #788 (LAMA0041 error for private generic templates used cross-assembly) appears to have been fixed in a prior change. This PR adds a test to prevent regression.

Closes #788

## Test plan
- [x] Verify the new test (`TemplateTypeParameter.OverrideMethod_CrossAssembly`) passes on net8.0
- [x] Verify all 14 `TemplateTypeParameter` tests pass
- [ ] Verify `Build.ps1 build` completes with zero warnings
- [ ] Verify `Build.ps1 test` completes successfully

— Claude for @gfraiteur