### PR TITLE
Fix flaky CleanUpTests.Clean_DeepDirectoryStructure (#1346)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Maintenance/TempFileManager.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Maintenance/TempFileManager.cs
@@ -352,7 +352,7 @@ public sealed class TempFileManager : ITempFileManager
             var lastWriteTime = this._fileSystem.GetFileLastWriteTime( file );
             var lastWriteTimeUtc = lastWriteTime.ToUniversalTime();
 
-            if ( lastWriteTimeUtc < threshold )
+            if ( lastWriteTimeUtc <= threshold )
             {
                 if ( isCleanupFile )
                 {

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Maintenance/CleanUpTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Maintenance/CleanUpTests.cs
@@ -301,6 +301,42 @@ public sealed class CleanUpTests : TestsBase
     }
 
     [Fact]
+    public void Clean_DeepDirectoryStructure_WhenFileTimestampEqualsThreshold()
+    {
+        // Regression test for #1346: When the file timestamp exactly equals the cleanup threshold,
+        // the directory should still be deleted. This reproduces the flaky test condition where
+        // Windows timer coarseness causes file creation and AddTime to use the same tick value.
+
+        // Freeze time at a known point so that all file timestamps are deterministic.
+        var frozenTime = new DateTime( 2025, 1, 1, 12, 0, 0, DateTimeKind.Utc );
+        this.Time.Set( frozenTime );
+
+        // Create a directory with a cleanup.json file at the frozen time.
+        var testDirectory = Path.Combine( this._standardDirectories.TempDirectory, "BoundaryTest" );
+
+        for ( var i = 0; i < 3; i++ )
+        {
+            var subDirectory = Path.Combine( testDirectory, $"sub_{i}" );
+            this.FileSystem.CreateDirectory( subDirectory );
+            var cleanUpFile = new CleanUpFile { Strategy = CleanUpStrategy.Always };
+            var cleanUpFileContent = JsonConvert.SerializeObject( cleanUpFile );
+            this.FileSystem.WriteAllText( Path.Combine( subDirectory, "cleanup.json" ), cleanUpFileContent );
+        }
+
+        // First cleanup: deletes non-cleanup files but keeps directories with cleanup.json.
+        var tempFileManager = new TempFileManager( this.ServiceProvider );
+        tempFileManager.CleanTempDirectories( true );
+
+        // Advance time by exactly 4 hours (the Always strategy threshold).
+        // Since time was frozen at frozenTime, file timestamps == frozenTime.
+        // The threshold will be (frozenTime + 4h) - 4h == frozenTime.
+        // With strict '<', frozenTime < frozenTime is false, so the directory would NOT be deleted.
+        this.Time.AddTime( TimeSpan.FromHours( 4 ) );
+        tempFileManager.CleanTempDirectories( true );
+        Assert.False( this.FileSystem.DirectoryExists( testDirectory ) );
+    }
+
+    [Fact]
     public void Clean_ReadOnlyFiles()
     {
         // Create a read-only file.


### PR DESCRIPTION
## Summary

Fixes #1346 — Flaky test `CleanUpTests.Clean_DeepDirectoryStructure` under concurrent CI load.

**Root cause:** The `TempFileManager.DeleteIndividualFiles` method used a strict `<` comparison when checking if a file's last write time is older than the cleanup threshold. Under heavy CI load, Windows timer coarseness (~15.6ms) can cause file creation timestamps and the threshold computation to use the same tick value, making `fileLastWriteTime == threshold` evaluate `<` to `false` and skip cleanup.

**Fix:** Changed `<` to `<=` in the cleanup age comparison (line 355 of `TempFileManager.cs`) so that files created at exactly the cleanup threshold are still considered old enough for deletion.

**Regression test:** Added `Clean_DeepDirectoryStructure_WhenFileTimestampEqualsThreshold` which deterministically reproduces the boundary condition by freezing the `TestDateTimeProvider` before file creation.

## Progress Checklist

- [x] Reproduce the bug with a deterministic regression test
- [x] Implement the fix
- [x] Run all tests in the solution (1246 passed on net8.0, 11 CleanUpTests passed on both net8.0 and net472)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Finalize and mark PR as ready

## Changed Files

- `Metalama.Backstage/src/Metalama.Backstage/Maintenance/TempFileManager.cs` — Change `<` to `<=` in `DeleteIndividualFiles`
- `Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Maintenance/CleanUpTests.cs` — Add regression test

— Claude for @gfraiteur