### PR TITLE
Make design-time auxiliary files read-only (#745)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
@@ -169,9 +169,16 @@ public sealed partial class SourceTransformer : ISourceTransformerWithServices
 
             foreach ( var deletedAuxiliaryFile in existingFiles.Except( finalFiles ) )
             {
-                // Remove read-only attribute before deleting.
-                File.SetAttributes( deletedAuxiliaryFile, FileAttributes.Normal );
-                File.Delete( deletedAuxiliaryFile );
+                try
+                {
+                    // Remove read-only attribute before deleting.
+                    File.SetAttributes( deletedAuxiliaryFile, FileAttributes.Normal );
+                    File.Delete( deletedAuxiliaryFile );
+                }
+                catch ( FileNotFoundException )
+                {
+                    // The file may have been deleted between Directory.GetFiles and here.
+                }
             }
 
             foreach ( var file in pipelineResult.AdditionalCompilationOutputFiles )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
@@ -169,6 +169,8 @@ public sealed partial class SourceTransformer : ISourceTransformerWithServices
 
             foreach ( var deletedAuxiliaryFile in existingFiles.Except( finalFiles ) )
             {
+                // Remove read-only attribute before deleting.
+                File.SetAttributes( deletedAuxiliaryFile, FileAttributes.Normal );
                 File.Delete( deletedAuxiliaryFile );
             }
 
@@ -176,8 +178,20 @@ public sealed partial class SourceTransformer : ISourceTransformerWithServices
             {
                 var fullPath = GetFileFullPath( file );
                 Directory.CreateDirectory( Path.GetDirectoryName( fullPath )! );
-                using var stream = File.Open( fullPath, FileMode.Create );
-                file.WriteToStream( stream );
+
+                if ( File.Exists( fullPath ) )
+                {
+                    // Remove read-only attribute before overwriting.
+                    File.SetAttributes( fullPath, FileAttributes.Normal );
+                }
+
+                using ( var stream = File.Open( fullPath, FileMode.Create ) )
+                {
+                    file.WriteToStream( stream );
+                }
+
+                // Set the file as read-only so we have no temptation to edit it.
+                File.SetAttributes( fullPath, FileAttributes.ReadOnly );
             }
 
             string GetFileFullPath( AdditionalCompilationOutputFile file )


### PR DESCRIPTION
## Summary

- Sets `FileAttributes.ReadOnly` on design-time auxiliary files written to `obj/<Config>/metalama-aux/` to discourage editing (edits are lost on rebuild).
- Handles read-only files when deleting or overwriting existing auxiliary files.
- Catches `FileNotFoundException` when deleting stale auxiliary files to handle race conditions.
- Compile-time files in `CompileTimeCompilationBuilder.cs` were already read-only.

See also: https://github.com/metalama/Metalama.Compiler/pull/159 for the companion change in Metalama.Compiler (transformed source code files in `obj/<Config>/<TFM>/metalama/`).

Fixes https://github.com/metalama/Metalama/issues/745

## Checklist

- [x] Implement fix
- [x] Address review feedback (catch FileNotFoundException in delete loop)
- [x] Build passes (0 warnings, 0 errors)
- [x] All tests pass
- [x] Finalize