### PR TITLE
OfAttributeType: accept unbound generic types (#802)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/AttributeCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/AttributeCollection.cs
@@ -30,7 +30,10 @@ namespace Metalama.Framework.Engine.CodeModel.Collections
             => this.OfAttributeType( type, conversionKind );
 
         private IEnumerable<IAttribute> OfAttributeType( IType type, ConversionKind conversionKind = ConversionKind.Default )
-            => this.GetItems(
+        {
+            conversionKind = GetEffectiveConversionKind( type, conversionKind );
+
+            return this.GetItems(
                 this.Source.Where(
                     a =>
                     {
@@ -38,6 +41,7 @@ namespace Metalama.Framework.Engine.CodeModel.Collections
 
                         return attributeType.IsConvertibleTo( type, conversionKind );
                     } ) );
+        }
 
         IEnumerable<IAttribute> IAttributeCollection.OfAttributeType( Type type ) => this.OfAttributeType( type );
 
@@ -69,7 +73,11 @@ namespace Metalama.Framework.Engine.CodeModel.Collections
         bool IAttributeCollection.Any( IType type, ConversionKind conversionKind ) => this.Any( type, conversionKind );
 
         private bool Any( IType type, ConversionKind conversionKind = ConversionKind.Default )
-            => this.Source.Any( a => ((AttributeRef) a).AttributeType.GetTarget( this.Compilation ).IsConvertibleTo( type, conversionKind ) );
+        {
+            conversionKind = GetEffectiveConversionKind( type, conversionKind );
+
+            return this.Source.Any( a => ((AttributeRef) a).AttributeType.GetTarget( this.Compilation ).IsConvertibleTo( type, conversionKind ) );
+        }
 
         bool IAttributeCollection.Any( Type type ) => this.Any( type );
 
@@ -84,6 +92,21 @@ namespace Metalama.Framework.Engine.CodeModel.Collections
             }
 
             return this.Any( (INamedType) this.ContainingDeclaration!.GetCompilationModel().Factory.GetTypeByReflectionType( type ), conversionKind );
+        }
+
+        /// <summary>
+        /// When <paramref name="conversionKind"/> is <see cref="ConversionKind.Default"/> and the <paramref name="type"/> is an unbound generic type
+        /// (i.e. a generic type definition with type parameters bound to themselves), automatically switches to <see cref="ConversionKind.TypeDefinition"/>
+        /// so that all constructed instances of that generic type are matched.
+        /// </summary>
+        private static ConversionKind GetEffectiveConversionKind( IType type, ConversionKind conversionKind )
+        {
+            if ( conversionKind == ConversionKind.Default && type is INamedType { IsGeneric: true, IsCanonicalGenericInstance: true } )
+            {
+                return ConversionKind.TypeDefinition;
+            }
+
+            return conversionKind;
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/AttributeCollectionTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/AttributeCollectionTests.cs
@@ -127,7 +127,7 @@ class C
         }
 
         [Fact]
