### PR TITLE
Fix silent failure when .Dependency.cs compile-time assembly fails (#768)

### DIFF
--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
@@ -281,9 +281,9 @@ internal abstract partial class BaseTestRunner
 
             if ( !string.IsNullOrEmpty( testInput.FullPath ) )
             {
-                (mainProject, _) = await AddDependencyProjectAsync( mainProject, testInput.FullPath );
+                (var dependencySuccess, mainProject, _) = await AddDependencyProjectAsync( mainProject, testInput.FullPath );
 
-                if ( !testResult.Success )
+                if ( !dependencySuccess )
                 {
                     return;
                 }
@@ -307,9 +307,9 @@ internal abstract partial class BaseTestRunner
                     continue;
                 }
 
-                (mainProject, _) = await AddDependencyProjectAsync( mainProject, includedFileName );
+                (var includedDependencySuccess, mainProject, _) = await AddDependencyProjectAsync( mainProject, includedFileName );
 
-                if ( !testResult.Success )
+                if ( !includedDependencySuccess )
                 {
                     return;
                 }
@@ -397,14 +397,14 @@ internal abstract partial class BaseTestRunner
             }
 #pragma warning restore CS1998
 
-            async Task<(Project Project, ImmutableArray<MetadataReference> References)> AddDependencyProjectAsync( Project baseProject, string basePath = "" )
+            async Task<(bool Success, Project Project, ImmutableArray<MetadataReference> References)> AddDependencyProjectAsync( Project baseProject, string basePath = "" )
             {
                 var dependencyName = Path.GetFileNameWithoutExtension( basePath ) + ".Dependency.cs";
                 var dependencyPath = Path.GetFullPath( Path.Combine( testDirectory, dependencyName ) );
 
                 if ( !this._fileSystem.FileExists( dependencyPath ) )
                 {
-                    return (baseProject, ImmutableArray<MetadataReference>.Empty);
+                    return (true, baseProject, ImmutableArray<MetadataReference>.Empty);
                 }
 
                 // Add documents to the dependency project.
@@ -428,7 +428,12 @@ internal abstract partial class BaseTestRunner
                 dependencyProject = await AddAdditionalDocumentsAsync( dependencyProject, dependencyParseOptions );
 
                 // Add dependencies recursively.
-                (dependencyProject, var recursiveReferences) = await AddDependencyProjectAsync( dependencyProject, dependencyName );
+                (var recursiveSuccess, dependencyProject, var recursiveReferences) = await AddDependencyProjectAsync( dependencyProject, dependencyName );
+
+                if ( !recursiveSuccess )
+                {
+                    return (false, baseProject, ImmutableArray<MetadataReference>.Empty);
+                }
 
                 // Compile the dependency.
                 var (dependencyReference, _) =
@@ -440,12 +445,12 @@ internal abstract partial class BaseTestRunner
 
                 if ( dependencyReference == null )
                 {
-                    return (baseProject, ImmutableArray<MetadataReference>.Empty);
+                    return (false, baseProject, ImmutableArray<MetadataReference>.Empty);
                 }
 
                 var allReferences = recursiveReferences.Add( dependencyReference );
 
-                return (baseProject.AddMetadataReferences( allReferences ), allReferences);
+                return (true, baseProject.AddMetadataReferences( allReferences ), allReferences);
             }
         }
         finally

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
@@ -282,6 +282,11 @@ internal abstract partial class BaseTestRunner
             if ( !string.IsNullOrEmpty( testInput.FullPath ) )
             {
                 (mainProject, _) = await AddDependencyProjectAsync( mainProject, testInput.FullPath );
+
+                if ( !testResult.Success )
+                {
+                    return;
+                }
             }
 
             // Add additional input documents.
@@ -303,6 +308,11 @@ internal abstract partial class BaseTestRunner
                 }
 
                 (mainProject, _) = await AddDependencyProjectAsync( mainProject, includedFileName );
