### PR TITLE
Fix StructuralDeclarationComparer for extension blocks

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Comparers/StructuralDeclarationComparer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Comparers/StructuralDeclarationComparer.cs
@@ -629,7 +629,7 @@ internal sealed class StructuralDeclarationComparer : IEqualityComparer<ICompila
 
                 return result;
 
-            case TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Error
+            case TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Error or TypeKind.Extension
                 when typeX is INamedType namedTypeX && typeY is INamedType namedTypeY:
                 return this.CompareNamedTypes( namedTypeX, namedTypeY, this._options );
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/DeclarationExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/DeclarationExtensions.cs
@@ -116,7 +116,7 @@ namespace Metalama.Framework.Code
             /// <value>
             ///     <c>true</c> if the declaration kind represents a member or named type; otherwise, <c>false</c>.
             /// </value>
-            public bool IsMemberOrNamedType => kind.IsMember || kind == DeclarationKind.NamedType;
+            public bool IsMemberOrNamedType => kind.IsMember || kind is DeclarationKind.NamedType or DeclarationKind.ExtensionBlock;
 
             /// <summary>
             /// Determines whether a <see cref="DeclarationKind"/> represents an <see cref="IType"/>.
@@ -124,7 +124,7 @@ namespace Metalama.Framework.Code
             /// <value>
             ///     <c>true</c> if the declaration kind represents a type; otherwise, <c>false</c>.
             /// </value>
-            public bool IsType => kind is DeclarationKind.NamedType or DeclarationKind.TypeParameter or DeclarationKind.Type;
+            public bool IsType => kind is DeclarationKind.NamedType or DeclarationKind.ExtensionBlock or DeclarationKind.TypeParameter or DeclarationKind.Type;
 
             /// <summary>
             /// Gets a value indicating whether the declaration kind represents an assembly

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/StructuralSymbolComparerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/StructuralSymbolComparerTests.cs
@@ -123,6 +123,34 @@ class A
             Assert.False( StructuralDeclarationComparer.IncludeAssembly.Equals( externalNamespace, internalNamespace ) );
         }
 
+#if ROSLYN_5_0_0_OR_GREATER && NET7_0_OR_GREATER
+        [Fact]
+        public void ExtensionBlocks()
+        {
+            const string code = """
+                                public static class MyExtensions
+                                {
+                                    extension(string self)
+                                    {
+                                        public int GetLength() => self.Length;
+                                        public bool IsEmpty() => self.Length == 0;
+                                    }
+                                }
+                                """;
+
+            using var testContext = this.CreateTestContext();
+
+            var compilation1 = testContext.CreateCompilationModel( code );
+            var compilation2 = testContext.CreateCompilationModel( code );
+
+            AssertSymbolsEqual(
+                GetAllDeclarations( compilation1 ),
+                GetAllDeclarations( compilation2 ),
+                StructuralDeclarationComparer.BypassSymbols,
+                CompilationElementEqualityComparer.Default );
+        }
+#endif
+
         // TODO: More tests.
 
         private static void AssertSymbolsEqual<T>(


### PR DESCRIPTION
## Summary

Fixes #1339.

`StructuralDeclarationComparer.Compare` throws `NotImplementedException("Unexpected DeclarationKind: ExtensionBlock.")` when comparing extension blocks without Roslyn symbols. This is because:

1. The `DeclarationKind.IsType` extension property doesn't include `DeclarationKind.ExtensionBlock`, so extension blocks are routed to the declaration comparison branch instead of the type comparison branch.
2. The declaration comparison switch has no case for `DeclarationKind.ExtensionBlock`, causing the `default` case to throw.
3. Additionally, `CompareTypes` doesn't handle `TypeKind.Extension` in its switch.

## Changes

- **`DeclarationExtensions.cs`**: Added `DeclarationKind.ExtensionBlock` to `IsType` and `IsMemberOrNamedType` extension properties.
- **`StructuralDeclarationComparer.cs`**: Added `TypeKind.Extension` to the `CompareTypes` switch, routing through `CompareNamedTypes`.
- **`StructuralSymbolComparerTests.cs`**: Regression test using `BypassSymbols` to exercise the non-symbol comparison path.

## Test plan

- [x] New unit test `ExtensionBlocks` in `StructuralSymbolComparerTests` passes
- [x] Existing extension block aspect tests pass
- [x] Full `Build.ps1 build` succeeds with zero warnings
- [x] Full `Build.ps1 test` succeeds with zero failures and zero warnings

— Claude for @gfraiteur