### PR TITLE
Increase DotNetTool default timeout to 5 minutes (#1340)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
@@ -25,7 +25,7 @@ public sealed class DotNetTool
     public void Execute(
         string arguments,
         string? workingDirectory = null,
-        int timeout = 30_000,
+        int timeout = 300_000,
         Func<KeyValuePair<string, string?>, bool>? environmentVariableFilter = null )
     {
         var startInfo = new ProcessStartInfo( this._platformInfo.DotNetExePath, arguments )


### PR DESCRIPTION
## Summary
- Increases the default timeout in `DotNetTool.Execute` from 30 seconds to 5 minutes (300,000 ms)
- Fixes flaky test `Metalama.Framework.Tests.Workspaces.WorkspaceTests.CrossProjectInboundReferences` which fails intermittently when `dotnet restore` exceeds 30 seconds under high CI load

## Test plan
- [x] All 8 workspace tests pass locally
- [x] All 4 AspectTestRunnerTests pass locally
- [x] Full `Build.ps1 build` succeeds with zero warnings
- [x] Branch merged with latest develop/2026.1
- [ ] TC build passes (awaiting new CI run)

Fixes #1340

— Claude for @gfraiteur