### PR TITLE
Fix [InterfaceMember] and [Template] with same name causing exception (#718)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateMemberRef.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateMemberRef.cs
@@ -57,11 +57,13 @@ internal readonly struct TemplateMemberRef
         var type = templateReflectionContext.Compilation.GetTypeByMetadataNameSafe( this._templateMember.TemplateClass.FullName );
 
         var parameters = this._templateMember.Parameters;
+        var typeParameterCount = this._templateMember.TypeParameters.Length;
 
         var symbol = type.GetSingleMemberIncludingBase(
             this._templateMember.Name,
             symbol => classifier.IsTemplate( symbol )
-                      && symbol.GetParameters().Select( p => p.Type ).SequenceEqual( parameters.Select( p => p.Type ), StructuralSymbolComparer.Default ) );
+                      && symbol.GetParameters().Select( p => p.Type ).SequenceEqual( parameters.Select( p => p.Type ), StructuralSymbolComparer.Default )
+                      && (symbol is not Microsoft.CodeAnalysis.IMethodSymbol methodSymbol || methodSymbol.TypeParameters.Length == typeParameterCount) );
 
         var declaration = templateReflectionContext.GetCompilationModel( compilation ).Factory.GetDeclaration( symbol );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateNameHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateNameHelper.cs
@@ -52,12 +52,15 @@ namespace Metalama.Framework.Engine.Templating
 
             var principal = "__" + templateMemberName;
 
-            if ( parameters.IsDefaultOrEmpty || (ignoredLastParameter && parameters.Length == 1) )
+            var hasParameters = !parameters.IsDefaultOrEmpty && !(ignoredLastParameter && parameters.Length == 1);
+            var hasTypeParameters = symbol.Kind == SymbolKind.Method && symbol is IMethodSymbol { TypeParameters.Length: > 0 };
+
+            if ( !hasParameters && !hasTypeParameters )
             {
                 return principal;
             }
 
-            // If we have parameters, we need to add a unique hash of the symbol to differentiate symbols
+            // If we have parameters or type parameters, we need to add a unique hash of the symbol to differentiate symbols
             // of the same name. It is essential that this hash is consistent across runtimes and versions of Roslyn and Metalama.
             using var hashHandle = HashUtilities.AllocateHasher();
             var hashCode = hashHandle.Value;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Comparers/MemberComparer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Comparers/MemberComparer.cs
@@ -54,6 +54,11 @@ namespace Metalama.Framework.Engine.Utilities.Comparers
                     return false;
                 }
 
+                if ( x is IMethod xMethod && y is IMethod yMethod && xMethod.TypeParameters.Count != yMethod.TypeParameters.Count )
+                {
+                    return false;
+                }
+
                 for ( var i = 0; i < xHasParameters.Parameters.Count; i++ )
                 {
                     var xParameter = xHasParameters.Parameters[i].Type;
@@ -77,6 +82,11 @@ namespace Metalama.Framework.Engine.Utilities.Comparers
             if ( obj.DeclarationKind is DeclarationKind.Method or DeclarationKind.Constructor or DeclarationKind.Indexer
                 && obj is IHasParameters hasParameters )
             {
+                if ( obj is IMethod method )
+                {
+                    hashCode.Add( method.TypeParameters.Count );
+                }
+
                 foreach ( var parameter in hasParameters.Parameters )
                 {
                     hashCode.Add( parameter.Type, this._typeComparer );

--- a/Metalama.Framework/src/Metalama.Framework/Code/MethodCollectionExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/MethodCollectionExtensions.cs
@@ -119,7 +119,8 @@ public static class MethodCollectionExtensions
             signatureTemplate.Name,
             signatureTemplate.Parameters.Count,
             GetParameter,
-            matchIsStatic ? signatureTemplate.IsStatic : null );
+            matchIsStatic ? signatureTemplate.IsStatic : null,
+            signatureTemplate.TypeParameters.Count );
 
         static (IType Type, RefKind RefKind) GetParameter( IMethod context, int index ) => (context.Parameters[index].Type, context.Parameters[index].RefKind);
     }

