### PR TITLE
Fix invoker generic method type arguments (#765)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
@@ -24,19 +24,15 @@ namespace Metalama.Framework.Engine.CodeModel.Invokers;
 
 internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
 {
-#if ROSLYN_5_0_0_OR_GREATER
     private readonly bool _skipTypeArgumentInference;
-#endif
 
     public MethodInvoker( IMethod method, InvokerOptions options = default, IExpression? target = null ) : base( method, options, target ) { }
 
-#if ROSLYN_5_0_0_OR_GREATER
     private MethodInvoker( IMethod method, InvokerOptions options, IExpression? target, bool skipTypeArgumentInference )
         : base( method, options, target )
     {
         this._skipTypeArgumentInference = skipTypeArgumentInference;
     }
-#endif
 
     public object? Invoke( IEnumerable<IExpression> args ) => this.InvokeCore( args.ToReadOnlyList() );
 
@@ -127,14 +123,11 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
 
     private DelegateUserExpression InvokeDefaultMethod( IReadOnlyList<IExpression> args )
     {
-#if ROSLYN_5_0_0_OR_GREATER
-
         // For extension members, redirect to the implementation method.
         if ( this.IsExtensionMember )
         {
             return this.InvokeExtensionImplementationMethod( args );
         }
-#endif
 
         // If the method is a canonical generic instance (type arguments are the type parameters themselves),
         // attempt to infer type arguments from the actual argument types. This prevents generating invalid code
@@ -142,10 +135,7 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
         var resolvedMethod = this.Member;
 
         if ( resolvedMethod.IsGeneric && resolvedMethod.IsCanonicalGenericInstance && args.Count > 0
-#if ROSLYN_5_0_0_OR_GREATER
-             && !this._skipTypeArgumentInference
-#endif
-           )
+             && !this._skipTypeArgumentInference )
         {
             var inferredMethod = TryInferTypeArguments( resolvedMethod, args );
 
@@ -275,7 +265,6 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
         }
     }
 
-#if ROSLYN_5_0_0_OR_GREATER
     private DelegateUserExpression InvokeExtensionImplementationMethod( IReadOnlyList<IExpression> args )
     {
         var implMethod = this.Member.ExtensionImplementationMethod;
@@ -312,7 +301,6 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
 
         return (DelegateUserExpression) implInvoker.CreateInvokeExpression( implArgs );
     }
-#endif
 
     private ExpressionSyntax CreateInvocationExpression(
         ReceiverExpressionSyntax receiverTypedExpressionSyntax,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.Code;
 using Metalama.Framework.Code.Invokers;
+using Metalama.Framework.Code.Types;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Diagnostics;
@@ -123,6 +124,23 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
         }
 #endif
 
+        // If the method is a canonical generic instance (type arguments are the type parameters themselves),
+        // attempt to infer type arguments from the actual argument types. This prevents generating invalid code
+        // with unresolved type parameters like `Bar<T>` instead of `Bar<int>`. (See #765)
+        var resolvedMethod = this.Member;
+
+        if ( resolvedMethod.IsGeneric && resolvedMethod.IsCanonicalGenericInstance && args.Count > 0 )
+        {
+            var inferredMethod = TryInferTypeArguments( resolvedMethod, args );
+
+            if ( inferredMethod != null )
+            {
+                resolvedMethod = inferredMethod;
+            }
+        }
+
+        var methodForCodeGen = resolvedMethod;
+
         return new DelegateUserExpression(
             context =>
             {
@@ -130,18 +148,18 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
 
                 var receiverInfo = this.GetReceiverInfo( context );
 
-                if ( this.Member.IsGeneric )
+                if ( methodForCodeGen.IsGeneric )
                 {
                     name = GenericName(
                         SyntaxFactoryEx.SafeIdentifier( this.GetCleanTargetMemberName() ),
-                        TypeArgumentList( SeparatedList( this.Member.TypeArguments.SelectAsImmutableArray( t => context.SyntaxGenerator.TypeSyntax( t ) ) ) ) );
+                        TypeArgumentList( SeparatedList( methodForCodeGen.TypeArguments.SelectAsImmutableArray( t => context.SyntaxGenerator.TypeSyntax( t ) ) ) ) );
                 }
                 else
                 {
                     name = SyntaxFactoryEx.SafeIdentifierName( this.GetCleanTargetMemberName() );
                 }
 
-                var arguments = this.Member.GetArguments( this.Member.Parameters, args, context );
+                var arguments = methodForCodeGen.GetArguments( methodForCodeGen.Parameters, args, context );
 
                 if ( this.Member.MethodKind == MethodKind.LocalFunction )
                 {
@@ -165,7 +183,80 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
                     return this.CreateInvocationExpression( receiver, name, arguments, AspectReferenceTargetKind.Self, context );
                 }
             },
-            (this.Options & InvokerOptions.NullConditional) != 0 ? this.Member.ReturnType.ToNullable() : this.Member.ReturnType );
+            (this.Options & InvokerOptions.NullConditional) != 0 ? methodForCodeGen.ReturnType.ToNullable() : methodForCodeGen.ReturnType );
+    }
+
+    /// <summary>
+    /// Attempts to infer type arguments for a canonical generic method from the actual argument types.
+    /// Returns a constructed generic method if all type parameters can be inferred, or <c>null</c> otherwise.
+    /// </summary>
+    private static IMethod? TryInferTypeArguments( IMethod method, IReadOnlyList<IExpression> args )
+    {
+        var typeParameters = method.TypeParameters;
+        var inferredTypes = new IType?[typeParameters.Count];
+
+        // Match each argument type against the corresponding parameter type to infer type arguments.
+        var parameters = method.Parameters;
+
+        for ( var i = 0; i < Math.Min( args.Count, parameters.Count ); i++ )
+        {
+            var argType = args[i].Type;
+            var paramType = parameters[i].Type;
+
+            TryMatchTypeArguments( paramType, argType, typeParameters, inferredTypes );
+        }
+
+        // Check if all type parameters were inferred.
+        for ( var i = 0; i < inferredTypes.Length; i++ )
+        {
+            if ( inferredTypes[i] == null )
+            {
+                return null;
+            }
+        }
+
+        return method.MakeGenericInstance( inferredTypes! );
+    }
+
+    /// <summary>
+    /// Recursively matches an argument type against a parameter type to discover type parameter mappings.
+    /// For example, matching <c>TestData&lt;int&gt;</c> against <c>TestData&lt;T&gt;</c> infers <c>T = int</c>.
+    /// </summary>
+    private static void TryMatchTypeArguments(
+        IType parameterType,
+        IType argumentType,
+        IReadOnlyList<ITypeParameter> typeParameters,
+        IType?[] inferredTypes )
+    {
+        if ( parameterType.TypeKind == TypeKind.TypeParameter && parameterType is ITypeParameter typeParam )
+        {
+            // Check that this type parameter belongs to the method (not the declaring type).
+            if ( typeParam.TypeParameterKind == TypeParameterKind.Method && typeParam.Index < inferredTypes.Length )
+            {
+                inferredTypes[typeParam.Index] = argumentType;
+            }
+
+            return;
+        }
+
+        // For named types (e.g., TestData<T>), match type arguments recursively.
+        if ( parameterType is INamedType paramNamedType && argumentType is INamedType argNamedType )
+        {
+            if ( paramNamedType.TypeArguments.Count > 0 &&
+                 paramNamedType.TypeArguments.Count == argNamedType.TypeArguments.Count )
+            {
+                for ( var i = 0; i < paramNamedType.TypeArguments.Count; i++ )
+                {
+                    TryMatchTypeArguments( paramNamedType.TypeArguments[i], argNamedType.TypeArguments[i], typeParameters, inferredTypes );
+                }
+            }
+        }
+
+        // For array types, match element types.
+        if ( parameterType is IArrayType paramArrayType && argumentType is IArrayType argArrayType )
+        {
+            TryMatchTypeArguments( paramArrayType.ElementType, argArrayType.ElementType, typeParameters, inferredTypes );
+        }
     }
 
 #if ROSLYN_5_0_0_OR_GREATER

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
@@ -239,7 +239,19 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
             // Check that this type parameter belongs to the method (not the declaring type).
             if ( typeParam.TypeParameterKind == TypeParameterKind.Method && typeParam.Index < inferredTypes.Length )
             {
-                inferredTypes[typeParam.Index] = argumentType;
+                var existingType = inferredTypes[typeParam.Index];
+
+                if ( existingType == null )
+                {
+                    inferredTypes[typeParam.Index] = argumentType;
+                }
+                else if ( !existingType.Equals( argumentType ) )
+                {
+                    // Conflicting inference — mark as failed by using a sentinel.
+                    // TryInferTypeArguments checks for null, so we need a way to signal conflict.
+                    // We set to null and rely on the null check in TryInferTypeArguments to fail.
+                    inferredTypes[typeParam.Index] = null;
+                }
             }
 
             return;
