### PR TITLE
Fix [RunTime] interface on [RunTimeOrCompileTime] type producing invalid compile-time code

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.CollectSerializableFieldsVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.CollectSerializableFieldsVisitor.cs
@@ -77,6 +77,13 @@ namespace Metalama.Framework.Engine.CompileTime
                     return;
                 }
 
+                // Skip explicit interface implementations of runtime-only interfaces.
+                if ( propertySymbol.ExplicitInterfaceImplementations.Any(
+                        p => this._compilationContext.SymbolClassifier.GetTemplatingScope( p.ContainingType ) == TemplatingScope.RunTimeOnly ) )
+                {
+                    return;
+                }
+
                 var backingField = propertySymbol.GetBackingField().AssertNotNull();
 
                 if ( !backingField.GetAttributes().Any( a => this._compilationContext.SymbolComparer.Equals( a.AttributeClass, this._nonSerializedAttribute ) )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
@@ -648,6 +648,7 @@ namespace Metalama.Framework.Engine.CompileTime
                 }
 
                 var transformedNode = node.WithMembers( List( members ) )
+                    .WithBaseList( this.FilterBaseList( node.BaseList, node.SyntaxTree ) )
                     .WithAdditionalAnnotations( _hasCompileTimeCodeAnnotation )
                     .WithAttributeLists( this.VisitAttributeLists( node.AttributeLists ) );
 
@@ -738,10 +739,66 @@ namespace Metalama.Framework.Engine.CompileTime
 
                     return true;
                 }
-                else
+
+                // Exclude explicit interface implementations of runtime-only interfaces.
+                if ( this.IsExplicitImplementationOfRunTimeOnlyInterface( symbol ) )
                 {
-                    return false;
+                    return true;
                 }
+
+                return false;
+            }
+
+            private bool IsExplicitImplementationOfRunTimeOnlyInterface( ISymbol symbol )
+            {
+                var explicitImplementations = symbol.Kind switch
+                {
+                    SymbolKind.Method when symbol is IMethodSymbol method => method.ExplicitInterfaceImplementations.Select( m => m.ContainingType ),
+                    SymbolKind.Property when symbol is IPropertySymbol property => property.ExplicitInterfaceImplementations.Select( p => p.ContainingType ),
+                    SymbolKind.Event when symbol is IEventSymbol @event => @event.ExplicitInterfaceImplementations.Select( e => e.ContainingType ),
+                    _ => Enumerable.Empty<INamedTypeSymbol>()
+                };
+
+                return explicitImplementations.Any( t => this.SymbolClassifier.GetTemplatingScope( t ) == TemplatingScope.RunTimeOnly );
+            }
+
+            private BaseListSyntax? FilterBaseList( BaseListSyntax? baseList, SyntaxTree syntaxTree )
+            {
+                if ( baseList == null )
+                {
+                    return null;
+                }
+
+                var semanticModel = this.RunTimeSemanticModelProvider.GetSemanticModel( syntaxTree );
+                var filteredTypes = new List<BaseTypeSyntax>();
+
+                foreach ( var baseType in baseList.Types )
+                {
+                    var typeInfo = semanticModel.GetTypeInfo( baseType.Type );
+
+                    if ( typeInfo.Type is INamedTypeSymbol namedType
+                         && namedType.TypeKind == TypeKind.Interface
+                         && this.SymbolClassifier.GetTemplatingScope( namedType ) == TemplatingScope.RunTimeOnly )
+                    {
+                        // Skip runtime-only interfaces.
+                        continue;
+                    }
+
+                    filteredTypes.Add( baseType );
+                }
+
+                if ( filteredTypes.Count == baseList.Types.Count )
+                {
+                    // No interfaces were removed.
+                    return baseList;
+                }
+
+                if ( filteredTypes.Count == 0 )
+                {
+                    return null;
+                }
+
+                return baseList.WithTypes( SeparatedList( filteredTypes ) );
             }
 
             private IEnumerable<MethodDeclarationSyntax> TransformMethodDeclaration( MethodDeclarationSyntax node )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/Serialization/SerializerGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/Serialization/SerializerGenerator.cs
@@ -824,6 +824,12 @@ internal sealed class SerializerGenerator : ISerializerGenerator
             return false;
         }
 
+        // Skip explicit interface implementations — they cannot be accessed as this.Name.
+        if ( fieldOrProperty.IsExplicitInterfaceMemberImplementation() )
+        {
+            return false;
+        }
+
         if ( fieldOrProperty.GetAttributes()
             .Any(
                 a => this._runTimeCompilationContext.SymbolComparer.IsConvertibleTo(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Serialization/ReferenceType_RuntimeExplicitInterfaceImpl.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Serialization/ReferenceType_RuntimeExplicitInterfaceImpl.Dependency.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Serialization;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Serialization.ReferenceType_RuntimeExplicitInterfaceImpl;
+
+[RunTime]
+public interface IFace
+{
+    int Value { get; set; }
+
+    int ValueGetOnly { get; }
+}
+
+[RunTimeOrCompileTime]
+public class ReferenceType : IFace, ICompileTimeSerializable
+{
+    // Implicit member (not part of explicit interface impl).
+    public int OwnValue { get; set; }
+
+    // Explicit interface implementations.
+    int IFace.Value { get; set; }
+
+    int IFace.ValueGetOnly => OwnValue;
+
+    public ReferenceType( int value )
+    {
+        OwnValue = value;
+    }
+}
+
+[Inheritable]
+public class TestAspect : OverrideMethodAspect
+{
+    public ReferenceType SerializedValue;
+
+    public TestAspect( int x )
+    {
+        SerializedValue = new ReferenceType( x );
+    }
+
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( meta.CompileTime( SerializedValue.OwnValue ) );
+
+        return meta.Proceed();
+    }
+}
+
+public class BaseClass
+{
+    [TestAspect( 42 )]
+    public virtual void Foo() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Serialization/ReferenceType_RuntimeExplicitInterfaceImpl.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Serialization/ReferenceType_RuntimeExplicitInterfaceImpl.cs
@@ -2,16 +2,12 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-#if TEST_OPTIONS
-// @IncludeAllSeverities
-#endif
-
 using System;
 
-namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Serialization.ReferenceType_RuntimeInterfaceImpl;
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Serialization.ReferenceType_RuntimeExplicitInterfaceImpl;
 
 /*
- * A serializable reference type implicitly implementing an interface.
+ * A serializable reference type explicitly implementing a [RunTime] interface.
  */
 
 //<target>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Serialization/ReferenceType_RuntimeExplicitInterfaceImpl.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Serialization/ReferenceType_RuntimeExplicitInterfaceImpl.t.cs
@@ -1,0 +1,9 @@
+public class TargetClass : BaseClass
+{
+  public override void Foo()
+  {
+    global::System.Console.WriteLine(42);
+    Console.WriteLine("Original");
+    return;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #758

- Remove `[RunTime]` interfaces from the base list of compile-time versions of `[RunTimeOrCompileTime]` types
- Remove explicit implementations of `[RunTime]` interface members from compile-time versions

## Test plan

- [x] Un-skip existing `ReferenceType_RuntimeInterfaceImpl` test (implicit interface implementation)
- [x] Add new `ReferenceType_RuntimeExplicitInterfaceImpl` test (explicit interface implementation)
- [x] Both tests currently FAIL (confirming the bug)
- [x] Implement fix
- [x] Both tests pass after fix
- [x] All existing serialization tests still pass
- [x] Full build with zero warnings