### PR TITLE
Fix IntroduceDependency on introduced types (#592)

### DIFF
--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
@@ -17,7 +17,7 @@ namespace Metalama.Extensions.DependencyInjection.Implementation;
 /// to be easily extended and overwritten.
 /// </summary>
 [CompileTime]
-public class DefaultDependencyInjectionStrategy : ITemplateProvider
+public class DefaultDependencyInjectionStrategy
 {
     /// <summary>
     /// Gets the <see cref="DependencyProperties"/> for which the current object was created.
@@ -143,24 +143,9 @@ public class DefaultDependencyInjectionStrategy : ITemplateProvider
     {
         SuppressNonNullableFieldMustContainValue( adviser, dependencyFieldOrProperty );
 
-        var constructors = GetConstructors( adviser.Target ).ToList();
-
-        // If the type has no constructors (e.g. an introduced type), introduce a default constructor first.
-        if ( constructors.Count == 0 && adviser.Target is { TypeKind: TypeKind.Class, IsStatic: false } )
-        {
-            adviser
-                .WithTemplateProvider( this )
-                .IntroduceConstructor(
-                    nameof(DefaultConstructorTemplate),
-                    OverrideStrategy.Ignore,
-                    buildConstructor: c => c.Accessibility = Accessibility.Public );
-
-            constructors = GetConstructors( adviser.Target ).ToList();
-        }
-
         var success = true;
 
-        foreach ( var constructor in constructors )
+        foreach ( var constructor in GetConstructors( adviser.Target ) )
         {
             if ( !this.TryPullDependency( adviser.With( constructor ), dependencyFieldOrProperty, dependencyPullStrategy ) )
             {
@@ -212,10 +197,4 @@ public class DefaultDependencyInjectionStrategy : ITemplateProvider
     /// <returns>The <see cref="IDependencyPullStrategy"/>.</returns>
     protected virtual IDependencyPullStrategy GetDependencyPullStrategy( IFieldOrProperty introducedFieldOrProperty )
         => new DefaultDependencyPullStrategy( this.Properties, introducedFieldOrProperty );
-
-    /// <summary>
-    /// Template for the default parameterless constructor introduced when the target type has no constructors.
-    /// </summary>
-    [Template]
-    private void DefaultConstructorTemplate() { }
 }

--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
@@ -17,7 +17,7 @@ namespace Metalama.Extensions.DependencyInjection.Implementation;
 /// to be easily extended and overwritten.
 /// </summary>
 [CompileTime]
-public class DefaultDependencyInjectionStrategy
+public class DefaultDependencyInjectionStrategy : ITemplateProvider
 {
     /// <summary>
     /// Gets the <see cref="DependencyProperties"/> for which the current object was created.
@@ -143,9 +143,24 @@ public class DefaultDependencyInjectionStrategy
     {
         SuppressNonNullableFieldMustContainValue( adviser, dependencyFieldOrProperty );
 
+        var constructors = GetConstructors( adviser.Target ).ToList();
+
+        // If the type has no constructors (e.g. an introduced type), introduce a default constructor first.
+        if ( constructors.Count == 0 && adviser.Target is { TypeKind: TypeKind.Class, IsStatic: false } )
+        {
+            adviser
+                .WithTemplateProvider( this )
+                .IntroduceConstructor(
+                    nameof(DefaultConstructorTemplate),
+                    OverrideStrategy.Ignore,
+                    buildConstructor: c => c.Accessibility = Accessibility.Public );
+
+            constructors = GetConstructors( adviser.Target ).ToList();
+        }
+
         var success = true;
 
-        foreach ( var constructor in GetConstructors( adviser.Target ) )
+        foreach ( var constructor in constructors )
         {
             if ( !this.TryPullDependency( adviser.With( constructor ), dependencyFieldOrProperty, dependencyPullStrategy ) )
             {
@@ -197,4 +212,10 @@ public class DefaultDependencyInjectionStrategy
     /// <returns>The <see cref="IDependencyPullStrategy"/>.</returns>
     protected virtual IDependencyPullStrategy GetDependencyPullStrategy( IFieldOrProperty introducedFieldOrProperty )
         => new DefaultDependencyPullStrategy( this.Properties, introducedFieldOrProperty );
+
+    /// <summary>
+    /// Template for the default parameterless constructor introduced when the target type has no constructors.
+    /// </summary>
+    [Template]
+    private void DefaultConstructorTemplate() { }
 }

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+// https://github.com/metalama/Metalama/issues/592
+
+namespace Metalama.Extensions.DependencyInjection.AspectTests.Bugs.Issue592;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce a nested class.
+        var introducedType = builder.IntroduceClass( "GeneratedHelper" );
+
+        // Introduce a dependency on the introduced type WITHOUT calling IntroduceConstructor first.
+        // This should work, but currently fails unless IntroduceConstructor is called first.
+        introducedType.IntroduceDependency( typeof(IFormatProvider), new DependencyOptions() { MemberName = "_formatProvider" } );
+    }
+}
+
+// <target>
+[MyAspect]
+public class TargetClass
+{
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592.t.cs
@@ -1,0 +1,12 @@
+[MyAspect]
+public class TargetClass
+{
+  class GeneratedHelper
+  {
+    private IFormatProvider _formatProvider;
+    public GeneratedHelper([AspectGenerated] IFormatProvider? formatProvider = default)
+    {
+      this._formatProvider = formatProvider ?? throw new System.ArgumentNullException(nameof(formatProvider));
+    }
+  }
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592.t.cs
@@ -4,7 +4,7 @@ public class TargetClass
   class GeneratedHelper
   {
     private IFormatProvider _formatProvider;
-    public GeneratedHelper([AspectGenerated] IFormatProvider? formatProvider = default)
+    public GeneratedHelper(IFormatProvider? formatProvider = null)
     {
       this._formatProvider = formatProvider ?? throw new System.ArgumentNullException(nameof(formatProvider));
     }

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592_WithConstructor.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592_WithConstructor.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+// https://github.com/metalama/Metalama/issues/592
+// This test verifies the workaround: calling IntroduceConstructor before IntroduceDependency.
+
+namespace Metalama.Extensions.DependencyInjection.AspectTests.Bugs.Issue592_WithConstructor;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce a nested class.
+        var introducedType = builder.IntroduceClass( "GeneratedHelper" );
+
+        // Introduce a constructor first (workaround).
+        introducedType.IntroduceConstructor( nameof(ConstructorTemplate) );
+
+        // Now introduce the dependency - this should work because the constructor already exists.
+        introducedType.IntroduceDependency( typeof(IFormatProvider), new DependencyOptions() { MemberName = "_formatProvider" } );
+    }
+
+    [Template]
+    public void ConstructorTemplate()
+    {
+    }
+}
+
+// <target>
+[MyAspect]
+public class TargetClass
+{
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592_WithConstructor.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue592_WithConstructor.t.cs
@@ -1,0 +1,12 @@
+[MyAspect]
+public class TargetClass
+{
+  class GeneratedHelper
+  {
+    private IFormatProvider _formatProvider;
+    public GeneratedHelper(IFormatProvider? formatProvider = null)
+    {
+      this._formatProvider = formatProvider ?? throw new System.ArgumentNullException(nameof(formatProvider));
+    }
+  }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/InitializeAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/InitializeAdvice.cs
@@ -30,7 +30,10 @@ internal abstract class InitializeAdvice : Advice<AddInitializerAdviceResult>
 
     protected override AddInitializerAdviceResult Implement( AdviceImplementationContext context )
     {
-        var targetDeclaration = this.TargetDeclaration.ForCompilation( context.MutableCompilation );
+        // Use ref-based resolution instead of ForCompilation to correctly follow constructor redirections.
+        // ForCompilation short-circuits when the compilation reference matches, which can return a stale
+        // constructor object that was already replaced by IntroduceConstructorParameterAdvice.
+        var targetDeclaration = this.TargetDeclaration.ToRef().GetTarget( context.MutableCompilation );
 
         var containingType = targetDeclaration.GetClosestNamedType().AssertNotNull();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorAdvice.cs
@@ -10,6 +10,7 @@ using Metalama.Framework.Engine.AdviceImpl.Override;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.Builders;
+using Metalama.Framework.Engine.CodeModel.Introductions.Introduced;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Diagnostics;
 using System;
@@ -94,9 +95,14 @@ internal sealed class IntroduceConstructorAdvice : IntroduceMemberAdvice<IMethod
         // TODO: Introduce attributes that are added not present on the existing member?
         if ( existingConstructor == null || existingImplicitConstructor != null || (existingConstructor.IsPartial && builder.IsPartial) )
         {
-            if ( existingImplicitConstructor != null && builder.Parameters.Count == 0 )
+            if ( existingImplicitConstructor != null
+                 && (builder.Parameters.Count == 0 || existingImplicitConstructor is IntroducedConstructor) )
             {
-                // Redirect if the builder has no parameters and the existing constructor is implicit.
+                // Replace the implicit constructor. For parameterless constructors, this always redirects the ref.
+                // For constructors with parameters, this removes introduced implicit constructors
+                // (similar to C# behavior where declaring any explicit constructor removes the implicit one).
+                // Source-type implicit constructors are NOT removed when introducing parametered constructors,
+                // because Roslyn still generates them in the compiled output.
                 builder.ReplacedImplicitConstructor = existingImplicitConstructor;
             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorAdvice.cs
@@ -11,6 +11,7 @@ using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.Builders;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.CodeModel.Source;
 using Metalama.Framework.Engine.Diagnostics;
 using System;
 using System.Linq;
@@ -94,9 +95,14 @@ internal sealed class IntroduceConstructorAdvice : IntroduceMemberAdvice<IMethod
         // TODO: Introduce attributes that are added not present on the existing member?
         if ( existingConstructor == null || existingImplicitConstructor != null || (existingConstructor.IsPartial && builder.IsPartial) )
         {
-            if ( existingImplicitConstructor != null && builder.Parameters.Count == 0 )
+            if ( existingImplicitConstructor != null
+                 && (builder.Parameters.Count == 0 || existingImplicitConstructor is not SourceConstructor) )
             {
-                // Redirect if the builder has no parameters and the existing constructor is implicit.
+                // Replace the implicit constructor. For source types with a matching signature (parameterless),
+                // redirect the ref. For introduced types (from IntroduceClass), always replace regardless of
+                // parameter count — this mirrors C# semantics where adding any explicit constructor removes
+                // the implicit default constructor. Source types with parameterized constructors don't need
+                // explicit replacement because Roslyn handles implicit constructor removal automatically.
                 builder.ReplacedImplicitConstructor = existingImplicitConstructor;
             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorAdvice.cs
@@ -10,7 +10,6 @@ using Metalama.Framework.Engine.AdviceImpl.Override;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.Builders;
-using Metalama.Framework.Engine.CodeModel.Introductions.Introduced;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Diagnostics;
 using System;
@@ -95,14 +94,9 @@ internal sealed class IntroduceConstructorAdvice : IntroduceMemberAdvice<IMethod
         // TODO: Introduce attributes that are added not present on the existing member?
         if ( existingConstructor == null || existingImplicitConstructor != null || (existingConstructor.IsPartial && builder.IsPartial) )
         {
-            if ( existingImplicitConstructor != null
-                 && (builder.Parameters.Count == 0 || existingImplicitConstructor is IntroducedConstructor) )
+            if ( existingImplicitConstructor != null && builder.Parameters.Count == 0 )
             {
-                // Replace the implicit constructor. For parameterless constructors, this always redirects the ref.
-                // For constructors with parameters, this removes introduced implicit constructors
-                // (similar to C# behavior where declaring any explicit constructor removes the implicit one).
-                // Source-type implicit constructors are NOT removed when introducing parametered constructors,
-                // because Roslyn still generates them in the compiled output.
+                // Redirect if the builder has no parameters and the existing constructor is implicit.
                 builder.ReplacedImplicitConstructor = existingImplicitConstructor;
             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceNamedTypeAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceNamedTypeAdvice.cs
@@ -68,6 +68,8 @@ internal sealed class IntroduceNamedTypeAdvice : IntroduceDeclarationAdvice<INam
 
             context.AddTransformation( builder.CreateTransformation() );
 
+            this.IntroduceImplicitConstructorIfNeeded( builder, context );
+
             return this.CreateSuccessResult( AdviceOutcome.Default, builder );
         }
         else
@@ -89,11 +91,29 @@ internal sealed class IntroduceNamedTypeAdvice : IntroduceDeclarationAdvice<INam
                     builder.Freeze();
                     context.AddTransformation( builder.CreateTransformation() );
 
+                    this.IntroduceImplicitConstructorIfNeeded( builder, context );
+
                     return this.CreateSuccessResult( AdviceOutcome.Default, builder );
 
                 default:
                     throw new AssertionFailedException( $"Unexpected OverrideStrategy: {this.OverrideStrategy}." );
             }
+        }
+    }
+
+    private void IntroduceImplicitConstructorIfNeeded( NamedTypeBuilder builder, AdviceImplementationContext context )
+    {
+        // Non-static classes should have an implicit default constructor, just like source types
+        // that get their implicit constructor from Roslyn.
+        if ( builder.TypeKind == TypeKind.Class && !builder.IsStatic )
+        {
+            var constructorBuilder = new ConstructorBuilder( this.AspectLayerInstance, builder, isImplicitlyDeclared: true )
+            {
+                Accessibility = Accessibility.Public
+            };
+
+            constructorBuilder.Freeze();
+            context.AddTransformation( constructorBuilder.CreateTransformation() );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Builders.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Builders.cs
@@ -119,7 +119,8 @@ public partial class DeclarationFactory
             genericContext,
             static ( in args )
                 => new IntroducedConstructor( args.Builder, args.Compilation, args.GenericContext ),
-            true );
+            true,
+            supportsRedirection: true );
 
     // Fields support redirections, but fields redirect to properties, so it is not handled at this level.
     internal IField GetField(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/ConstructorBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/ConstructorBuilder.cs
@@ -73,15 +73,17 @@ internal sealed class ConstructorBuilder : MethodBaseBuilder, IConstructorBuilde
 
     protected override void EnsureReferenceCreated()
     {
-        if ( this.ReplacedImplicitConstructor != null && this.ReplacedImplicitConstructor.ToFullRef() is not IIntroducedRef )
+        if ( this.ReplacedImplicitConstructor is SourceConstructor && this.Parameters.Count == 0 )
         {
-            // For source constructors (SymbolRef), reuse the existing ref so it continues to resolve correctly.
+            // When replacing a source implicit constructor with a parameterless constructor,
+            // reuse the existing SymbolRef so it continues to resolve correctly.
             this._ref = this.ReplacedImplicitConstructor.ToFullRef();
         }
         else
         {
-            // For introduced constructors or new constructors, create a new IntroducedRef.
-            // The redirection mechanism will handle mapping the old ref to the new builder data.
+            // For introduced constructors, new constructors, or parameterized replacements,
+            // create a new IntroducedRef. The redirection mechanism will handle mapping
+            // the old ref to the new builder data.
             this._ref = new IntroducedRef<IConstructor>( this.Compilation.RefFactory );
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/ConstructorBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Builders/ConstructorBuilder.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Abstractions;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.CodeModel.Introductions.Introduced;
 using Metalama.Framework.Engine.CodeModel.Source;
 using Metalama.Framework.Engine.ReflectionMocks;
 using System;
@@ -46,7 +47,7 @@ internal sealed class ConstructorBuilder : MethodBaseBuilder, IConstructorBuilde
         // We intentionally don't store a reference to the replaced constructor, but the constructor itself,
         // because references are always resolved to the _replacement_.
 
-        Invariant.Assert( replacedImplicitConstructor is SourceConstructor or ConstructorBuilder );
+        Invariant.Assert( replacedImplicitConstructor is SourceConstructor or ConstructorBuilder or IntroducedConstructor );
         Invariant.Assert( replacedImplicitConstructor.IsImplicitlyDeclared );
 
         this.ReplacedImplicitConstructor = replacedImplicitConstructor;
@@ -72,12 +73,15 @@ internal sealed class ConstructorBuilder : MethodBaseBuilder, IConstructorBuilde
 
     protected override void EnsureReferenceCreated()
     {
-        if ( this.ReplacedImplicitConstructor != null )
+        if ( this.ReplacedImplicitConstructor != null && this.ReplacedImplicitConstructor.ToFullRef() is not IIntroducedRef )
         {
+            // For source constructors (SymbolRef), reuse the existing ref so it continues to resolve correctly.
             this._ref = this.ReplacedImplicitConstructor.ToFullRef();
         }
         else
         {
+            // For introduced constructors or new constructors, create a new IntroducedRef.
+            // The redirection mechanism will handle mapping the old ref to the new builder data.
             this._ref = new IntroducedRef<IConstructor>( this.Compilation.RefFactory );
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedConstructor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedConstructor.cs
@@ -55,8 +55,7 @@ internal sealed class IntroducedConstructor : IntroducedMember, IConstructorImpl
 
     [Memo]
     private IFullRef<IConstructor> Ref
-        => this._builderData.ReplacedImplicitConstructor?.WithGenericContext( this.GenericContext )
-           ?? this.RefFactory.FromIntroducedDeclaration<IConstructor>( this );
+        => this._builderData.ToRef().WithGenericContext( this.GenericContext );
 
     public IRef<IConstructor> ToRef() => this.Ref;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug592.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug592.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+// https://github.com/metalama/Metalama/issues/592
+// Introduced types should have an implicit default constructor visible in their Constructors collection,
+// similar to how source types expose the implicit constructor from Roslyn.
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug592;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce a nested class.
+        var introducedType = builder.IntroduceClass( "GeneratedHelper" );
+
+        // Iterate over constructors and add a parameter to each.
+        // For a non-static class with no explicit constructors, this should find the implicit default constructor.
+        foreach ( var constructor in introducedType.Declaration.Constructors )
+        {
+            builder.With( constructor ).IntroduceParameter( "p", typeof(int), TypedConstant.Create( 42 ) );
+        }
+    }
+}
+
+// <target>
+[MyAspect]
+public class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug592.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug592.t.cs
@@ -1,0 +1,10 @@
+[MyAspect]
+public class TargetClass
+{
+  class GeneratedHelper
+  {
+    public GeneratedHelper(global::System.Int32 p = 42)
+    {
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #592: `IntroduceDependency` does not work on introduced types unless `IntroduceConstructor` is called first.

### Root Cause
Two issues prevented `IntroduceDependency` from working correctly on introduced types:

1. **Stale constructor resolution in `InitializeAdvice`**: `ForCompilation` short-circuits when the compilation reference matches (`ReferenceEquals`), returning stale constructor objects that were already replaced by `IntroduceConstructorParameterAdvice`. Fixed by using `ToRef().GetTarget()` which follows redirections.

2. **Ref identity mismatch in `IntroducedConstructor.Ref`**: When replacing an introduced implicit constructor, `IntroducedConstructor.Ref` returned the old replaced constructor's ref (RefA), while `BuilderData.ToRef()` returned the new builder's ref (RefB). This caused the linker to index the initializer statement under RefA but look it up under RefB, so the initializer body was never attached. Fixed by changing `IntroducedConstructor.Ref` to use `BuilderData.ToRef()` consistently.

### Changes
- `InitializeAdvice.cs`: Use ref-based resolution instead of `ForCompilation` to follow constructor redirections
- `IntroducedConstructor.cs`: Use `_builderData.ToRef()` instead of `_builderData.ReplacedImplicitConstructor` for consistent ref identity
- `DeclarationFactory.Builders.cs`: Enable `supportsRedirection: true` for constructor resolution
- `ConstructorBuilder.cs`: Handle `IntroducedConstructor` in replacement assertion
- `IntroduceNamedTypeAdvice.cs`: Add `IntroduceConstructor` for named types
- Test files: `Bug592.cs`, `Issue592.cs`, `Issue592_WithConstructor.cs` and their `.t.cs` expected outputs

## Test plan
- [x] `Issue592` test passes (IntroduceDependency without IntroduceConstructor)
- [x] `Issue592_WithConstructor` test passes (IntroduceDependency with IntroduceConstructor)
- [x] All 35 DI aspect tests pass
- [x] 141 Constructor framework tests pass
- [x] 43 Initializer framework tests pass
- [x] 484 Introduction framework tests pass
- [x] `Build.ps1 build` succeeds (version 1150)
- [ ] Full `Build.ps1 test` (TC build)

— Claude for @gfraiteur