-        public void OfAttributeType_ReflectionType_UnboundGeneric()
+        public void OfAttributeType_ReflectionType_NonGeneric()
         {
             using var testContext = this.CreateTestContext();
 
@@ -146,6 +146,32 @@ class C
                 .ToArray();
 
             Assert.Single( attributes );
+        }
+
+        [Fact]
+        public void OfAttributeType_AndAny_WithReflectionUnboundGenericType()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+[System.ObsoleteAttribute]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Passing an unbound generic reflection type (List<>) should be accepted and
+            // go through the ConversionKind.Default -> TypeDefinition promotion path.
+            var unboundGenericReflectionType = typeof(System.Collections.Generic.List<>);
+
+            var attributes = type.Attributes.OfAttributeType( unboundGenericReflectionType )
+                .ToArray();
+
+            Assert.Empty( attributes );
+            Assert.False( type.Attributes.Any( unboundGenericReflectionType ) );
         }
 
         [Fact]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/AttributeCollectionTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/AttributeCollectionTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Metalama.Framework.Tests.UnitTests.CodeModel
 {
-    public sealed class CodeModelIAttributeCollectionOfUnboundGenericTypeTests : UnitTestClass
+    public sealed class AttributeCollectionTests : UnitTestClass
     {
         [Fact]
         public void OfAttributeType_UnboundGenericType_ReturnsAttributes()

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelIAttributeCollectionOfUnboundGenericTypeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelIAttributeCollectionOfUnboundGenericTypeTests.cs
@@ -174,5 +174,129 @@ class C
 
             Assert.Single( attributes );
         }
+
+        [Fact]
+        public void OfAttributeType_UnboundGenericType_NoMatch()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+class A<T> : System.Attribute
+{
+}
+
+class B : System.Attribute
+{
+}
+
+[B]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Unbound generic type should not match unrelated attributes.
+            var attributes = type.Attributes.OfAttributeType( attributeType )
+                .ToArray();
+
+            Assert.Empty( attributes );
+        }
+
+        [Fact]
+        public void OfAttributeType_UnboundGenericType_GenericInterface()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+interface I<T>
+{
+}
+
+class A : System.Attribute, I<int>
+{
+}
+
+[A]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var interfaceType = compilation.Types.Single( t => t.Name == "I" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Unbound generic interface type should match attributes implementing it.
+            var attributes = type.Attributes.OfAttributeType( interfaceType )
+                .ToArray();
+
+            Assert.Single( attributes );
+            Assert.Equal( "A", attributes[0].Type.Name );
+        }
+
+        [Fact]
+        public void Any_UnboundGenericType_NoMatch_ReturnsFalse()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+class A<T> : System.Attribute
+{
+}
+
+class B : System.Attribute
+{
+}
+
+[B]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Any with unbound generic type should return false when no match.
+            Assert.False( type.Attributes.Any( attributeType ) );
+        }
+
+        [Fact]
+        public void OfAttributeType_ConstructedGenericType_ExactMatch()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using System;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+class A<T> : System.Attribute
+{
+}
+
+[A<int>]
+[A<string>]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Passing a constructed generic type (not unbound) should only match that specific construction.
+            var intType = compilation.Factory.GetTypeByReflectionType( typeof(int) );
+            var constructedType = attributeType.MakeGenericInstance( intType );
+            var attributes = type.Attributes.OfAttributeType( constructedType )
+                .ToArray();
+
+            Assert.Single( attributes );
+        }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelIAttributeCollectionOfUnboundGenericTypeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelIAttributeCollectionOfUnboundGenericTypeTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Code;
+using Metalama.Testing.UnitTesting;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CodeModel
+{
+    public sealed class CodeModelIAttributeCollectionOfUnboundGenericTypeTests : UnitTestClass
+    {
+        [Fact]
+        public void OfAttributeType_UnboundGenericType_ReturnsAttributes()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+class A<T> : System.Attribute
+{
+}
+
+[A<int>]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // When passing the unbound generic type (type definition) without explicit ConversionKind,
+            // OfAttributeType should still return attributes of constructed instances.
+            var attributes = type.Attributes.OfAttributeType( attributeType )
+                .ToArray();
+
+            Assert.Single( attributes );
+        }
+
+        [Fact]
+        public void OfAttributeType_UnboundGenericType_MultipleConstructions()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using System;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+class A<T> : System.Attribute
+{
+}
+
+[A<int>]
+[A<string>]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // When passing the unbound generic type, all constructions should be returned.
+            var attributes = type.Attributes.OfAttributeType( attributeType )
+                .ToArray();
+
+            Assert.Equal( 2, attributes.Length );
+        }
+
+        [Fact]
+        public void OfAttributeType_UnboundGenericType_DerivedAttribute()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+class A<T> : System.Attribute
+{
+}
+
+class B : A<int>
+{
+}
+
+[B]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // When passing the unbound generic type, attributes of derived types should also be returned.
+            var attributes = type.Attributes.OfAttributeType( attributeType )
+                .ToArray();
+
+            Assert.Single( attributes );
+            Assert.Equal( "B", attributes[0].Type.Name );
+        }
+
+        [Fact]
+        public void Any_UnboundGenericType_ReturnsTrue()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+class A<T> : System.Attribute
+{
+}
+
+[A<int>]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Any should also work with unbound generic types.
+            Assert.True( type.Attributes.Any( attributeType ) );
+        }
+
+        [Fact]
+        public void OfAttributeType_ReflectionType_UnboundGeneric()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+[System.ObsoleteAttribute]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Non-generic reflection type should work as before.
+            var attributes = type.Attributes.OfAttributeType( typeof(System.ObsoleteAttribute) )
+                .ToArray();
+
+            Assert.Single( attributes );
+        }
+
+        [Fact]
+        public void OfAttributeType_NonGenericType_StillWorks()
+        {
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+class A : System.Attribute
+{
+}
+
+[A]
+class C
+{
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var attributeType = compilation.Types.Single( t => t.Name == "A" );
+            var type = compilation.Types.Single( t => t.Name == "C" );
+
+            // Non-generic types should continue to work as before.
+            var attributes = type.Attributes.OfAttributeType( attributeType )
+                .ToArray();
+
+            Assert.Single( attributes );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #802 - IAttributeCollection.OfAttributeType and Any now accept unbound generic types.

When an unbound generic type (type definition, e.g. MyAttribute<>) is passed to OfAttributeType or Any without an explicit ConversionKind, the methods now automatically detect this and switch to ConversionKind.TypeDefinition, so all constructed instances of that generic type are matched.

## Changes

**AttributeCollection.cs**: Added GetEffectiveConversionKind helper that promotes ConversionKind.Default to ConversionKind.TypeDefinition when the input type is an unbound generic (IsGeneric && IsCanonicalGenericInstance). Integrated into both OfAttributeType and Any methods.

**AttributeCollectionTests.cs**: 11 unit tests covering:
- Basic unbound generic matching
- Multiple constructions of the same generic type
- Derived attribute types
- Any() method with unbound generics
- Reflection type overloads (non-generic and unbound generic typeof(List<>))
- Non-generic types (backward compatibility)
- Negative tests (no match)
- Generic interface matching
- Constructed generic type exact matching

## Checklist
- [x] Reproduce bug with failing tests
- [x] Implement fix
- [x] Run all tests in the solution
- [x] Build with Build.ps1 build
- [x] Verify zero warnings
- [x] Run Build.ps1 test - all tests pass
- [x] Address review feedback
- [x] Finalize PR