### PR TITLE
Fix invokers in initializer advice not correctly resolved

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/AspectReferenceResolver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/AspectReferenceResolver.cs
@@ -156,7 +156,7 @@ internal sealed class AspectReferenceResolver
         // At this point we should always target a method or a specific target.
         Invariant.AssertNot( resolvedReferencedSymbol.Kind is SymbolKind.Property or SymbolKind.Event or SymbolKind.Field && targetKind == AspectReferenceTargetKind.Self );
 
-        var annotationLayerIndex = this.GetAnnotationLayerIndex( containingSemantic.Symbol );
+        var annotationLayerIndex = this.GetAnnotationLayerIndex( containingSemantic.Symbol, referenceSpecification.AspectLayerId );
 
         // If the override target was introduced, determine the index.
         var targetIntroductionInjectedMember = this._injectionRegistry.GetInjectedMemberForSymbol( resolvedReferencedSymbol );
@@ -455,13 +455,23 @@ internal sealed class AspectReferenceResolver
         return this.GetMemberLayerIndex( injectedMember );
     }
 
-    private MemberLayerIndex GetAnnotationLayerIndex( ISymbol containingSymbol )
+    private MemberLayerIndex GetAnnotationLayerIndex( ISymbol containingSymbol, AspectLayerId annotationAspectLayerId )
     {
-        var containingInjectedMember =
-            this._injectionRegistry.GetInjectedMemberForSymbol( containingSymbol )
-            ?? throw new AssertionFailedException( $"Could not find injected member for {containingSymbol}." );
+        var containingInjectedMember = this._injectionRegistry.GetInjectedMemberForSymbol( containingSymbol );
 
-        return this.GetMemberLayerIndex( containingInjectedMember );
+        if ( containingInjectedMember != null )
+        {
+            return this.GetMemberLayerIndex( containingInjectedMember );
+        }
+
+        // For source members with inserted statements (e.g. constructors with AddInitializer advice),
+        // the containing symbol is not an injected member. Use the aspect layer from the annotation itself.
+        if ( annotationAspectLayerId != default && this._layerIndex.TryGetValue( annotationAspectLayerId, out var layerIndex ) )
+        {
+            return new MemberLayerIndex( layerIndex, 0, 0 );
+        }
+
+        throw new AssertionFailedException( $"Could not find injected member for {containingSymbol}." );
     }
 
     private MemberLayerIndex GetMemberLayerIndex( InjectedMember injectedMember )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.AspectReferenceCollector.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.AspectReferenceCollector.cs
@@ -286,6 +286,23 @@ internal sealed partial class LinkerAnalysisStep
                 }
             }
 
+            // Analyze source constructor bodies that received inserted initializer statements.
+            // These constructors are not injected members but their bodies may contain aspect reference annotations
+            // from initializer advice templates (AddInitializer). Without this analysis, invokers in initializer
+            // advice code would not be correctly resolved by the linker.
+            // We exclude:
+            //  - Constructors that are already injected members (already processed above by ProcessInjectedMember).
+            //  - Primary constructors (their initializer statements are in an auxiliary body, an injected member).
+            var constructorsWithInsertedStatements = this._injectionRegistry.GetConstructorsWithInsertedStatements()
+                .Where( c => this._injectionRegistry.GetInjectedMemberForSymbol( c ) == null
+                             && c.GetPrimaryDeclarationSyntax() is ConstructorDeclarationSyntax )
+                .ToList();
+
+            await this._concurrentTaskRunner.RunConcurrentlyAsync(
+                constructorsWithInsertedStatements,
+                AnalyzeIntroducedBody,
+                cancellationToken );
+
             return aspectReferences;
 
             void AnalyzeIntroducedBody( IMethodSymbol symbol )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
@@ -345,16 +345,13 @@ internal sealed partial class LinkerAnalysisStep
                     }
                 }
 