@@ -249,7 +261,8 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
         if ( parameterType is INamedType paramNamedType && argumentType is INamedType argNamedType )
         {
             if ( paramNamedType.TypeArguments.Count > 0 &&
-                 paramNamedType.TypeArguments.Count == argNamedType.TypeArguments.Count )
+                 paramNamedType.TypeArguments.Count == argNamedType.TypeArguments.Count &&
+                 paramNamedType.Definition.Equals( argNamedType.Definition ) )
             {
                 for ( var i = 0; i < paramNamedType.TypeArguments.Count; i++ )
                 {
@@ -258,8 +271,9 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
             }
         }
 
-        // For array types, match element types.
-        if ( parameterType is IArrayType paramArrayType && argumentType is IArrayType argArrayType )
+        // For array types, match element types only when ranks are equal.
+        if ( parameterType is IArrayType paramArrayType && argumentType is IArrayType argArrayType
+             && paramArrayType.Rank == argArrayType.Rank )
         {
             TryMatchTypeArguments( paramArrayType.ElementType, argArrayType.ElementType, typeParameters, inferredTypes );
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
@@ -143,6 +143,10 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
             {
                 resolvedMethod = inferredMethod;
             }
+            else
+            {
+                throw GeneralDiagnosticDescriptors.CannotInferTypeArguments.CreateException( resolvedMethod );
+            }
         }
 
         var methodForCodeGen = resolvedMethod;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Invokers/MethodInvoker.cs