--- a/Metalama.Framework/src/Metalama.Framework/Code/SignatureMatcher.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/SignatureMatcher.cs
@@ -84,7 +84,8 @@ namespace Metalama.Framework.Code
             string? name,
             int parameterCount,
             Func<TPayload, int, (IType Type, RefKind RefKind)> parameterGetter,
-            bool? isStatic )
+            bool? isStatic,
+            int? typeParameterCount = null )
             where TMember : class, IHasParameters
         {
             var compilation = members.DeclaringType.Compilation;
@@ -95,7 +96,8 @@ namespace Metalama.Framework.Code
                 name,
                 parameterCount,
                 IsMatchingParameter,
-                isStatic );
+                isStatic,
+                typeParameterCount: typeParameterCount );
 
             // We use First and not Single because advices may provide many methods with same signature.
             // They do not make it to the final code, but they are stored in this class.
@@ -136,7 +138,8 @@ namespace Metalama.Framework.Code
             int? argumentCount,
             Func<TPayload, int, IType, RefKind, bool> argumentPredicate,
             bool? isStatic,
-            bool expandParams = false )
+            bool expandParams = false,
+            int? typeParameterCount = null )
             where TMember : class, IHasParameters
         {
             var candidates = name != null ? members.OfName( name ) : members;
@@ -149,7 +152,8 @@ namespace Metalama.Framework.Code
             {
                 if ( (isStatic != null && isStatic != sourceItem.IsStatic)
                      || (argumentCount != null && !expandParams && sourceItem.Parameters.Count != argumentCount)
-                     || (argumentCount != null && expandParams && sourceItem.Parameters.Count > argumentCount + 1) )
+                     || (argumentCount != null && expandParams && sourceItem.Parameters.Count > argumentCount + 1)
+                     || (typeParameterCount != null && sourceItem is IMethod m && m.TypeParameters.Count != typeParameterCount) )
                 {
                     continue;
                 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug34183.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug34183.cs
@@ -3,7 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 #if TEST_OPTIONS
-// @Skipped (#34183 - [Template] [InterfaceMember] conflict)
+// @Skipped (#34183 - IntroduceMethod with same name as [InterfaceMember] needs prefix naming)
 #endif
 
 using Metalama.Framework.Advising;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug34183.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug34183.cs
@@ -2,10 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-#if TEST_OPTIONS
-// @Skipped (#34183 - IntroduceMethod with same name as [InterfaceMember] needs prefix naming)
-#endif
-
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug34183.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug34183.t.cs
@@ -1,1 +1,13 @@
-// TODO: Replace this file with the correct transformed code. See the test output for the actual transformed code.
+[Test]
+public class TestClass : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug34183.ITest
+{
+  public void Foo()
+  {
+  }
+  public void Foo<T>()
+  {
+  }
+  public void Foo<T, U>()
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.cs
@@ -27,7 +27,7 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug718
 
             foreach ( var method in builder.Target.Methods )
             {
-                builder.With( method ).Override( nameof(Foo) );
+                builder.With( method ).Override( nameof(Foo), args: new { T = builder.Target } );
             }
         }
 
@@ -38,11 +38,12 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug718
         }
 
         [Template]
-        public void Foo<[CompileTime] T>()
+        public dynamic? Foo<[CompileTime] T>()
         {
-            Console.WriteLine( "Before" );
-            meta.Proceed();
-            Console.WriteLine( "After" );
+            Console.WriteLine( $"Overriding in {typeof(T).Name}" );
+            var result = meta.Proceed();
+
+            return result;
         }
     }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug718