-                // Add substitutions of non-inlined aspect references.
-                if ( this._nonInlinedReferences.TryGetValue( inliningSpecification.TargetSemantic, out var nonInlinedReferenceList ) )
-                {
-                    foreach ( var nonInlinedReference in nonInlinedReferenceList )
-                    {
-                        AddSubstitutionsForNonInlinedReference( nonInlinedReference, inliningSpecification.ContextIdentifier );
-                    }
-                }
+                // Add substitutions for redirected nodes first, then aspect references.
+                // Redirections take priority over aspect references because the redirection mechanism
+                // (e.g., for get-only auto property overrides) is more specific. An aspect reference
+                // substitution targeting a parent node would overwrite the child redirection.
+                // This mirrors the ordering and filtering logic in ProcessNonInlinedSemantic.
+                HashSet<SyntaxNode>? inlinedAspectReferenceRootNodesWithRedirectedDescendant = null;
 
-                // Add substitutions for redirected nodes.
                 if ( this._redirectedSymbolReferencesByContainingSemantic.TryGetValue( inliningSpecification.TargetSemantic, out var references ) )
                 {
                     foreach ( var reference in references )
@@ -364,6 +361,45 @@ internal sealed partial class LinkerAnalysisStep
                         AddSubstitution(
                             inliningSpecification.ContextIdentifier,
                             new RedirectionSubstitution( this._intermediateCompilationContext, reference.ReferencingNode, redirectionTarget ) );
+                    }
+
+                    // Build a set of aspect reference root nodes that contain a redirected descendant.
+                    if ( this._nonInlinedReferences.TryGetValue( inliningSpecification.TargetSemantic, out var referencesForIndex )
+                         && referencesForIndex.Count > 0 )
+                    {
+                        var aspectReferenceRootNodes = new HashSet<SyntaxNode>( referencesForIndex.SelectAsArray( r => r.RootNode ) );
+
+                        inlinedAspectReferenceRootNodesWithRedirectedDescendant = new HashSet<SyntaxNode>();
+
+                        foreach ( var reference in references )
+                        {
+                            foreach ( var ancestor in reference.ReferencingNode.Ancestors() )
+                            {
+                                if ( aspectReferenceRootNodes.Contains( ancestor ) )
+                                {
+                                    inlinedAspectReferenceRootNodesWithRedirectedDescendant.Add( ancestor );
+
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Add substitutions of non-inlined aspect references, skipping any whose root node
+                // has a redirected descendant (the redirection already handles the renaming).
+                if ( this._nonInlinedReferences.TryGetValue( inliningSpecification.TargetSemantic, out var nonInlinedReferenceList ) )
+                {
+                    foreach ( var nonInlinedReference in nonInlinedReferenceList )
+                    {
+                        if ( inlinedAspectReferenceRootNodesWithRedirectedDescendant != null
+                             && inlinedAspectReferenceRootNodesWithRedirectedDescendant.Contains( nonInlinedReference.RootNode ) )
+                        {
+                            // Skip this aspect reference - its target is already handled by the redirection substitution.
+                            continue;
+                        }
+
+                        AddSubstitutionsForNonInlinedReference( nonInlinedReference, inliningSpecification.ContextIdentifier );
                     }
                 }
 
@@ -692,15 +728,31 @@ internal sealed partial class LinkerAnalysisStep
                 {
                     var existingSubstitution = dictionary[substitution.ReplacedNode];
 
-                    // Only allow known compatible pairs: a RedirectionSubstitution and an AspectReferenceOverrideSubstitution
-                    // can target the same node when a constructor with initializer advice also accesses a redirected
-                    // get-only auto property. The redirection takes priority.
-                    if ( !((existingSubstitution is RedirectionSubstitution && substitution is AspectReferenceOverrideSubstitution)
-                           || (existingSubstitution is AspectReferenceOverrideSubstitution && substitution is RedirectionSubstitution)) )
+                    // A RedirectionSubstitution and an AspectReferenceOverrideSubstitution can target the same node
+                    // when a constructor with initializer advice also accesses a redirected get-only auto property.
+                    // The RedirectionSubstitution takes priority because it handles the backing field redirection.
+                    // Note: In practice, these two substitution types target different syntax tree levels
+                    // (IdentifierNameSyntax for redirection vs MemberAccessExpressionSyntax for aspect references),
+                    // so this conflict handler is a defensive measure. The primary protection is the
+                    // aspectReferenceRootNodesWithRedirectedDescendant filtering in ProcessNonInlinedSemantic.
+                    var isExistingRedirectionNewOverride =
+                        existingSubstitution is RedirectionSubstitution && substitution is AspectReferenceOverrideSubstitution;
+
+                    var isExistingOverrideNewRedirection =
+                        existingSubstitution is AspectReferenceOverrideSubstitution && substitution is RedirectionSubstitution;
+
+                    if ( !(isExistingRedirectionNewOverride || isExistingOverrideNewRedirection) )
                     {
                         throw new AssertionFailedException(
                             $"Conflicting substitutions for node '{substitution.ReplacedNode}': " +
                             $"existing '{existingSubstitution.GetType().Name}', new '{substitution.GetType().Name}'." );
+                    }
+
+                    // Enforce RedirectionSubstitution priority: if the new substitution is a RedirectionSubstitution
+                    // and the existing one is an AspectReferenceOverrideSubstitution, replace the existing entry.
+                    if ( isExistingOverrideNewRedirection )
+                    {
+                        dictionary[substitution.ReplacedNode] = substitution;
                     }
                 }
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
@@ -159,25 +159,40 @@ internal sealed partial class LinkerAnalysisStep
                 var nonInlinedSemanticBody = nonInlinedSemantic.ToTyped<IMethodSymbol>();
                 var context = new InliningContextIdentifier( nonInlinedSemanticBody );
 
-                // Add aspect reference substitution for all aspect references.
-                if ( this._nonInlinedReferences.TryGetValue( nonInlinedSemanticBody, out var nonInlinedReferenceList ) )
-                {
-                    foreach ( var nonInlinedReference in nonInlinedReferenceList )
-                    {
-                        AddSubstitutionsForNonInlinedReference( nonInlinedReference, context );
-                    }
-                }
+                // Collect nodes that have redirected symbol substitutions. These take priority over aspect reference
+                // substitutions because the redirection mechanism (e.g., for get-only auto property overrides) is more
+                // specific than the general aspect reference renaming. An aspect reference substitution targeting a
+                // parent node (MemberAccessExpression) would overwrite the child redirection (IdentifierName).
+                HashSet<SyntaxNode>? redirectedNodes = null;
 
-                // Add substitutions for redirected nodes.
                 if ( this._redirectedSymbolReferencesByContainingSemantic.TryGetValue( nonInlinedSemanticBody, out var redirectedSymbolReference ) )
                 {
+                    redirectedNodes = new HashSet<SyntaxNode>();
+
                     foreach ( var reference in redirectedSymbolReference )
                     {
                         var redirectionTarget = this._redirectedSymbols[reference.TargetSemantic.Symbol];
+                        redirectedNodes.Add( reference.ReferencingNode );
 
                         AddSubstitution(
                             context,
                             new RedirectionSubstitution( this._intermediateCompilationContext, reference.ReferencingNode, redirectionTarget ) );
+                    }
+                }
+
+                // Add aspect reference substitution for all aspect references, skipping any whose root node
+                // is an ancestor of a redirected symbol reference node (the redirection already handles the renaming).
+                if ( this._nonInlinedReferences.TryGetValue( nonInlinedSemanticBody, out var nonInlinedReferenceList ) )
+                {
+                    foreach ( var nonInlinedReference in nonInlinedReferenceList )
+                    {
+                        if ( redirectedNodes != null && HasRedirectedDescendant( nonInlinedReference.RootNode, redirectedNodes ) )
+                        {
+                            // Skip this aspect reference - its target is already handled by the redirection substitution.
+                            continue;
+                        }
+
+                        AddSubstitutionsForNonInlinedReference( nonInlinedReference, context );
                     }
                 }
 
@@ -649,14 +664,29 @@ internal sealed partial class LinkerAnalysisStep
                 }
             }
 
+            static bool HasRedirectedDescendant( SyntaxNode rootNode, HashSet<SyntaxNode> redirectedNodes )
+            {
+                foreach ( var descendant in rootNode.DescendantNodes() )
+                {
+                    if ( redirectedNodes.Contains( descendant ) )
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             void AddSubstitution( InliningContextIdentifier inliningContextId, SyntaxNodeSubstitution substitution )
             {
                 var dictionary = substitutions.GetOrAddNew( inliningContextId );
 
                 if ( !dictionary.TryAdd( substitution.ReplacedNode, substitution ) )
                 {
-                    // TODO: The item was already added, but there is no logic to cover this situation.
-                    throw new AssertionFailedException( $"The substitution was already added for node {substitution.ReplacedNode}." );
+                    // A substitution already exists for this node. This can happen when both the aspect reference
+                    // mechanism and the redirected symbol mechanism target the same syntax node (e.g., a constructor
+                    // with initializer advice that also accesses a redirected get-only auto property).
+                    // The first substitution wins; the second is compatible and can be safely skipped.
                 }
             }
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
@@ -163,30 +163,50 @@ internal sealed partial class LinkerAnalysisStep
                 // substitutions because the redirection mechanism (e.g., for get-only auto property overrides) is more
                 // specific than the general aspect reference renaming. An aspect reference substitution targeting a
                 // parent node (MemberAccessExpression) would overwrite the child redirection (IdentifierName).
-                HashSet<SyntaxNode>? redirectedNodes = null;
+                HashSet<SyntaxNode>? aspectReferenceRootNodesWithRedirectedDescendant = null;
 
                 if ( this._redirectedSymbolReferencesByContainingSemantic.TryGetValue( nonInlinedSemanticBody, out var redirectedSymbolReference ) )
                 {
-                    redirectedNodes = new HashSet<SyntaxNode>();
-
                     foreach ( var reference in redirectedSymbolReference )
                     {
                         var redirectionTarget = this._redirectedSymbols[reference.TargetSemantic.Symbol];
-                        redirectedNodes.Add( reference.ReferencingNode );
 
                         AddSubstitution(
                             context,
                             new RedirectionSubstitution( this._intermediateCompilationContext, reference.ReferencingNode, redirectionTarget ) );
                     }
+
+                    // Build a set of aspect reference root nodes that contain a redirected descendant.
+                    // Instead of walking descendants of each root (O(N*M)), walk ancestors of each redirected node (O(N*depth)).
+                    if ( this._nonInlinedReferences.TryGetValue( nonInlinedSemanticBody, out var referencesForIndex ) && referencesForIndex.Count > 0 )
+                    {
+                        var aspectReferenceRootNodes = new HashSet<SyntaxNode>( referencesForIndex.SelectAsArray( r => r.RootNode ) );
+
+                        aspectReferenceRootNodesWithRedirectedDescendant = new HashSet<SyntaxNode>();
+
+                        foreach ( var reference in redirectedSymbolReference )
+                        {
+                            foreach ( var ancestor in reference.ReferencingNode.Ancestors() )
+                            {
+                                if ( aspectReferenceRootNodes.Contains( ancestor ) )
+                                {
+                                    aspectReferenceRootNodesWithRedirectedDescendant.Add( ancestor );
+
+                                    break;
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Add aspect reference substitution for all aspect references, skipping any whose root node
-                // is an ancestor of a redirected symbol reference node (the redirection already handles the renaming).
+                // has a redirected descendant (the redirection already handles the renaming).
                 if ( this._nonInlinedReferences.TryGetValue( nonInlinedSemanticBody, out var nonInlinedReferenceList ) )
                 {
                     foreach ( var nonInlinedReference in nonInlinedReferenceList )
                     {
-                        if ( redirectedNodes != null && HasRedirectedDescendant( nonInlinedReference.RootNode, redirectedNodes ) )
+                        if ( aspectReferenceRootNodesWithRedirectedDescendant != null
+                             && aspectReferenceRootNodesWithRedirectedDescendant.Contains( nonInlinedReference.RootNode ) )
                         {
                             // Skip this aspect reference - its target is already handled by the redirection substitution.
                             continue;
@@ -664,29 +684,24 @@ internal sealed partial class LinkerAnalysisStep
                 }
             }
 
-            static bool HasRedirectedDescendant( SyntaxNode rootNode, HashSet<SyntaxNode> redirectedNodes )
-            {
-                foreach ( var descendant in rootNode.DescendantNodes() )
-                {
-                    if ( redirectedNodes.Contains( descendant ) )
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
             void AddSubstitution( InliningContextIdentifier inliningContextId, SyntaxNodeSubstitution substitution )
             {
                 var dictionary = substitutions.GetOrAddNew( inliningContextId );
 
                 if ( !dictionary.TryAdd( substitution.ReplacedNode, substitution ) )
                 {
-                    // A substitution already exists for this node. This can happen when both the aspect reference
-                    // mechanism and the redirected symbol mechanism target the same syntax node (e.g., a constructor
-                    // with initializer advice that also accesses a redirected get-only auto property).
-                    // The first substitution wins; the second is compatible and can be safely skipped.
+                    var existingSubstitution = dictionary[substitution.ReplacedNode];
+
+                    // Only allow known compatible pairs: a RedirectionSubstitution and an AspectReferenceOverrideSubstitution
+                    // can target the same node when a constructor with initializer advice also accesses a redirected
+                    // get-only auto property. The redirection takes priority.
+                    if ( !((existingSubstitution is RedirectionSubstitution && substitution is AspectReferenceOverrideSubstitution)
+                           || (existingSubstitution is AspectReferenceOverrideSubstitution && substitution is RedirectionSubstitution)) )
+                    {
+                        throw new AssertionFailedException(
+                            $"Conflicting substitutions for node '{substitution.ReplacedNode}': " +
+                            $"existing '{existingSubstitution.GetType().Name}', new '{substitution.GetType().Name}'." );
+                    }
                 }
             }
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.cs
@@ -109,12 +109,27 @@ namespace Metalama.Framework.Engine.Linking
 
             var resolvedReferencesBySource = await aspectReferenceCollector.RunAsync( cancellationToken );
 
+            // Constructors with inserted initializer statements need to be non-discardable,
+            // so their aspect references (invokers in AddInitializer templates) are properly resolved.
+            // Primary constructors are excluded because their initializer statements live in an auxiliary body
+            // (an injected member), not in the primary constructor's class/record declaration.
+            var constructorSemantics = input.InjectionRegistry.GetConstructorsWithInsertedStatements()
+                .Where( c => c.GetPrimaryDeclarationSyntax() is ConstructorDeclarationSyntax )
+                .Select( c => (IntermediateSymbolSemantic) c.ToSemantic( IntermediateSymbolSemanticKind.Default ) )
+                .ToArray();
+
+            var additionalNonDiscardableSemantics = eventFieldRaiseReferences
+                .SelectAsReadOnlyList( x => x.TargetSemantic )
+                .Concat( constructorSemantics )
+                .Distinct()
+                .ToArray();
+
             var reachabilityAnalyzer = new ReachabilityAnalyzer(
                 this._serviceProvider,
                 input.IntermediateCompilation.CompilationContext,
                 input.InjectionRegistry,
                 resolvedReferencesBySource,
-                eventFieldRaiseReferences.SelectAsReadOnlyList( x => x.TargetSemantic ).Distinct().ToArray() );
+                additionalNonDiscardableSemantics );
 
             var reachableSemantics = await reachabilityAnalyzer.RunAsync( cancellationToken );
 
@@ -799,9 +814,15 @@ namespace Metalama.Framework.Engine.Linking
                                 break;
                         }
                     }
-                    else
+                    else if ( injectionRegistry.IsOverride( nonInlinedSemantic.Symbol ) )
                     {
                         overrideTarget = injectionRegistry.GetOverrideTarget( nonInlinedSemantic.Symbol ).AssertNotNull();
+                    }
+                    else
+                    {
+                        // Source constructors with inserted initializer statements are non-inlined semantics
+                        // but they are neither override targets nor overrides. Skip inlineability verification.
+                        continue;
                     }
 
                     var sourceName =

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionRegistry.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionRegistry.cs
@@ -51,6 +51,8 @@ internal sealed class LinkerInjectionRegistry
     // TODO: This is used only for mapping of constructors with introduced parameters (limitation of code model).
     private readonly IReadOnlyDictionary<IRef<IDeclaration>, IReadOnlyList<IntroduceParameterTransformation>> _introducedParametersByTargetDeclaration;
 
+    private readonly IReadOnlyCollection<IMethodSymbol> _constructorsWithInsertedStatements;
+
     public LinkerInjectionRegistry(
         TransformationLinkerOrderComparer comparer,
         PartialCompilation intermediateCompilation,
@@ -59,6 +61,7 @@ internal sealed class LinkerInjectionRegistry
         IReadOnlyDictionary<DeclarationBuilderData, IIntroduceDeclarationTransformation> builderToTransformationMap,
         IReadOnlyDictionary<IRef<IDeclaration>, IReadOnlyList<IntroduceParameterTransformation>> introducedParametersByTargetDeclaration,
         ISet<ITransformation> transformationsCausingAuxiliaryOverrides,
+        IReadOnlyCollection<IRef<IMethodBase>> constructorsWithInsertedStatements,
         IConcurrentTaskRunner concurrentTaskRunner,
         CancellationToken cancellationToken )
     {
@@ -82,6 +85,15 @@ internal sealed class LinkerInjectionRegistry
         this._injectedMembers = injectedMembers.ToReadOnlyList();
         this._builderToTransformationMap = builderToTransformationMap;
         this._introducedParametersByTargetDeclaration = introducedParametersByTargetDeclaration;
+
+        // Translate constructor refs from the final compilation to the intermediate compilation.
+        this._constructorsWithInsertedStatements = constructorsWithInsertedStatements
+            .OfType<ISymbolRef>()
+            .Select(
+                r => intermediateCompilation.CompilationContext.SymbolTranslator.Translate(
+                    r.Symbol.GetCanonicalDefinition().AssertNotNull() ) )
+            .OfType<IMethodSymbol>()
+            .ToList();
 
         this._overrideTargets = overrideTargets = new ConcurrentQueue<ISymbol>();
 
@@ -519,6 +531,12 @@ internal sealed class LinkerInjectionRegistry
     /// </summary>
     /// <returns>Enumeration of introduced members.</returns>
     public IEnumerable<InjectedMember> GetInjectedMembers() => this._injectedMembers;
+
+    /// <summary>
+    /// Gets the set of constructor symbols (in the intermediate compilation) that have inserted initializer statements.
+    /// These constructors need to be analyzed by the linker for aspect references in their bodies.
+    /// </summary>
+    public IReadOnlyCollection<IMethodSymbol> GetConstructorsWithInsertedStatements() => this._constructorsWithInsertedStatements;
 
     /// <summary>
     /// Gets all symbols for overridden members.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionRegistry.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionRegistry.cs
@@ -87,13 +87,31 @@ internal sealed class LinkerInjectionRegistry
         this._introducedParametersByTargetDeclaration = introducedParametersByTargetDeclaration;
 
         // Translate constructor refs from the final compilation to the intermediate compilation.
-        this._constructorsWithInsertedStatements = constructorsWithInsertedStatements
-            .OfType<ISymbolRef>()
-            .Select(
-                r => intermediateCompilation.CompilationContext.SymbolTranslator.Translate(
-                    r.Symbol.GetCanonicalDefinition().AssertNotNull() ) )
-            .OfType<IMethodSymbol>()
-            .ToList();
+        // Translation may return null for constructors with introduced parameters (whose signatures differ
+        // between the final and intermediate compilations), so those are filtered out.
+        var translatedConstructors = new List<IMethodSymbol>();
+
+        foreach ( var r in constructorsWithInsertedStatements.OfType<ISymbolRef>() )
+        {
+            var translated = intermediateCompilation.CompilationContext.SymbolTranslator.Translate(
+                r.Symbol.GetCanonicalDefinition().AssertNotNull() );
+
+            // Translation can legitimately return null for constructors with introduced parameters.
+            if ( translated == null )
+            {
+                continue;
+            }
+
+            if ( translated is not IMethodSymbol methodSymbol )
+            {
+                throw new AssertionFailedException(
+                    $"Translated constructor symbol '{r.Symbol}' is not an IMethodSymbol but '{translated.GetType().Name}'." );
+            }
+
+            translatedConstructors.Add( methodSymbol );
+        }
+
+        this._constructorsWithInsertedStatements = translatedConstructors;
 
         this._overrideTargets = overrideTargets = new ConcurrentQueue<ISymbol>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -66,6 +66,16 @@ internal sealed partial class LinkerInjectionStep
 
         public IReadOnlyDictionary<DeclarationBuilderData, IIntroduceDeclarationTransformation> BuilderToTransformationMap => this._builderToTransformationMap;
 
+        /// <summary>
+        /// Gets the set of constructor references that have inserted initializer statements.
+        /// Used by the linker analysis step to find aspect references in initializer advice code.
+        /// </summary>
+        public IReadOnlyCollection<IRef<IMethodBase>> ConstructorsWithInsertedStatements
+            => this._insertedStatementsByTargetMethodBase
+                .Where( kvp => kvp.Value.Any( s => s.Kind == InsertedStatementKind.Initializer ) )
+                .Select( kvp => kvp.Key )
+                .ToList();
+
         public IReadOnlyDictionary<IRef<IDeclaration>, IReadOnlyList<IntroduceParameterTransformation>> IntroducedParametersByTargetDeclaration
             => this._introducedParametersByTargetDeclaration;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -11,6 +11,7 @@ using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.Introductions.BuilderData;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Transformations;
+using Metalama.Framework.Engine.Utilities;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Framework.Engine.Utilities.Threading;
 using Microsoft.CodeAnalysis;
@@ -70,11 +71,12 @@ internal sealed partial class LinkerInjectionStep
         /// Gets the set of constructor references that have inserted initializer statements.
         /// Used by the linker analysis step to find aspect references in initializer advice code.
         /// </summary>
-        public IReadOnlyCollection<IRef<IMethodBase>> ConstructorsWithInsertedStatements
+        [Memo]
+        public IReadOnlyList<IRef<IMethodBase>> ConstructorsWithInsertedStatements
             => this._insertedStatementsByTargetMethodBase
                 .Where( kvp => kvp.Value.Any( s => s.Kind == InsertedStatementKind.Initializer ) )
                 .Select( kvp => kvp.Key )
-                .ToList();
+                .ToReadOnlyList();
 
         public IReadOnlyDictionary<IRef<IDeclaration>, IReadOnlyList<IntroduceParameterTransformation>> IntroducedParametersByTargetDeclaration
             => this._introducedParametersByTargetDeclaration;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
@@ -366,6 +366,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
             transformationCollection.BuilderToTransformationMap,
             transformationCollection.IntroducedParametersByTargetDeclaration,
             transformationCollection.TransformationsCausingAuxiliaryOverrides,
+            transformationCollection.ConstructorsWithInsertedStatements,
             this._concurrentTaskRunner,
             cancellationToken );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Fields/Initializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Fields/Initializer.t.cs
@@ -32,7 +32,7 @@ public class TestClass
   }
   public TestClass()
   {
-    this.TestField = default;
-    this.TestProperty = default;
+    this._testField = default;
+    this._testProperty = default;
   }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/Initializer_MethodInvoker.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/Initializer_MethodInvoker.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Code.Invokers;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.Initializer_MethodInvoker;
+using System;
+using System.Linq;
+
+[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(OverrideAttribute), typeof(InitializerAttribute) )]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Invokers.Methods.Initializer_MethodInvoker;
+
+/*
+ * Tests that invokers in an initializer advice correctly resolve to the appropriate property version.
+ * When using InvokerOptions.Base in an initializer, the invoker should resolve to the original property
+ * (i.e. backing field), not the overridden version.
+ */
+
+public class OverrideAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        foreach ( var property in builder.Target.Properties )
+        {
+            builder.With( property ).Override( nameof(this.PropertyTemplate) );
+        }
+    }
+
+    [Template]
+    public dynamic? PropertyTemplate
+    {
+        get
+        {
+            Console.WriteLine( "Overridden" );
+
+            return meta.Proceed();
+        }
+
+        set
+        {
+            Console.WriteLine( "Overridden" );
+            meta.Proceed();
+        }
+    }
+}
+
+public class InitializerAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(this.InitializerTemplate), InitializerKind.BeforeInstanceConstructor );
+    }
+
+    [Template]
+    public void InitializerTemplate()
+    {
+        foreach ( var property in meta.Target.Type.Properties.OrderBy( p => p.Name ) )
+        {
+            // InvokerOptions.Base should access the property before overrides by this aspect layer.
+            property.WithOptions( InvokerOptions.Base ).Value = 42;
+        }
+
+        foreach ( var property in meta.Target.Type.Properties.OrderBy( p => p.Name ) )
+        {
+            // InvokerOptions.Current should access the property after this aspect layer's changes.
+            property.WithOptions( InvokerOptions.Current ).Value = 42;
+        }
+
+        foreach ( var property in meta.Target.Type.Properties.OrderBy( p => p.Name ) )
+        {
+            // InvokerOptions.Final should access the final overridden property.
+            property.WithOptions( InvokerOptions.Final ).Value = 42;
+        }
+    }
+}
+
+// <target>
+[Override]
+[Initializer]
+public class TestClass
+{
+    public int Property1 { get; set; }
+
+    public int Property2 { get; set; }
+
+    public TestClass() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/Initializer_MethodInvoker.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Invokers/Methods/Initializer_MethodInvoker.t.cs
@@ -1,0 +1,42 @@
+[Override]
+[Initializer]
+public class TestClass
+{
+  private int _property1;
+  public int Property1
+  {
+    get
+    {
+      global::System.Console.WriteLine("Overridden");
+      return this._property1;
+    }
+    set
+    {
+      global::System.Console.WriteLine("Overridden");
+      this._property1 = value;
+    }
+  }
+  private int _property2;
+  public int Property2
+  {
+    get
+    {
+      global::System.Console.WriteLine("Overridden");
+      return this._property2;
+    }
+    set
+    {
+      global::System.Console.WriteLine("Overridden");
+      this._property2 = value;
+    }
+  }
+  public TestClass()
+  {
+    this._property1 = 42;
+    this._property2 = 42;
+    this._property1 = 42;
+    this._property2 = 42;
+    this.Property1 = 42;
+    this.Property2 = 42;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #751

- Invoker templates expanded via `AddInitializer` are placed directly into the constructor body without an aspect reference annotation.
- This causes the linker to resolve all `InvokerOptions` (Base, Current, Final) to the final implementation, ignoring the aspect layer context.
- The fix tracks constructors with inserted initializer statements through the injection pipeline, scans their bodies for aspect reference annotations, and resolves references using the annotation's `AspectLayerId`.

## Checklist

- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Address PR review feedback (O(N^2) perf, stricter substitution handling, [Memo], AssertionFailedException)
- [x] Address substitution ordering feedback (enforce RedirectionSubstitution priority, add descendant filtering to ProcessInliningSpecification)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Run all tests with `Build.ps1 test` (all pass)
- [x] Finalize

## Test plan

- [x] Verify `Initializer_MethodInvoker` test passes with correct resolution of `InvokerOptions.Base` → backing field
- [x] Verify existing `Invokers/Fields/Initializer` test updated with correct expectations
- [x] Verify all existing invoker and initializer tests pass (128/128)
- [x] Verify all aspect tests pass (2029 passed, 31 skipped, 0 failed on net8.0)
- [x] Zero warnings in build and test