@@ -24,7 +24,19 @@ namespace Metalama.Framework.Engine.CodeModel.Invokers;
 
 internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
 {
+#if ROSLYN_5_0_0_OR_GREATER
+    private readonly bool _skipTypeArgumentInference;
+#endif
+
     public MethodInvoker( IMethod method, InvokerOptions options = default, IExpression? target = null ) : base( method, options, target ) { }
+
+#if ROSLYN_5_0_0_OR_GREATER
+    private MethodInvoker( IMethod method, InvokerOptions options, IExpression? target, bool skipTypeArgumentInference )
+        : base( method, options, target )
+    {
+        this._skipTypeArgumentInference = skipTypeArgumentInference;
+    }
+#endif
 
     public object? Invoke( IEnumerable<IExpression> args ) => this.InvokeCore( args.ToReadOnlyList() );
 
@@ -129,7 +141,11 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
         // with unresolved type parameters like `Bar<T>` instead of `Bar<int>`. (See #765)
         var resolvedMethod = this.Member;
 
-        if ( resolvedMethod.IsGeneric && resolvedMethod.IsCanonicalGenericInstance && args.Count > 0 )
+        if ( resolvedMethod.IsGeneric && resolvedMethod.IsCanonicalGenericInstance && args.Count > 0
+#if ROSLYN_5_0_0_OR_GREATER
+             && !this._skipTypeArgumentInference
+#endif
+           )
         {
             var inferredMethod = TryInferTypeArguments( resolvedMethod, args );
 
@@ -270,7 +286,9 @@ internal sealed class MethodInvoker : Invoker<IMethod>, IMethodInvoker
         }
 
         // The implementation method is always static, so we pass null as target.
-        var implInvoker = new MethodInvoker( implMethod, this.Options, target: null );
+        // Skip type argument inference for extension implementation methods because
+        // their type parameters (from the extension block) should be kept as-is.
+        var implInvoker = new MethodInvoker( implMethod, this.Options, target: null, skipTypeArgumentInference: true );
 
         // For instance extension members, the receiver becomes the first argument.
         IReadOnlyList<IExpression> implArgs;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
@@ -349,6 +349,14 @@ namespace Metalama.Framework.Engine.Diagnostics
                 "Cannot load an extension assembly.",
                 _category );
 
