### PR TITLE
Fix ToExecutionScope assertion failure for unhandled scope values (#701)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/TemplatingScopeExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/TemplatingScopeExtensions.cs
@@ -118,7 +118,8 @@ namespace Metalama.Framework.Engine.CompileTime
             {
                 CompileTimeOnly => ExecutionScope.CompileTime,
                 RunTimeOnly => ExecutionScope.RunTime,
-                RunTimeOrCompileTime => ExecutionScope.RunTimeOrCompileTime,
+                RunTimeOrCompileTime or ForcedRunTimeOrCompileTime or ImplicitlyRunTimeOrCompileTime
+                    or LateBound or MustFollowParent or NotCompileTimeOnly => ExecutionScope.RunTimeOrCompileTime,
                 Conflict => ExecutionScope.RunTime, // It seems this may happen at design-time during a background rebuild.
                 _ => throw new AssertionFailedException( $"Unexpected scope: {templatingScope}" )
             };

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/TemplatingScopeExtensionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/TemplatingScopeExtensionsTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime
+{
+    public sealed class TemplatingScopeExtensionsTests
+    {
+        /// <summary>
+        /// Regression test for https://github.com/metalama/Metalama/issues/701.
+        /// Verifies that ToExecutionScope does not throw for any TemplatingScope value.
+        /// </summary>
+        [Fact]
+        public void ToExecutionScope_DoesNotThrow()
+        {
+            var allValues = Enum.GetValues( typeof(TemplatingScope) ).Cast<TemplatingScope>();
+            var failures = new List<string>();
+
+            foreach ( var scope in allValues )
+            {
+                var exception = Record.Exception( () => scope.ToExecutionScope() );
+
+                if ( exception != null )
+                {
+                    failures.Add( $"{scope}: {exception.Message}" );
+                }
+            }
+
+            Assert.Empty( failures );
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/TemplatingScopeExtensionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/TemplatingScopeExtensionsTests.cs
@@ -3,6 +3,8 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.CompileTime.Manifest;
+using Metalama.Testing.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,14 +12,17 @@ using Xunit;
 
 namespace Metalama.Framework.Tests.UnitTests.CompileTime
 {
-    public sealed class TemplatingScopeExtensionsTests
+    public sealed class TemplatingScopeExtensionsTests : UnitTestClass
     {
         /// <summary>
         /// Regression test for https://github.com/metalama/Metalama/issues/701.
-        /// Verifies that ToExecutionScope does not throw for any TemplatingScope value.
+        /// Verifies that ToExecutionScope handles all TemplatingScope enum values without throwing.
+        /// The design-time pipeline can encounter any scope value when building the template manifest,
+        /// particularly when user code contains errors (e.g. invalid using directives). Each scope must
+        /// map to a valid ExecutionScope rather than throw an AssertionFailedException.
         /// </summary>
         [Fact]
-        public void ToExecutionScope_DoesNotThrow()
+        public void ToExecutionScope_HandlesAllScopeValues()
         {
             var allValues = Enum.GetValues( typeof(TemplatingScope) ).Cast<TemplatingScope>();
             var failures = new List<string>();
@@ -33,6 +38,45 @@ namespace Metalama.Framework.Tests.UnitTests.CompileTime
             }
 
             Assert.Empty( failures );
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/metalama/Metalama/issues/701.
+        /// Verifies that <see cref="TemplateSymbolManifest.Builder.Build"/> does not throw when
+        /// a symbol has been added with a <see cref="TemplatingScope"/> value that was previously
+        /// unhandled by <see cref="TemplatingScopeExtensions.ToExecutionScope"/>.
+        /// This exercises the exact code path from the stack trace: <c>TemplateSymbolManifest.Builder.Build()</c>
+        /// → <c>TemplatingScopeExtensions.ToExecutionScope()</c>.
+        /// </summary>
+        [Theory]
+        [InlineData( nameof(TemplatingScope.LateBound) )]
+        [InlineData( nameof(TemplatingScope.MustFollowParent) )]
+        [InlineData( nameof(TemplatingScope.ForcedRunTimeOrCompileTime) )]
+        [InlineData( nameof(TemplatingScope.ImplicitlyRunTimeOrCompileTime) )]
+        [InlineData( nameof(TemplatingScope.NotCompileTimeOnly) )]
+        public void ManifestBuild_HandlesAllScopeValues( string scopeName )
+        {
+            var scope = Enum.Parse<TemplatingScope>( scopeName );
+
+            using var testContext = this.CreateTestContext();
+
+            var compilation = testContext.CreateCSharpCompilation(
+                """
+                class C
+                {
+                    void M() {}
+                }
+                """ );
+
+            var symbol = compilation.GetTypeByMetadataName( "C" )!.GetMembers( "M" ).Single();
+
+            var builder = new TemplateProjectManifestBuilder( compilation.SourceModule.GlobalNamespace );
+            builder.AddOrUpdateSymbol( symbol, scope );
+
+            // Build() calls ToExecutionScope() on the stored scope — this must not throw.
+            var manifest = builder.Build();
+
+            Assert.NotNull( manifest );
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/DiagnosticAnalyzerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/DiagnosticAnalyzerTests.cs
@@ -182,4 +182,39 @@ public sealed class DiagnosticAnalyzerTests( ITestOutputHelper logger ) : Diagno
         Assert.Equal( diagnostic1.WarningLevel, diagnostic2.WarningLevel );
         Assert.Equal( diagnostic1.Properties, diagnostic2.Properties );
     }
+
+    /// <summary>
+    /// Regression test for https://github.com/metalama/Metalama/issues/701.
+    /// When an aspect contains a template and the code has an invalid using directive,
+    /// the design-time pipeline should report diagnostics gracefully instead of throwing
+    /// <c>AssertionFailedException: Unexpected scope</c> in <c>ToExecutionScope</c>.
+    /// </summary>
+    [Fact]
+    public async Task InvalidUsingInAspectDoesNotCrash()
+    {
+        const string code = """
+                            using Metalama.Framework.Advising;
+                            using Metalama.Framework.Aspects;
+                            using NonExistent.Namespace;
+
+                            class TheAspect : OverrideMethodAspect
+                            {
+                                public override dynamic? OverrideMethod()
+                                {
+                                    return meta.Proceed();
+                                }
+                            }
+
+                            class Target
+                            {
+                                [TheAspect]
+                                void M() { }
+                            }
+                            """;
+
+        // The pipeline should not throw an AssertionFailedException.
+        await this.RunAnalyzer( code );
+
+        // We don't assert specific diagnostics — the key is that the pipeline doesn't crash.
+    }
 }


### PR DESCRIPTION
Closes #701

## Summary

Fix `AssertionFailedException: Unexpected scope` in `TemplatingScopeExtensions.ToExecutionScope()` that occurs when the method encounters `TemplatingScope` values it doesn't handle.

## Checklist

- [x] Reproduce bug with failing regression test
- [x] Implement fix
- [x] Build and test (zero warnings, all tests pass)
- [x] Finalize

## Details

The `ToExecutionScope()` method throws an `AssertionFailedException` for the following `TemplatingScope` values after `GetExpressionExecutionScope()`:
- `LateBound`
- `MustFollowParent`
- `ForcedRunTimeOrCompileTime`
- `ImplicitlyRunTimeOrCompileTime`
- `NotCompileTimeOnly`

These values all represent scopes that are semantically equivalent to `RunTimeOrCompileTime` (undetermined or compatible with both), so the fix maps them to `ExecutionScope.RunTimeOrCompileTime` in the switch expression.

## Changes

1. **`TemplatingScopeExtensions.cs`**: Added handling for `ForcedRunTimeOrCompileTime`, `ImplicitlyRunTimeOrCompileTime`, `LateBound`, `MustFollowParent`, and `NotCompileTimeOnly` in `ToExecutionScope()`, mapping them all to `ExecutionScope.RunTimeOrCompileTime`.

2. **`TemplatingScopeExtensionsTests.cs`**: 
   - `ToExecutionScope_HandlesAllScopeValues` (Fact): Verifies `ToExecutionScope()` handles all enum values without throwing.
   - `ManifestBuild_HandlesAllScopeValues` (Theory, 5 cases): Exercises the exact code path from the stack trace — creates a real compilation, adds a symbol to `TemplateProjectManifestBuilder` with each problematic scope value, then calls `Build()` which triggers `TemplateSymbolManifest.Builder.Build()` → `ToExecutionScope()`.

3. **`DiagnosticAnalyzerTests.cs`**: Added `InvalidUsingInAspectDoesNotCrash` integration test that runs the full design-time DiagnosticAnalyzer pipeline with an aspect containing an invalid using directive.

All 6 regression tests fail without the fix and pass with it.

— Claude for @gfraiteur