### PR TITLE
Add regression tests for #716: private InterfaceMember cross-assembly

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/Accessibility_Explicit_CrossAssembly.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/Accessibility_Explicit_CrossAssembly.Dependency.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly
+{
+    public interface IInterface
+    {
+        void Method();
+
+        int Property { get; set; }
+
+        int Property_GetOnly { get; }
+
+        int Property_ExpressionBody { get; }
+
+        int AutoProperty { get; set; }
+
+        event EventHandler? EventField;
+
+        event EventHandler? Event;
+    }
+
+    public class IntroductionAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> aspectBuilder )
+        {
+            aspectBuilder.ImplementInterface( typeof(IInterface) );
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private void Method()
+        {
+            Console.WriteLine( "Introduced interface member" );
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private int Property
+        {
+            get
+            {
+                return 42;
+            }
+
+            set { }
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private int Property_GetOnly
+        {
+            get
+            {
+                return 42;
+            }
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private int Property_ExpressionBody => 42;
+
+        [InterfaceMember( IsExplicit = true )]
+        private int AutoProperty { get; set; }
+
+        [InterfaceMember( IsExplicit = true )]
+        private event EventHandler? EventField;
+
+        [InterfaceMember( IsExplicit = true )]
+        private event EventHandler? Event
+        {
+            add { }
+            remove { }
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/Accessibility_Explicit_CrossAssembly.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/Accessibility_Explicit_CrossAssembly.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#pragma warning disable CS0067
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly
+{
+    /*
+     * Tests that private explicit interface members are correctly found in cross-assembly scenario.
+     * Regression test for issue #716.
+     */
+
+    // <target>
+    [Introduction]
+    public class TargetClass { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/Accessibility_Explicit_CrossAssembly.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/Accessibility_Explicit_CrossAssembly.t.cs
@@ -1,0 +1,54 @@
+[Introduction]
+public class TargetClass : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface
+{
+  global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.AutoProperty { get; set; }
+  global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.Property
+  {
+    get
+    {
+      return (global::System.Int32)42;
+    }
+    set
+    {
+    }
+  }
+  global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.Property_ExpressionBody
+  {
+    get
+    {
+      return (global::System.Int32)42;
+    }
+  }
+  global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.Property_GetOnly
+  {
+    get
+    {
+      return (global::System.Int32)42;
+    }
+  }
+  void global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.Method()
+  {
+    global::System.Console.WriteLine("Introduced interface member");
+  }
+  event global::System.EventHandler? global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.Event
+  {
+    add
+    {
+    }
+    remove
+    {
+    }
+  }
+  private event global::System.EventHandler? _eventField;
+  event global::System.EventHandler? global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.Accessibility_Explicit_CrossAssembly.IInterface.EventField
+  {
+    add
+    {
+      this._eventField += value;
+    }
+    remove
+    {
+      this._eventField -= value;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.0.i.cs
@@ -1,0 +1,38 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly
+{
+  partial class TargetClass : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly.IInterface
+  {
+    void global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly.IInterface.Method()
+    {
+    }
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly.IInterface.Property
+    {
+      get
+      {
+        return default(global::System.Int32);
+      }
+      set
+      {
+      }
+    }
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly.IInterface.AutoProperty { get; set; }
+    event global::System.EventHandler? global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly.IInterface.EventField
+    {
+      add
+      {
+      }
+      remove
+      {
+      }
+    }
+    event global::System.EventHandler? global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly.IInterface.Event
+    {
+      add
+      {
+      }
+      remove
+      {
+      }
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.Dependency.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+#pragma warning disable CS0067
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly
+{
+    public interface IInterface
+    {
+        void Method();
+
+        int Property { get; set; }
+
+        int AutoProperty { get; set; }
+
+        event EventHandler? EventField;
+
+        event EventHandler? Event;
+    }
+
+    public class IntroductionAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> aspectBuilder )
+        {
+            aspectBuilder.ImplementInterface( typeof(IInterface) );
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private void Method()
+        {
+            Console.WriteLine( "Introduced interface member" );
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private int Property
+        {
+            get
+            {
+                return 42;
+            }
+
+            set { }
+        }
+
+        [InterfaceMember( IsExplicit = true )]
+        private int AutoProperty { get; set; }
+
+        [InterfaceMember( IsExplicit = true )]
+        private event EventHandler? EventField;
+
+        [InterfaceMember( IsExplicit = true )]
+        private event EventHandler? Event
+        {
+            add { }
+            remove { }
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @TestScenario(DesignTime)
+#endif
+
+#pragma warning disable CS0067
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.DesignTimeExplicitMembers_CrossAssembly
+{
+    /*
+     * Tests that private explicit interface members are correctly found in cross-assembly design-time scenario.
+     * Regression test for issue #716.
+     */
+
+    // <target>
+    [Introduction]
+    public partial class TargetClass { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/DesignTimeExplicitMembers_CrossAssembly.t.cs
@@ -1,0 +1,4 @@
+[Introduction]
+public partial class TargetClass
+{
+}


### PR DESCRIPTION
Closes #716

## Summary

- Adds regression tests for private `[InterfaceMember(IsExplicit = true)]` in cross-assembly scenarios
- Tests cover both build-time and design-time (with `@TestScenario(DesignTime)`) scenarios
- The bug described in #716 appears to have been already fixed (likely during #32580 "Handle private template members in interface introductions" or #28699 "Programmatic interface introductions")
- These tests serve as regression protection to prevent reintroduction

## Test Files Added

1. **`Accessibility_Explicit_CrossAssembly`** - Build-time test with private explicit interface members in cross-assembly scenario
2. **`DesignTimeExplicitMembers_CrossAssembly`** - Design-time test with private explicit interface members in cross-assembly scenario

## Checklist

- [x] Confirm bug is already fixed
- [x] Add regression tests
- [x] Build (`Build.ps1 build`)
- [x] Run tests (`Build.ps1 test`)
- [x] Finalize

— Claude for @gfraiteur