### PR TITLE
Add regression test for #764: WithTypeArguments params extension method in templates

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug764.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug764.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Collections.Generic;
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+#pragma warning disable CS0618 // WithTypeArguments is obsolete
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug764;
+
+public class TestData<T>
+{
+    public T? Value { get; set; }
+}
+
+public class MyAspect : MethodAspect
+{
+    public override void BuildAspect( IAspectBuilder<IMethod> builder )
+    {
+        builder.Override( nameof(Template), args: new { T = builder.Target.ReturnType } );
+    }
+
+    [Template]
+    public dynamic? Template<[CompileTime] T>()
+    {
+        var method = meta.Target.Type.Methods.OfName( "Bar" ).Single();
+
+        // Scenario from the bug: WithTypeArguments (params extension method) with typeof(T).
+        method.WithTypeArguments( typeof(T) ).Invoke( new TestData<T>() );
+
+        // Same with MakeGenericInstance (non-obsolete equivalent).
+        method.MakeGenericInstance( typeof(T) ).Invoke( new TestData<T>() );
+
+        // WithTypeArguments with multiple params type arguments.
+        var method2 = meta.Target.Type.Methods.OfName( "Baz" ).Single();
+        method2.WithTypeArguments( typeof(T), typeof(int) ).Invoke( new TestData<T>(), new List<int>() );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+public class Target
+{
+    public void Bar<TValue>( TestData<TValue> data ) { }
+
+    public void Baz<TValue, TExtra>( TestData<TValue> data, List<TExtra> extra ) { }
+
+    [MyAspect]
+    public string Foo() => "";
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug764.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug764.t.cs
@@ -1,0 +1,17 @@
+public class Target
+{
+  public void Bar<TValue>(TestData<TValue> data)
+  {
+  }
+  public void Baz<TValue, TExtra>(TestData<TValue> data, List<TExtra> extra)
+  {
+  }
+  [MyAspect]
+  public string Foo()
+  {
+    this.Bar<global::System.String>(new global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug764.TestData<global::System.String>());
+    this.Bar<global::System.String>(new global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug764.TestData<global::System.String>());
+    this.Baz<global::System.String, global::System.Int32>(new global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug764.TestData<global::System.String>(), new global::System.Collections.Generic.List<global::System.Int32>());
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary

Closes #764

The original bug reported that `method.WithTypeArguments(typeof(T)).Invoke(new TestData<T>())` in a T# template (where `T` is a `[CompileTime]` type parameter) was not transformed correctly by the template compiler. Specifically, the compile-time code was incorrectly generating `typeof(T)` literally instead of properly resolving it.

This issue has been fixed incidentally by subsequent improvements to the template compiler (particularly changes to `TemplateCompilerRewriter` handling of extension methods, `typeof` resolution, and `params` arguments).

This PR adds a regression test to ensure the fix remains in place, covering:
- `WithTypeArguments(typeof(T))` with a single compile-time type parameter (the original bug scenario)
- `MakeGenericInstance(typeof(T))` (the non-obsolete equivalent)
- `WithTypeArguments(typeof(T), typeof(int))` with multiple `params` type arguments

All scenarios correctly transform the template and generate the expected run-time code.

## Test plan
- [x] Regression test `Bug764` passes on net8.0

— *Claude for @PostSharpAgent*