### PR TITLE
Fix template type parameter name mapping after introduction rename (#766)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/ITemplateSyntaxFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompileTimeContracts/ITemplateSyntaxFactory.cs
@@ -90,6 +90,13 @@ public interface ITemplateSyntaxFactory
 
     TypeOfExpressionSyntax TypeOf( string typeOfString, Dictionary<string, TypeSyntax> substitutions );
 
+    /// <summary>
+    /// Maps a template run-time type parameter name to the correct identifier in the current expansion context.
+    /// When the target method's type parameter has been renamed (e.g., by an introduction), this returns
+    /// the correct name based on ordinal position mapping.
+    /// </summary>
+    IdentifierNameSyntax RunTimeTypeParameterIdentifier( string templateParameterName );
+
     InterpolationSyntax FixInterpolationSyntax( InterpolationSyntax interpolation );
 
     ITemplateSyntaxFactory ForLocalFunction( string returnType, Dictionary<string, IType> genericArguments, bool isAsync = false );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateBindingHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateBindingHelper.cs
@@ -472,6 +472,10 @@ internal static class TemplateBindingHelper
 
             case { OperatorKind: OperatorKind.None }:
                 // For non-operator methods, we match parameters by name.
+                // An introduction can rename parameters, so if name-based lookup fails,
+                // we fall back to matching by ordinal position among run-time parameters.
+                var runTimeParameterIndex = 0;
+
                 foreach ( var templateParameter in templateMethodSymbol.Parameters )
                 {
                     if ( template.TemplateClassMember.Parameters[templateParameter.Ordinal].IsCompileTime )
@@ -483,11 +487,18 @@ internal static class TemplateBindingHelper
 
                     if ( methodParameter == null )
                     {
-                        var parameterNames = string.Join( ", ", targetMethod.Parameters.SelectAsImmutableArray( p => "'" + p.Name + "'" ) );
+                        if ( runTimeParameterIndex < targetMethod.Parameters.Count )
+                        {
+                            methodParameter = targetMethod.Parameters[runTimeParameterIndex];
+                        }
+                        else
+                        {
+                            var parameterNames = string.Join( ", ", targetMethod.Parameters.SelectAsImmutableArray( p => "'" + p.Name + "'" ) );
 
-                        throw new InvalidTemplateSignatureException(
-                            MetalamaStringFormatter.Format(
-                                $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the target method does not contain a parameter '{templateParameter.Name}'. Available parameters are: {parameterNames}." ) );
+                            throw new InvalidTemplateSignatureException(
+                                MetalamaStringFormatter.Format(
+                                    $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the target method does not contain a parameter '{templateParameter.Name}'. Available parameters are: {parameterNames}." ) );
+                        }
                     }
 
                     if ( !VerifyTemplateType( templateParameter.Type, methodParameter.Type, template, targetMethod, arguments ) )
@@ -498,6 +509,7 @@ internal static class TemplateBindingHelper
                     }
 
                     AddParameter( methodParameter, templateParameter );
+                    runTimeParameterIndex++;
                 }
 
                 // Check that template generic parameters match the target.
@@ -508,11 +520,24 @@ internal static class TemplateBindingHelper
                         continue;
                     }
 
-                    var methodParameter = targetMethod.TypeParameters.SingleOrDefault( p => p.Name == templateParameter.Name )
-                                          ??
-                                          throw new InvalidTemplateSignatureException(
-                                              MetalamaStringFormatter.Format(
-                                                  $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the target method does not contain a generic parameter '{templateParameter.Name}'." ) );
+                    // First try to match by name. If that fails, fall back to matching by ordinal position.
+                    // An introduction can rename type parameters, so the template may use the original name
+                    // while the target method uses the new name.
+                    var methodParameter = targetMethod.TypeParameters.SingleOrDefault( p => p.Name == templateParameter.Name );
+
+                    if ( methodParameter == null )
+                    {
+                        if ( templateParameter.Ordinal < targetMethod.TypeParameters.Count )
+                        {
+                            methodParameter = targetMethod.TypeParameters[templateParameter.Ordinal];
+                        }
+                        else
+                        {
+                            throw new InvalidTemplateSignatureException(
+                                MetalamaStringFormatter.Format(
+                                    $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the target method does not contain a generic parameter '{templateParameter.Name}'." ) );
+                        }
+                    }
 
                     if ( !templateParameter.IsCompatibleWith( methodParameter ) )
                     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateBindingHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateBindingHelper.cs
@@ -471,9 +471,8 @@ internal static class TemplateBindingHelper
                 break;
 
             case { OperatorKind: OperatorKind.None }:
-                // For non-operator methods, we match parameters by name.
-                // An introduction can rename parameters, so if name-based lookup fails,
-                // we fall back to matching by ordinal position among run-time parameters.
+                // For non-operator methods, we match parameters by name, falling back to ordinal position
+                // among run-time parameters when an introduction has renamed the parameter.
                 var runTimeParameterIndex = 0;
 
                 foreach ( var templateParameter in templateMethodSymbol.Parameters )
@@ -512,7 +511,9 @@ internal static class TemplateBindingHelper
                     runTimeParameterIndex++;
                 }
 
-                // Check that template generic parameters match the target.
+                // Check that template generic parameters match the target by ordinal position among run-time type parameters.
+                var runTimeTypeParameterIndex = 0;
+
                 foreach ( var templateParameter in templateMethodSymbol.TypeParameters )
                 {
                     if ( template.TemplateClassMember.TypeParameters[templateParameter.Ordinal].IsCompileTime )
@@ -520,31 +521,25 @@ internal static class TemplateBindingHelper
                         continue;
                     }
 
-                    // First try to match by name. If that fails, fall back to matching by ordinal position.
-                    // An introduction can rename type parameters, so the template may use the original name
-                    // while the target method uses the new name.
-                    var methodParameter = targetMethod.TypeParameters.SingleOrDefault( p => p.Name == templateParameter.Name );
-
-                    if ( methodParameter == null )
+                    if ( runTimeTypeParameterIndex < targetMethod.TypeParameters.Count )
                     {
-                        if ( templateParameter.Ordinal < targetMethod.TypeParameters.Count )
-                        {
-                            methodParameter = targetMethod.TypeParameters[templateParameter.Ordinal];
-                        }
-                        else
+                        var methodParameter = targetMethod.TypeParameters[runTimeTypeParameterIndex];
+
+                        if ( !templateParameter.IsCompatibleWith( methodParameter ) )
                         {
                             throw new InvalidTemplateSignatureException(
                                 MetalamaStringFormatter.Format(
-                                    $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the target method does not contain a generic parameter '{templateParameter.Name}'." ) );
+                                    $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the constraints on the template parameter '{templateParameter.Name}' are not compatible with the constraints on the target method parameter '{methodParameter.Name}'." ) );
                         }
                     }
-
-                    if ( !templateParameter.IsCompatibleWith( methodParameter ) )
+                    else
                     {
                         throw new InvalidTemplateSignatureException(
                             MetalamaStringFormatter.Format(
-                                $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the constraints on the template parameter '{templateParameter.Name}' are not compatible with the constraints on the target method parameter '{methodParameter.Name}'." ) );
+                                $"Cannot use the template '{templateMethodSymbol}' to override the method '{targetMethod}': the target method does not contain a generic parameter '{templateParameter.Name}'." ) );
                     }
+
+                    runTimeTypeParameterIndex++;
                 }
 
                 break;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateMemberGenericContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateMemberGenericContext.cs
@@ -52,11 +52,19 @@ internal sealed class TemplateMemberGenericContext : GenericContext
         }
         else if ( this._targetMethod.DeclarationKind == DeclarationKind.Method && this._targetMethod is IMethod method )
         {
+            // First try to match by name.
             var typeParameter = method.TypeParameters.FirstOrDefault( t => t.Name == name );
 
             if ( typeParameter != null )
             {
                 return typeParameter;
+            }
+
+            // Fall back to matching by ordinal position. An introduction can rename type parameters,
+            // so the template may use the original name while the target method uses the new name.
+            if ( index < method.TypeParameters.Count )
+            {
+                return method.TypeParameters[index];
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateMemberGenericContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateMemberGenericContext.cs
@@ -11,7 +11,6 @@ using Metalama.Framework.Engine.CodeModel.References;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using SpecialType = Metalama.Framework.Code.SpecialType;
 
 namespace Metalama.Framework.Engine.Advising;
@@ -52,19 +51,21 @@ internal sealed class TemplateMemberGenericContext : GenericContext
         }
         else if ( this._targetMethod.DeclarationKind == DeclarationKind.Method && this._targetMethod is IMethod method )
         {
-            // First try to match by name.
-            var typeParameter = method.TypeParameters.FirstOrDefault( t => t.Name == name );
+            // Match by ordinal position among run-time type parameters. We compute the run-time index
+            // by counting how many non-compile-time type parameters precede this one.
+            var runTimeIndex = 0;
 
-            if ( typeParameter != null )
+            for ( var i = 0; i < index; i++ )
             {
-                return typeParameter;
+                if ( !this._templateMember.TemplateClassMember.TypeParameters[i].IsCompileTime )
+                {
+                    runTimeIndex++;
+                }
             }
 
-            // Fall back to matching by ordinal position. An introduction can rename type parameters,
-            // so the template may use the original name while the target method uses the new name.
-            if ( index < method.TypeParameters.Count )
+            if ( runTimeIndex < method.TypeParameters.Count )
             {
-                return method.TypeParameters[index];
+                return method.TypeParameters[runTimeIndex];
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateCompilerRewriter.cs
@@ -2785,7 +2785,17 @@ internal sealed partial class TemplateCompilerRewriter : MetaSyntaxRewriter, IDi
             {
                 // Fully qualifies simple identifiers.
 
-                if ( symbol?.Kind is SymbolKind.Namespace or SymbolKind.NamedType or SymbolKind.ArrayType or SymbolKind.DynamicType or SymbolKind.ErrorType
+                if ( symbol?.Kind == SymbolKind.TypeParameter
+                     && symbol is ITypeParameterSymbol typeParameterSymbol
+                     && this._templateMemberClassifier.IsRunTimeTemplateTypeParameter( typeParameterSymbol ) )
+                {
+                    // For run-time type parameters, use ITemplateSyntaxFactory.RunTimeTypeParameterIdentifier
+                    // so the correct name is resolved at expansion time via TemplateExpansionContext.
+                    return InvocationExpression(
+                            this._templateMetaSyntaxFactory.TemplateSyntaxFactoryMember( nameof(ITemplateSyntaxFactory.RunTimeTypeParameterIdentifier) ) )
+                        .AddArgumentListArguments( Argument( SyntaxFactoryEx.LiteralExpression( typeParameterSymbol.Name ) ) );
+                }
+                else if ( symbol?.Kind is SymbolKind.Namespace or SymbolKind.NamedType or SymbolKind.ArrayType or SymbolKind.DynamicType or SymbolKind.ErrorType
                          or SymbolKind.FunctionPointerType or SymbolKind.PointerType or SymbolKind.TypeParameter
                      && symbol is INamespaceOrTypeSymbol namespaceOrType )
                 {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateDriver.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Formatting;
 using Metalama.Framework.Engine.Services;
@@ -11,10 +10,8 @@ using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Framework.Engine.Utilities.UserCode;
 using Metalama.Framework.Utilities;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -76,10 +73,6 @@ namespace Metalama.Framework.Engine.Templating
 
             block = (BlockSyntax) new FlattenBlocksRewriter().Visit( output )!;
 
-            // Rename template run-time type parameter references to match the target method's type parameter names.
-            // This is needed because the template may use different names than the target method (e.g., template uses T, target uses U).
-            block = RenameTypeParametersIfNecessary( block, templateExpansionContext );
-
             // If we're generating an async iterator method, but there is no yield statement, we would get an error.
             // Prevent that by adding `yield break;` at the end of the method body.
             block = templateExpansionContext.AddYieldBreakIfNecessary( block );
@@ -91,69 +84,6 @@ namespace Metalama.Framework.Engine.Templating
             block = block.WithGeneratedCodeAnnotation( aspectClass?.GeneratedCodeAnnotation ?? FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
             return errorCountAfter == errorCountBefore;
-        }
-
-        private static BlockSyntax RenameTypeParametersIfNecessary( BlockSyntax block, TemplateExpansionContext context )
-        {
-            var genericArguments = context.TemplateGenericArguments;
-
-            if ( genericArguments.Count == 0 )
-            {
-                return block;
-            }
-
-            // Build a renaming map from template type parameter name to target type parameter name,
-            // but only for type parameters that map to other type parameters (not concrete types).
-            Dictionary<string, string>? renameMap = null;
-
-            foreach ( var pair in genericArguments )
-            {
-                if ( pair.Value is ITypeParameter targetTypeParameter && pair.Key != targetTypeParameter.Name )
-                {
-                    renameMap ??= new Dictionary<string, string>();
-                    renameMap[pair.Key] = targetTypeParameter.Name;
-                }
-            }
-
-            if ( renameMap == null )
-            {
-                return block;
-            }
-
-            return (BlockSyntax) new TypeParameterRenamingRewriter( renameMap ).Visit( block )!;
-        }
-
-        /// <summary>
-        /// A syntax rewriter that renames type parameter identifiers in the expanded template body.
-        /// </summary>
-        private sealed class TypeParameterRenamingRewriter : CSharpSyntaxRewriter
-        {
-            private readonly Dictionary<string, string> _renameMap;
-
-            public TypeParameterRenamingRewriter( Dictionary<string, string> renameMap )
-            {
-                this._renameMap = renameMap;
-            }
-
-            public override SyntaxNode? VisitIdentifierName( IdentifierNameSyntax node )
-            {
-                if ( this._renameMap.TryGetValue( node.Identifier.ValueText, out var newName ) )
-                {
-                    return node.WithIdentifier( SyntaxFactoryEx.SafeIdentifier( newName ).WithTriviaFrom( node.Identifier ) );
-                }
-
-                return base.VisitIdentifierName( node );
-            }
-
-            public override SyntaxNode? VisitGenericName( GenericNameSyntax node )
-            {
-                if ( this._renameMap.TryGetValue( node.Identifier.ValueText, out var newName ) )
-                {
-                    node = node.WithIdentifier( SyntaxFactoryEx.SafeIdentifier( newName ).WithTriviaFrom( node.Identifier ) );
-                }
-
-                return base.VisitGenericName( node );
-            }
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateDriver.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Formatting;
 using Metalama.Framework.Engine.Services;
@@ -10,8 +11,10 @@ using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Framework.Engine.Utilities.UserCode;
 using Metalama.Framework.Utilities;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -73,6 +76,10 @@ namespace Metalama.Framework.Engine.Templating
 
             block = (BlockSyntax) new FlattenBlocksRewriter().Visit( output )!;
 
+            // Rename template run-time type parameter references to match the target method's type parameter names.
+            // This is needed because the template may use different names than the target method (e.g., template uses T, target uses U).
+            block = RenameTypeParametersIfNecessary( block, templateExpansionContext );
+
             // If we're generating an async iterator method, but there is no yield statement, we would get an error.
             // Prevent that by adding `yield break;` at the end of the method body.
             block = templateExpansionContext.AddYieldBreakIfNecessary( block );
@@ -84,6 +91,69 @@ namespace Metalama.Framework.Engine.Templating
             block = block.WithGeneratedCodeAnnotation( aspectClass?.GeneratedCodeAnnotation ?? FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
             return errorCountAfter == errorCountBefore;
+        }
+
+        private static BlockSyntax RenameTypeParametersIfNecessary( BlockSyntax block, TemplateExpansionContext context )
+        {
+            var genericArguments = context.TemplateGenericArguments;
+
+            if ( genericArguments.Count == 0 )
+            {
+                return block;
+            }
+
+            // Build a renaming map from template type parameter name to target type parameter name,
+            // but only for type parameters that map to other type parameters (not concrete types).
+            Dictionary<string, string>? renameMap = null;
+
+            foreach ( var pair in genericArguments )
+            {
+                if ( pair.Value is ITypeParameter targetTypeParameter && pair.Key != targetTypeParameter.Name )
+                {
+                    renameMap ??= new Dictionary<string, string>();
+                    renameMap[pair.Key] = targetTypeParameter.Name;
+                }
+            }
+
+            if ( renameMap == null )
+            {
+                return block;
+            }
+
+            return (BlockSyntax) new TypeParameterRenamingRewriter( renameMap ).Visit( block )!;
+        }
+
+        /// <summary>
+        /// A syntax rewriter that renames type parameter identifiers in the expanded template body.
+        /// </summary>
+        private sealed class TypeParameterRenamingRewriter : CSharpSyntaxRewriter
+        {
+            private readonly Dictionary<string, string> _renameMap;
+
+            public TypeParameterRenamingRewriter( Dictionary<string, string> renameMap )
+            {
+                this._renameMap = renameMap;
+            }
+
+            public override SyntaxNode? VisitIdentifierName( IdentifierNameSyntax node )
+            {
+                if ( this._renameMap.TryGetValue( node.Identifier.ValueText, out var newName ) )
+                {
+                    return node.WithIdentifier( SyntaxFactoryEx.SafeIdentifier( newName ).WithTriviaFrom( node.Identifier ) );
+                }
+
+                return base.VisitIdentifierName( node );
+            }
+
+            public override SyntaxNode? VisitGenericName( GenericNameSyntax node )
+            {
+                if ( this._renameMap.TryGetValue( node.Identifier.ValueText, out var newName ) )
+                {
+                    node = node.WithIdentifier( SyntaxFactoryEx.SafeIdentifier( newName ).WithTriviaFrom( node.Identifier ) );
+                }
+
+                return base.VisitGenericName( node );
+            }
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateExpansionContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateExpansionContext.cs
@@ -212,19 +212,30 @@ internal sealed partial class TemplateExpansionContext : UserCodeExecutionContex
         }
 
         if ( metaApi.Target.Declaration.DeclarationKind == DeclarationKind.Method
-             && metaApi.Target.Declaration is IMethod { TypeParameters.Count: > 0 } targetMethod )
+             && metaApi.Target.Declaration is IMethod { TypeParameters.Count: > 0 } targetMethod
+             && methodTemplate != null )
         {
             // Generic method - we need to add type parameters as named arguments for correct serializable id resolution.
-            // Any target method type parameter that matches name of template argument can be skipped - template will not have a runtime type parameter of that name.
+            // We map template run-time type parameters to target type parameters by ordinal position,
+            // since an introduction can rename type parameters.
+            var runTimeTypeParameterIndex = 0;
 
-            // TODO: This presumes mapping of type parameters by name, more appropriate place would be to have a map in BoundTemplateMethod, but there is currently no other use for that.
-
-            foreach ( var targetTypeParameter in targetMethod.TypeParameters )
+            foreach ( var templateTypeParameter in methodTemplate.TemplateMember.TemplateClassMember.TypeParameters )
             {
-                if ( !templateTypeArguments.ContainsKey( targetTypeParameter.Name ) )
+                if ( templateTypeParameter.IsCompileTime )
                 {
-                    templateTypeArguments.Add( targetTypeParameter.Name, targetTypeParameter );
+                    continue;
                 }
+
+                if ( runTimeTypeParameterIndex < targetMethod.TypeParameters.Count )
+                {
+                    if ( !templateTypeArguments.ContainsKey( templateTypeParameter.Name ) )
+                    {
+                        templateTypeArguments.Add( templateTypeParameter.Name, targetMethod.TypeParameters[runTimeTypeParameterIndex] );
+                    }
+                }
+
+                runTimeTypeParameterIndex++;
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateSyntaxFactoryImpl.cs
@@ -550,13 +550,60 @@ namespace Metalama.Framework.Engine.Templating
         {
             var typeOfExpression = (TypeOfExpressionSyntax) SyntaxFactoryEx.ParseExpressionSafe( typeOfString );
 
+            // Apply compile-time type parameter substitutions.
             if ( substitutions is { Count: > 0 } )
             {
                 var rewriter = new SerializedTypeOfRewriter( substitutions );
                 typeOfExpression = (TypeOfExpressionSyntax) rewriter.Visit( typeOfExpression )!;
             }
 
+            // Apply run-time type parameter renaming from the expansion context.
+            // This handles the case where a template type parameter name (e.g., T) differs from
+            // the target method's type parameter name (e.g., U) due to an introduction renaming.
+            var runTimeSubstitutions = this.GetRunTimeTypeParameterSubstitutions();
+
+            if ( runTimeSubstitutions != null )
+            {
+                var rewriter = new SerializedTypeOfRewriter( runTimeSubstitutions );
+                typeOfExpression = (TypeOfExpressionSyntax) rewriter.Visit( typeOfExpression )!;
+            }
+
             return typeOfExpression;
+        }
+
+        public IdentifierNameSyntax RunTimeTypeParameterIdentifier( string templateParameterName )
+        {
+            var genericArguments = this._templateExpansionContext.TemplateGenericArguments;
+
+            if ( genericArguments.TryGetValue( templateParameterName, out var targetType ) && targetType is ITypeParameter targetTypeParameter )
+            {
+                return SyntaxFactoryEx.SafeIdentifierName( targetTypeParameter.Name );
+            }
+
+            return SyntaxFactoryEx.SafeIdentifierName( templateParameterName );
+        }
+
+        private Dictionary<string, TypeSyntax>? GetRunTimeTypeParameterSubstitutions()
+        {
+            var genericArguments = this._templateExpansionContext.TemplateGenericArguments;
+
+            if ( genericArguments.Count == 0 )
+            {
+                return null;
+            }
+
+            Dictionary<string, TypeSyntax>? substitutions = null;
+
+            foreach ( var pair in genericArguments )
+            {
+                if ( pair.Value is ITypeParameter targetTypeParameter && pair.Key != targetTypeParameter.Name )
+                {
+                    substitutions ??= new Dictionary<string, TypeSyntax>();
+                    substitutions[pair.Key] = SyntaxFactoryEx.SafeIdentifierName( targetTypeParameter.Name );
+                }
+            }
+
+            return substitutions;
         }
 
         public InterpolationSyntax FixInterpolationSyntax( InterpolationSyntax interpolation ) => InterpolationSyntaxHelper.Fix( interpolation );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesMixedTypeParameters.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesMixedTypeParameters.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+[assembly: AspectOrder( AspectOrderDirection.CompileTime, typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesMixedTypeParameters.TestAspect1), typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesMixedTypeParameters.TestAspect2) )]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesMixedTypeParameters
+{
+    public class TestAspect1 : TypeAspect
+    {
+        // This aspect introduces/overrides the method, renaming the type parameters from A, B, C to X, Y, Z.
+        [Introduce( WhenExists = OverrideStrategy.Override )]
+        public void Foo<X, Y, Z>()
+        {
+            Console.WriteLine( typeof(X) );
+            meta.Proceed();
+        }
+    }
+
+    public class TestAspect2 : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            if ( builder.Target.IsConvertibleTo( typeof(Base) ) )
+            {
+                builder.With( builder.Target.Methods.OfName( "Foo" ).Single() ).Override(
+                    nameof(FooTemplate),
+                    new { T2 = typeof(int), T4 = typeof(string) } );
+            }
+        }
+
+        // The template uses mixed compile-time and run-time type parameters, not packed adjacently.
+        // Run-time: T1, T3, T5 should map by position to the target's X, Y, Z.
+        // Compile-time: T2, T4 are provided via arguments.
+        [Template]
+        public void FooTemplate<T1, [CompileTime] T2, T3, [CompileTime] T4, T5>()
+        {
+            Console.WriteLine( typeof(T1) );
+            Console.WriteLine( typeof(T3) );
+            Console.WriteLine( typeof(T5) );
+            meta.Proceed();
+        }
+    }
+
+    internal class Base
+    {
+        public virtual void Foo<A, B, C>()
+        {
+        }
+    }
+
+    // <target>
+    [TestAspect1]
+    [TestAspect2]
+    internal class Target : Base
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesMixedTypeParameters.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesMixedTypeParameters.t.cs
@@ -1,0 +1,12 @@
+[TestAspect1]
+[TestAspect2]
+internal class Target : Base
+{
+  public override void Foo<X, Y, Z>()
+  {
+    global::System.Console.WriteLine(typeof(X));
+    global::System.Console.WriteLine(typeof(Y));
+    global::System.Console.WriteLine(typeof(Z));
+    global::System.Console.WriteLine(typeof(X));
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.cs
@@ -6,17 +6,18 @@ using System.Linq;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 
-[assembly: AspectOrder( AspectOrderDirection.CompileTime, typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesTypeParameter.TestAspect1), typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesTypeParameter.TestAspect2) )]
+[assembly: AspectOrder( AspectOrderDirection.CompileTime, typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesParameterAndTypeParameter.TestAspect1), typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesParameterAndTypeParameter.TestAspect2) )]
 
-namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesTypeParameter
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesParameterAndTypeParameter
 {
     public class TestAspect1 : TypeAspect
     {
-        // This aspect introduces/overrides the method changing the type parameter name from T to U.
+        // This aspect introduces/overrides the method, renaming both the type parameter (T -> U)
+        // and the regular parameter (value -> item).
         [Introduce( WhenExists = OverrideStrategy.Override )]
-        public void Foo<U>()
+        public U Foo<U>( U item )
         {
-            meta.Proceed();
+            return meta.Proceed()!;
         }
     }
 
@@ -30,18 +31,19 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOv
             }
         }
 
-        // The template uses the original type parameter name T (as defined in Base).
+        // The template uses the original names (T, value) as defined in the base class.
         [Template]
-        public void FooTemplate<T>()
+        public T FooTemplate<T>( T value )
         {
-            meta.Proceed();
+            return meta.Proceed()!;
         }
     }
 
     internal class Base
     {
-        public virtual void Foo<T>()
+        public virtual T Foo<T>( T value )
         {
+            return value;
         }
     }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using System;
 using System.Linq;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
@@ -12,11 +13,12 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOv
 {
     public class TestAspect1 : TypeAspect
     {
-        // This aspect introduces/overrides the method, renaming both the type parameter (T -> U)
+        // This aspect introduces/overrides the method, renaming both the type parameter (S -> U)
         // and the regular parameter (value -> item).
         [Introduce( WhenExists = OverrideStrategy.Override )]
         public U Foo<U>( U item )
         {
+            Console.WriteLine( typeof(U) );
             return meta.Proceed()!;
         }
     }
@@ -31,17 +33,18 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOv
             }
         }
 
-        // The template uses the original names (T, value) as defined in the base class.
+        // The template uses different names (T, x) from the base class (S, value) and the renamed (U, item).
         [Template]
-        public T FooTemplate<T>( T value )
+        public T FooTemplate<T>( T x )
         {
+            Console.WriteLine( typeof(T) );
             return meta.Proceed()!;
         }
     }
 
     internal class Base
     {
-        public virtual T Foo<T>( T value )
+        public virtual S Foo<S>( S value )
         {
             return value;
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.t.cs
@@ -4,6 +4,8 @@ internal class Target : Base
 {
   public U Foo<U>(U item)
   {
+    global::System.Console.WriteLine(typeof(U));
+    global::System.Console.WriteLine(typeof(U));
     return default(U);
   }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesParameterAndTypeParameter.t.cs
@@ -1,0 +1,9 @@
+[TestAspect1]
+[TestAspect2]
+internal class Target : Base
+{
+  public U Foo<U>(U item)
+  {
+    return default(U);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+[assembly: AspectOrder( AspectOrderDirection.CompileTime, typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesTypeParameter.TestAspect1), typeof(Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesTypeParameter.TestAspect2) )]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOverrideRenamesTypeParameter
+{
+    public class TestAspect1 : TypeAspect
+    {
+        // This aspect introduces/overrides the method changing the type parameter name from T to U.
+        [Introduce( WhenExists = OverrideStrategy.Override )]
+        public void Foo<U>()
+        {
+            meta.Proceed();
+        }
+    }
+
+    public class TestAspect2 : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            if ( builder.Target.IsConvertibleTo( typeof(Base) ) )
+            {
+                builder.With( builder.Target.AllMethods.OfName( "Foo" ).Single() ).Override( nameof(FooTemplate) );
+            }
+        }
+
+        // The template uses the original type parameter name T (as defined in Base).
+        [Template]
+        public void FooTemplate<T>()
+        {
+            meta.Proceed();
+        }
+    }
+
+    internal class Base
+    {
+        public virtual void Foo<T>()
+        {
+        }
+    }
+
+    // <target>
+    [TestAspect1]
+    [TestAspect2]
+    internal class Target : Base
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using System;
 using System.Linq;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
@@ -12,10 +13,11 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOv
 {
     public class TestAspect1 : TypeAspect
     {
-        // This aspect introduces/overrides the method changing the type parameter name from T to U.
+        // This aspect introduces/overrides the method changing the type parameter name from S to U.
         [Introduce( WhenExists = OverrideStrategy.Override )]
         public void Foo<U>()
         {
+            Console.WriteLine( typeof(U) );
             meta.Proceed();
         }
     }
@@ -30,17 +32,18 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Generic.IntroduceOv
             }
         }
 
-        // The template uses the original type parameter name T (as defined in Base).
+        // The template uses a different type parameter name T (neither the original S nor the renamed U).
         [Template]
         public void FooTemplate<T>()
         {
+            Console.WriteLine( typeof(T) );
             meta.Proceed();
         }
     }
 
     internal class Base
     {
-        public virtual void Foo<T>()
+        public virtual void Foo<S>()
         {
         }
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.t.cs
@@ -1,0 +1,8 @@
+[TestAspect1]
+[TestAspect2]
+internal class Target : Base
+{
+  public override void Foo<U>()
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Generic/IntroduceOverrideRenamesTypeParameter.t.cs
@@ -4,5 +4,7 @@ internal class Target : Base
 {
   public override void Foo<U>()
   {
+    global::System.Console.WriteLine(typeof(U));
+    global::System.Console.WriteLine(typeof(U));
   }
 }


### PR DESCRIPTION
## Summary

Fixes #766 - Template type parameter name mapping fails when an introduction renames type parameters.

When an `[Introduce]` aspect overrides a method and renames type parameters (e.g., `Foo<S>` → `Foo<U>`), subsequent override templates using the original names would fail. This PR fixes the mapping to use ordinal-based matching for type parameters and resolves names at expansion time through `ITemplateSyntaxFactory`.

## Changes

### Implementation
- **`ITemplateSyntaxFactory.cs`**: Added `RunTimeTypeParameterIdentifier(string templateParameterName)` method that maps template type parameter names to correct target names at expansion time
- **`TemplateSyntaxFactoryImpl.cs`**: Implemented `RunTimeTypeParameterIdentifier` using `TemplateExpansionContext.TemplateGenericArguments` for ordinal-based mapping. Also updated `TypeOf()` to apply run-time type parameter name substitutions during expansion
- **`TemplateCompilerRewriter.cs`**: For run-time type parameters in Transform mode, generates a call to `RunTimeTypeParameterIdentifier` instead of embedding the template's type parameter name via `SyntaxGenerator.TypeOrNamespace()`
- **`TemplateMemberGenericContext.cs`**: Use ordinal matching among run-time type parameters (skipping compile-time ones) instead of name-based matching
- **`TemplateBindingHelper.cs`**: Use ordinal-only matching for type parameters; keep name-based matching with ordinal fallback for regular parameters
- **`TemplateExpansionContext.cs`**: Map template run-time type parameter names to target type parameters by ordinal position
- **`TemplateDriver.cs`**: Removed `TypeParameterRenamingRewriter` and `RenameTypeParametersIfNecessary` — renaming is no longer done by post-processing, it happens at expansion time through the factory

### Tests
- **`IntroduceOverrideRenamesTypeParameter`**: Tests type parameter renaming (base `S` → intro `U`, override template `T` → output `U`)
- **`IntroduceOverrideRenamesParameterAndTypeParameter`**: Tests both type parameter and regular parameter renaming
- **`IntroduceOverrideRenamesMixedTypeParameters`**: Tests mixed compile-time and run-time type parameters with 5 type params (3 run-time, 2 compile-time)

## Checklist
- [x] Reproduce bug with regression test
- [x] Implement fix
- [x] Address all review feedback from @gfraiteur
- [x] All aspect tests pass (1990/1990)
- [x] All template tests pass (312/312)
- [x] `Build.ps1 build` passes with zero warnings
- [x] `Build.ps1 test` passes with zero failures and zero warnings

--- Claude for @PostSharpAgent