+{
+    /*
+     * Tests that when searching for a non-interface template, interface members should be ignored.
+     * This aspect has an [InterfaceMember] Foo() method and a [Template] Foo<T>() method with the same name.
+     * Override(nameof(Foo)) should find the [Template] and not the [InterfaceMember].
+     */
+
+    public interface IMyInterface
+    {
+        void Foo();
+    }
+
+    public class MyAspectAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            builder.ImplementInterface( typeof(IMyInterface) );
+
+            foreach ( var method in builder.Target.Methods )
+            {
+                builder.With( method ).Override( nameof(Foo) );
+            }
+        }
+
+        [InterfaceMember]
+        public void Foo()
+        {
+            Console.WriteLine( "Interface member implementation" );
+        }
+
+        [Template]
+        public void Foo<[CompileTime] T>()
+        {
+            Console.WriteLine( "Before" );
+            meta.Proceed();
+            Console.WriteLine( "After" );
+        }
+    }
+
+    // <target>
+    [MyAspect]
+    public partial class TargetClass
+    {
+        public void Bar()
+        {
+            Console.WriteLine( "Original Bar" );
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.t.cs
@@ -1,0 +1,1 @@
+// TODO: Replace this file with the correct transformed code. See the test output for the actual transformed code.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug718.t.cs
@@ -1,1 +1,15 @@
-// TODO: Replace this file with the correct transformed code. See the test output for the actual transformed code.
+[MyAspect]
+public partial class TargetClass : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug718.IMyInterface
+{
+  public void Bar()
+  {
+    global::System.Console.WriteLine($"Overriding in {typeof(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug718.TargetClass).Name}");
+    Console.WriteLine("Original Bar");
+    object result = null;
+    return;
+  }
+  public void Foo()
+  {
+    global::System.Console.WriteLine("Interface member implementation");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #718 - When an aspect has both an `[InterfaceMember]` method and a `[Template]` method with the same name (differentiated by generic type parameters), calling `IntroduceMethod(nameof(Foo))` throws `InvalidOperationException: Sequence contains more than one element`.

Also fixes Bug34183 - `ImplementInterface` failing to introduce generic overloads like `Foo<T>()` alongside non-generic `Foo()`.

## Root Causes

Four issues in the template resolution and member comparison pipeline:

1. **`TemplateMemberRef.GetTemplateMember`**: When resolving a template symbol by name, the predicate only matched value parameters but not type parameters. Both `[InterfaceMember] Foo()` and `[Template] Foo<T>()` have zero value parameters, so `SingleOrDefault` found two matches and threw.

2. **`TemplateNameHelper.GetCompiledTemplateName`**: The compiled template name was `__Foo` for both methods since the hash suffix was only added for methods with value parameters. This caused `AmbiguousMatchException` during Reflection lookup.

3. **`MemberComparer<T>`**: `Equals` and `GetHashCode` did not consider type parameter count when comparing methods. This caused `AllMethods` (which uses a `HashSet<IMethod>` with this comparer) to silently deduplicate `Foo()` and `Foo<T>()`, preventing `ImplementInterface` from finding templates for generic overloads.

4. **`SignatureMatcher.OfExactSignature`/`OfSignature`**: Did not filter by type parameter count, so `IntroduceMethod` incorrectly matched `Foo()` when looking for `Foo<T,U>()` (both have 0 value parameters).

## Fix

1. Added type parameter count matching to the symbol resolution predicate in `TemplateMemberRef`.
2. Extended hash suffix logic in `TemplateNameHelper` to also apply when a method has type parameters.
3. Added type parameter count to `MemberComparer.Equals` and `GetHashCode` for `IMethod` instances.
4. Added `typeParameterCount` parameter to `SignatureMatcher.OfExactSignature` and `OfSignature`, passed through from `MethodCollectionExtensions`.

## Test Plan

- [x] Bug718.cs regression test (new)
- [x] Bug34183 test un-skipped and passing
- [x] All 2027 aspect tests pass (0 failures)
- [x] All 1537 unit tests pass (0 failures)
- [x] Build.ps1 build succeeds with zero warnings
- [x] Build.ps1 test succeeds with zero warnings

— Claude for @gfraiteur