+
+                if ( !testResult.Success )
+                {
+                    return;
+                }
 
                 await testResult.AddInputDocumentAsync( includedDocument, includedFullPath );
             }

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/DesignTimeTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/DesignTimeTestRunner.cs
@@ -30,6 +30,11 @@ namespace Metalama.Testing.AspectTesting
         {
             await base.RunAsync( testInput, testResult, testContext );
 
+            if ( !testResult.Success )
+            {
+                return;
+            }
+
             using var pipeline = new TestDesignTimeAspectPipeline( testContext.ServiceProvider );
 
             var pipelineResult = await pipeline.ExecuteAsync( testResult.InputCompilation! );

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/LiveTemplateTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/LiveTemplateTestRunner.cs
@@ -39,6 +39,11 @@ namespace Metalama.Testing.AspectTesting
 
             await base.RunAsync( testInput, testResult, testContext );
 
+            if ( !testResult.Success )
+            {
+                return;
+            }
+
             var serviceProvider = testContext.ServiceProvider;
 
             var partialCompilation = PartialCompilation.CreateComplete( testResult.InputCompilation! );

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/PreviewTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/PreviewTestRunner.cs
@@ -34,6 +34,11 @@ internal sealed class PreviewTestRunner : BaseTestRunner
     {
         await base.RunAsync( testInput, testResult, testContext );
 
+        if ( !testResult.Success )
+        {
+            return;
+        }
+
         var inputCompilation = testResult.InputCompilation.AssertNotNull();
 
         var (project, _) = await WorkspaceHelper.CreateProjectFromCompilationAsync(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.Dependency.cs
@@ -8,10 +8,9 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug768;
 
 public class TestAspect : OverrideMethodAspect
 {
-    [Template]
     public override dynamic? OverrideMethod()
     {
-        X a = meta.CompileTime( new X() );
+        var x = meta.CompileTime( new X() );
 
         return meta.Proceed();
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.Dependency.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug768;
+
+public class TestAspect : OverrideMethodAspect
+{
+    [Template]
+    public override dynamic? OverrideMethod()
+    {
+        X a = meta.CompileTime( new X() );
+
+        return meta.Proceed();
+    }
+}
+
+public struct X { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug768;
+
+// <target>
+internal class TargetCode
+{
+    [TestAspect]
+    public void Foo() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.t.cs
@@ -1,1 +1,3 @@
 // Transformation of the dependency failed.
+// Error LAMA0226 on `CompileTime`: `'meta.CompileTime<X>(X)' is invalid because 'X' is run-time but 'meta.CompileTime<T>(T?)' is compile-time.`
+// Error LAMA0104 on `X`: `The expression 'X' is run-time but it is expected to be compile-time because the expression appears in a compile-time expression 'meta.CompileTime'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug768.t.cs
@@ -1,0 +1,1 @@
+// Transformation of the dependency failed.


### PR DESCRIPTION
## Summary

Fixes #768: When a `.Dependency.cs` file in an aspect test fails to create its compile-time assembly, the failure is silently ignored. The test then continues and throws a confusing `SyntaxProcessingException` ("The custom attribute cannot be resolved") from `ValidateCustomAttributes` instead of reporting the actual dependency compilation error.

**Root cause:** After `CompileDependencyAsync` fails and calls `SetFailed("Transformation of the dependency failed.")`, the `RunAsync` method in `BaseTestRunner` continues executing instead of returning early. This leads to `ValidateCustomAttributes` being called on a compilation that's missing the dependency's metadata references, causing the misleading exception.

**Fix:** 
- Refactored `AddDependencyProjectAsync` to return a `(bool Success, Project, ImmutableArray<MetadataReference>)` tuple, making the control flow explicit instead of relying on `testResult.Success`.
- Added early-return guards in `DesignTimeTestRunner`, `LiveTemplateTestRunner`, and `PreviewTestRunner` after `base.RunAsync()` to prevent `NullReferenceException` when dependency compilation fails. (`AspectTestRunner`, `TemplatingTestRunner`, and `LinkerTestRunner` already had these guards.)

## Test plan

- [x] New regression test `Bug768` reproduces the issue (test currently fails with confusing error)
- [x] After fix, `Bug768` passes with the correct error message
- [x] Existing cross-assembly dependency tests continue to pass (60/60)
- [x] `Build.ps1 build` passes with zero warnings
- [x] PR ready for review

— Claude for @PostSharpAgent