### PR TITLE
Fix OverrideFinalizer AdviceKind (#711)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideFinalizerAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideFinalizerAdvice.cs
@@ -8,10 +8,9 @@ using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.CodeModel.References;
 
 namespace Metalama.Framework.Engine.AdviceImpl.Override;
-// TODO: Check why this class is unused.
-// ReSharper disable once UnusedType.Global
 
-// Because we are using OverrideMethodAdvice, but that does not return a correct AdviceKind (#34372).
+// ReSharper disable once UnusedType.Global
+// This class is unused because OverrideMethodAdvice handles finalizers and now returns the correct AdviceKind.
 
 internal class OverrideFinalizerAdvice : OverrideMemberAdvice<IMethod, IMethod>
 {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMethodAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMethodAdvice.cs
@@ -19,7 +19,8 @@ internal sealed class OverrideMethodAdvice : OverrideMemberAdvice<IMethod, IMeth
         this._boundTemplate = boundTemplate;
     }
 
-    public override AdviceKind AdviceKind => AdviceKind.OverrideMethod;
+    public override AdviceKind AdviceKind
+        => this.TargetDeclaration.MethodKind == MethodKind.Finalizer ? AdviceKind.OverrideFinalizer : AdviceKind.OverrideMethod;
 
     protected override OverrideMemberAdviceResult<IMethod> Implement( AdviceImplementationContext context )
     {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Finalizers/AdviceResult.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Finalizers/AdviceResult.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Overrides.Finalizers.AdviceResult
+{
+    public class OverrideAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            var result = builder.With( builder.Target.Finalizer! ).Override( nameof(Template) );
+
+            if (result.AdviceKind != AdviceKind.OverrideFinalizer)
+            {
+                throw new InvalidOperationException( $"AdviceKind was {result.AdviceKind} instead of OverrideFinalizer." );
+            }
+        }
+
+        [Template]
+        public dynamic? Template()
+        {
+            Console.WriteLine( "This is the override." );
+
+            return meta.Proceed();
+        }
+    }
+
+    // <target>
+    [Override]
+    internal class TargetClass
+    {
+        ~TargetClass()
+        {
+            Console.WriteLine( $"This is the original finalizer." );
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Finalizers/AdviceResult.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Finalizers/AdviceResult.t.cs
@@ -1,0 +1,10 @@
+[Override]
+internal class TargetClass
+{
+  ~TargetClass()
+  {
+    global::System.Console.WriteLine("This is the override.");
+    Console.WriteLine($"This is the original finalizer.");
+    return;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #711: `OverrideFinalizer` is not reported as a correct `AdviceKind`
- When overriding a finalizer via `builder.With(target.Finalizer!).Override(...)`, the `AdviceKind` was incorrectly reported as `OverrideMethod` instead of `OverrideFinalizer`
- Root cause: `OverrideMethodAdvice.AdviceKind` was hardcoded to `AdviceKind.OverrideMethod`
- Fix: Made the property check `TargetDeclaration.MethodKind` to return the correct `AdviceKind`

## Changes
- `OverrideMethodAdvice.cs`: Dynamic `AdviceKind` based on target method kind
- `OverrideFinalizerAdvice.cs`: Updated comment (class remains unused)
- `Tests/Aspects/Overrides/Finalizers/AdviceResult.cs`: Regression test

## Checklist
- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Run all tests in solution
- [x] Build with `Build.ps1 build`
- [x] Verify zero warnings
- [x] Run `Build.ps1 test` — all pass
- [x] Finalize PR

— Claude for @gfraiteur