+        internal static readonly DiagnosticDefinition<IMethod>
+            CannotInferTypeArguments = new(
+                "LAMA0071",
+                _category,
+                "Cannot infer the type arguments for method '{0}'. Supply the type arguments explicitly using IMethod.WithTypeArguments.",
+                Error,
+                "Cannot infer the type arguments for a generic method." );
+
         // TODO: Use formattable string (C# does not seem to find extension methods).
         internal static readonly DiagnosticDefinition<string>
             UnsupportedFeature = new(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments;
+
+/*
+ * Tests that invoking a generic method without specifying type arguments produces valid code.
+ * Regression test for https://github.com/metalama/Metalama/issues/765
+ */
+
+public class TestData<T>
+{
+}
+
+public class TestAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+        method.Invoke( new TestData<int>() );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class TargetClass
+{
+    [TestAspect]
+    public void Foo()
+    {
+    }
+
+    public void Bar<T>( TestData<T> data )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments.t.cs
@@ -1,0 +1,12 @@
+public class TargetClass
+{
+  [TestAspect]
+  public void Foo()
+  {
+    this.Bar<global::System.Int32>(new global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments.TestData<global::System.Int32>());
+    return;
+  }
+  public void Bar<T>(TestData<T> data)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @OutputCompilationDisabled
+#endif
+
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments_ConflictingInference;
+
+/*
+ * Tests that when a type parameter appears in multiple positions with conflicting types (int vs string),
+ * the type argument inference fails gracefully and the method is invoked with canonical type parameters.
+ * Regression test for https://github.com/metalama/Metalama/issues/765
+ */
+
+public class TestAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+
+        // T appears in both parameters but we pass int and string — conflicting inference.
+        method.Invoke( 42, "hello" );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class TargetClass
+{
+    [TestAspect]
+    public void Foo()
+    {
+    }
+
+    public void Bar<T>( T first, T second )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.cs
@@ -2,10 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-#if TEST_OPTIONS
-// @OutputCompilationDisabled
-#endif
-
 using System.Linq;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
@@ -14,7 +10,7 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.Ge
 
 /*
  * Tests that when a type parameter appears in multiple positions with conflicting types (int vs string),
- * the type argument inference fails gracefully and the method is invoked with canonical type parameters.
+ * the type argument inference fails with an error telling the user to supply type arguments explicitly.
  * Regression test for https://github.com/metalama/Metalama/issues/765
  */
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.t.cs
@@ -1,15 +1,2 @@
-// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
-// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
-// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
-public class TargetClass
-{
-  [TestAspect]
-  public void Foo()
-  {
-    this.Bar<T>((T)42, (T)"hello");
-    return;
-  }
-  public void Bar<T>(T first, T second)
-  {
-  }
-}
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0071 on `Foo`: `Cannot infer the type arguments for method 'TargetClass.Bar<T>(T, T)'. Supply the type arguments explicitly using IMethod.WithTypeArguments.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_ConflictingInference.t.cs
@@ -1,0 +1,15 @@
+// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
+// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
+// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
+public class TargetClass
+{
+  [TestAspect]
+  public void Foo()
+  {
+    this.Bar<T>((T)42, (T)"hello");
+    return;
+  }
+  public void Bar<T>(T first, T second)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.cs
@@ -2,10 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-#if TEST_OPTIONS
-// @OutputCompilationDisabled
-#endif
-
 using System.Collections.Generic;
 using System.Linq;
 using Metalama.Framework.Aspects;
@@ -15,8 +11,8 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.Ge
 
 /*
  * Tests that when the parameter type is a generic type (e.g. List<T>) but the argument is a different generic type
- * with the same arity (e.g. HashSet<int>), type argument inference correctly checks the generic type definition
- * and does not incorrectly infer T from an unrelated type.
+ * with the same arity (e.g. HashSet<int>), type argument inference fails with an error telling the user
+ * to supply type arguments explicitly.
  * Regression test for https://github.com/metalama/Metalama/issues/765
  */
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @OutputCompilationDisabled
+#endif
+
+using System.Collections.Generic;
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments_DifferentGenericTypes;
+
+/*
+ * Tests that when the parameter type is a generic type (e.g. List<T>) but the argument is a different generic type
+ * with the same arity (e.g. HashSet<int>), type argument inference correctly checks the generic type definition
+ * and does not incorrectly infer T from an unrelated type.
+ * Regression test for https://github.com/metalama/Metalama/issues/765
+ */
+
+public class TestAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+
+        // The method expects List<T> but we pass HashSet<int>.
+        // The generic type definitions differ, so T should not be inferred.
+        method.Invoke( new HashSet<int>() );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class TargetClass
+{
+    [TestAspect]
+    public void Foo()
+    {
+    }
+
+    public void Bar<T>( List<T> items )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.t.cs
@@ -1,15 +1,2 @@
-// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
-// Error CS0030 on `(global::System.Collections.Generic.List<T>)new global::System.Collections.Generic.HashSet<global::System.Int32>()`: `Cannot convert type 'System.Collections.Generic.HashSet<int>' to 'System.Collections.Generic.List<T>'`
-// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
-public class TargetClass
-{
-  [TestAspect]
-  public void Foo()
-  {
-    this.Bar<T>((global::System.Collections.Generic.List<T>)new global::System.Collections.Generic.HashSet<global::System.Int32>());
-    return;
-  }
-  public void Bar<T>(List<T> items)
-  {
-  }
-}
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0071 on `Foo`: `Cannot infer the type arguments for method 'TargetClass.Bar<T>(List<T>)'. Supply the type arguments explicitly using IMethod.WithTypeArguments.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_DifferentGenericTypes.t.cs
@@ -1,0 +1,15 @@
+// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
+// Error CS0030 on `(global::System.Collections.Generic.List<T>)new global::System.Collections.Generic.HashSet<global::System.Int32>()`: `Cannot convert type 'System.Collections.Generic.HashSet<int>' to 'System.Collections.Generic.List<T>'`
+// Error CS0246 on `T`: `The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)`
+public class TargetClass
+{
+  [TestAspect]
+  public void Foo()
+  {
+    this.Bar<T>((global::System.Collections.Generic.List<T>)new global::System.Collections.Generic.HashSet<global::System.Int32>());
+    return;
+  }
+  public void Bar<T>(List<T> items)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_Direct.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_Direct.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments_Direct;
+
+/*
+ * Tests that invoking a generic method whose type parameter is used directly (not wrapped in another generic type)
+ * correctly infers the type argument.
+ * Regression test for https://github.com/metalama/Metalama/issues/765
+ */
+
+public class TestAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+        method.Invoke( 42 );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class TargetClass
+{
+    [TestAspect]
+    public void Foo()
+    {
+    }
+
+    public void Bar<T>( T value )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_Direct.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_Direct.t.cs
@@ -1,0 +1,12 @@
+public class TargetClass
+{
+  [TestAspect]
+  public void Foo()
+  {
+    this.Bar<global::System.Int32>(42);
+    return;
+  }
+  public void Bar<T>(T value)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_MultipleTypeParams.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_MultipleTypeParams.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using System.Collections.Generic;
 using System.Linq;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_MultipleTypeParams.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_MultipleTypeParams.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Collections.Generic;
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments_MultipleTypeParams;
+
+/*
+ * Tests that invoking a generic method with multiple type parameters correctly infers all type arguments.
+ * Regression test for https://github.com/metalama/Metalama/issues/765
+ */
+
+public class TestAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+        method.Invoke( "hello", 42 );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class TargetClass
+{
+    [TestAspect]
+    public void Foo()
+    {
+    }
+
+    public void Bar<TKey, TValue>( TKey key, TValue value )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_MultipleTypeParams.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_MultipleTypeParams.t.cs
@@ -1,0 +1,12 @@
+public class TargetClass
+{
+  [TestAspect]
+  public void Foo()
+  {
+    this.Bar<global::System.String, global::System.Int32>("hello", 42);
+    return;
+  }
+  public void Bar<TKey, TValue>(TKey key, TValue value)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_TemplateTypeParam.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_TemplateTypeParam.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments_TemplateTypeParam;
+
+/*
+ * Tests that invoking a generic method without specifying type arguments from a template with a compile-time type parameter
+ * produces valid code. This is the exact scenario described in issue #765.
+ */
+
+public class TestData<T>
+{
+}
+
+public class TestAspect : OverrideMethodAspect
+{
+    [Template]
+    public dynamic? Template<[CompileTime] T>()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+        method.Invoke( new TestData<T>() );
+
+        return meta.Proceed();
+    }
+
+    public override dynamic? OverrideMethod() => throw new System.NotSupportedException();
+
+    public override void BuildAspect( IAspectBuilder<IMethod> builder )
+    {
+        builder.Override( nameof(Template), new { T = typeof(int) } );
+    }
+}
+
+// <target>
+public class TargetClass
+{
+    [TestAspect]
+    public void Foo()
+    {
+    }
+
+    public void Bar<T>( TestData<T> data )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_TemplateTypeParam.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/GenericMethodWithoutTypeArguments_TemplateTypeParam.t.cs
@@ -1,0 +1,12 @@
+public class TargetClass
+{
+  [TestAspect]
+  public void Foo()
+  {
+    this.Bar<global::System.Int32>(new global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.GenericMethodWithoutTypeArguments_TemplateTypeParam.TestData<global::System.Int32>());
+    return;
+  }
+  public void Bar<T>(TestData<T> data)
+  {
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #765: When invoking a generic method via `IMethod.Invoke()` without specifying type arguments, the invoker now attempts to infer type arguments from the actual argument types. If inference fails, it throws LAMA0071 telling the user to supply type arguments explicitly.

### Changes

**`MethodInvoker.cs`** (`Metalama.Framework.Engine/CodeModel/Invokers`):
- Added `TryInferTypeArguments` method that attempts to infer type arguments for a canonical generic method from actual argument types
- Added `TryMatchTypeArguments` method that recursively matches argument types against parameter types to discover type parameter mappings (handles direct type parameters, named generic types, and array types)
- Modified `InvokeDefaultMethod` to use the inferred type arguments when generating code, instead of the canonical (unresolved) type parameters
- **Error on failure**: When inference fails (e.g., conflicting types for same type parameter, or unresolvable generic type definitions), throws LAMA0071 instead of generating invalid code
- **Conflict detection**: When the same type parameter is inferred to conflicting types from different arguments, inference fails
- **Generic type definition check**: Named type matching verifies `Definition.Equals` to prevent incorrect inference from unrelated generic types with same arity
- **Array rank check**: Array type matching verifies matching ranks

**`GeneralDiagnosticDescriptors.cs`**: Added LAMA0071 diagnostic for failed type argument inference.

### Test cases
- `GenericMethodWithoutTypeArguments` -- basic inference: `Bar<T>(TestData<T>)` called with `TestData<int>` infers `T = int`
- `GenericMethodWithoutTypeArguments_Direct` -- direct type param: `Bar<T>(T)` called with `int` infers `T = int`
- `GenericMethodWithoutTypeArguments_MultipleTypeParams` -- multiple params: `Bar<TKey, TValue>(TKey, TValue)` called with `(string, int)`
- `GenericMethodWithoutTypeArguments_TemplateTypeParam` -- compile-time type parameter in template
- `GenericMethodWithoutTypeArguments_ConflictingInference` -- conflict detection: `Bar<T>(T, T)` called with `(int, string)` → LAMA0071 error
- `GenericMethodWithoutTypeArguments_DifferentGenericTypes` -- definition mismatch: `Bar<T>(List<T>)` called with `HashSet<int>` → LAMA0071 error

### Checklist
- [x] Reproduce bug (regression test)
- [x] Implement fix
- [x] Address review feedback (round 1: remove preprocessor directives)
- [x] Address review feedback (round 2: conflict detection, definition check, array rank)
- [x] Address review feedback (round 3: throw error on inference failure)
- [x] Build passes with zero warnings
- [x] All tests pass (Build.ps1 build + Build.ps1 test)
- [ ] TeamCity build passes (could not trigger — permission denied)