### PR TITLE
Suppress CS0649 on fields targeted by [Dependency] (#743)

### DIFF
--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DefaultDependencyInjectionStrategy.cs
@@ -109,6 +109,10 @@ public class DefaultDependencyInjectionStrategy
 
     public virtual bool TryImplementDependency( IAdviser<IFieldOrProperty> adviser )
     {
+        // Suppress CS0649 ("Field is never assigned to") on the target field because
+        // the field will be assigned in generated constructor code.
+        adviser.Diagnostics.Suppress( DiagnosticDescriptors.FieldIsNeverAssigned, adviser.Target );
+
         var pullStrategy = this.GetDependencyPullStrategy( adviser.Target );
 
         this.TryPullDependency( adviser.WithDeclaringType(), adviser.Target, pullStrategy );

--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/LazyDependencyInjectionStrategy.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/LazyDependencyInjectionStrategy.cs
@@ -93,6 +93,10 @@ public partial class LazyDependencyInjectionStrategy : DefaultDependencyInjectio
 
     public override bool TryImplementDependency( IAdviser<IFieldOrProperty> adviser )
     {
+        // Suppress CS0649 ("Field is never assigned to") on the target field because
+        // the field will be assigned by the generated lazy resolution code.
+        adviser.Diagnostics.Suppress( DiagnosticDescriptors.FieldIsNeverAssigned, adviser.Target );
+
         var templateArgs = new TemplateArgs();
 
         var overrideResult = adviser

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+// https://github.com/metalama/Metalama/issues/743
+
+#if TEST_OPTIONS
+// @ClearIgnoredDiagnostics
+#endif
+
+#if !TESTRUNNER
+#pragma warning disable CS8618
+#pragma warning disable CS0649
+#endif
+
+namespace Metalama.Extensions.DependencyInjection.AspectTests.Bugs.Issue743;
+
+// <target>
+public class TargetClass
+{
+    [Dependency]
+    private readonly IFormatProvider _formatProvider;
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743.t.cs
@@ -1,0 +1,9 @@
+public class TargetClass
+{
+  [Dependency]
+  private readonly IFormatProvider _formatProvider;
+  public TargetClass([AspectGenerated] IFormatProvider? formatProvider = null)
+  {
+    this._formatProvider = formatProvider ?? throw new System.ArgumentNullException(nameof(formatProvider));
+  }
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743_Lazy.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743_Lazy.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+// https://github.com/metalama/Metalama/issues/743
+
+#if TEST_OPTIONS
+// @ClearIgnoredDiagnostics
+#endif
+
+#if !TESTRUNNER
+#pragma warning disable CS8618
+#pragma warning disable CS0649
+#endif
+
+namespace Metalama.Extensions.DependencyInjection.AspectTests.Bugs.Issue743_Lazy;
+
+// <target>
+public class TargetClass
+{
+    [Dependency( IsLazy = true )]
+    private readonly IFormatProvider _formatProvider;
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743_Lazy.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue743_Lazy.t.cs
@@ -1,0 +1,21 @@
+public class TargetClass
+{
+  [Dependency(IsLazy = true)]
+  private IFormatProvider _formatProvider
+  {
+    get
+    {
+      return _formatProviderCache ??= _formatProviderFunc.Invoke();
+    }
+    init
+    {
+      throw new NotSupportedException("Cannot set '_formatProvider' because of the dependency aspect.");
+    }
+  }
+  private IFormatProvider? _formatProviderCache;
+  private Func<IFormatProvider> _formatProviderFunc;
+  public TargetClass([AspectGenerated] Func<IFormatProvider>? formatProvider = null)
+  {
+    this._formatProviderFunc = formatProvider ?? throw new System.ArgumentNullException(nameof(formatProvider));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds CS0649 ("Field is never assigned to") suppression on fields targeted by `[Dependency]` in both the default (eager) and lazy dependency injection strategies.
- The `[Dependency]` aspect generates constructor code that assigns the field, but the compiler's static analysis doesn't see this at design time, producing spurious CS0649 warnings.
- CS8618 suppression was already handled; this fix addresses the missing CS0649 suppression.

Fixes #743

## Changes

- `DefaultDependencyInjectionStrategy.TryImplementDependency`: Added `adviser.Diagnostics.Suppress(DiagnosticDescriptors.FieldIsNeverAssigned, ...)` on the target field.
- `LazyDependencyInjectionStrategy.TryImplementDependency`: Same suppression added for the lazy dependency path.
- Added regression tests `Issue743.cs` and `Issue743_Lazy.cs`.

## Checklist

- [x] Reproduce bug (regression test)
- [x] Implement fix
- [x] Run all DI aspect tests (37/37 pass)
- [x] Run all ServiceLocator DI tests (12/12 pass)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Run `Build.ps1 test` (all suites pass, zero failures)
- [x] Finalize

## Test plan

- [x] Verify `Issue743` test passes (early/required dependency with non-nullable field)
- [x] Verify `Issue743_Lazy` test passes (lazy dependency with non-nullable field)
- [x] Verify all existing DI tests still pass
- [x] Verify all ServiceLocator DI tests still pass

— Claude for @gfraiteur