### PR TITLE
Move MetalamaFormatOutput default to .targets (#594)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.props
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.props
@@ -29,10 +29,6 @@
 
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(MetalamaDebugTransformedCode)'=='True'">
-        <MetalamaFormatOutput Condition="'$(MetalamaFormatOutput)'==''">True</MetalamaFormatOutput>
-    </PropertyGroup>
-
     <ItemGroup>
         <!-- Source generator attributes targeting members present in .Net 9 (dotnet/runtime and dotnet/extensions): -->
         <MetalamaSourceGeneratorAttribute Include="Microsoft.Extensions.Diagnostics.Metrics.CounterAttribute" />

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
@@ -32,6 +32,12 @@
 
     </PropertyGroup>
 
+    <!-- Default MetalamaFormatOutput to True when MetalamaDebugTransformedCode is True.
+         This must be in the .targets file (not .props) so it can see properties set in the project file. -->
+    <PropertyGroup Condition="'$(MetalamaDebugTransformedCode)'=='True'">
+        <MetalamaFormatOutput Condition="'$(MetalamaFormatOutput)'==''">True</MetalamaFormatOutput>
+    </PropertyGroup>
+
       <!-- The LangVersionImplicitlySet property is set by Metalama.Compiler when LangVersion is not defined, according to the current target framework.
          We change this value to our own lowest supported version. 
         -->

--- a/Metalama.Framework/src/tests/Standalone/Issue594/Issue594.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue594/Issue594.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- Issue 594: Setting MetalamaDebugTransformedCode=True in the project file should
+         automatically result in MetalamaFormatOutput=True. This only works if the
+         defaulting logic is in .targets (evaluated after the project file), not in .props
+         (evaluated before the project file). -->
+    <MetalamaDebugTransformedCode>True</MetalamaDebugTransformedCode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metalama.Framework" />
+  </ItemGroup>
+
+  <!-- Verify that MetalamaFormatOutput was correctly defaulted to True. -->
+  <Target Name="ValidateMetalamaFormatOutput" BeforeTargets="CoreCompile">
+    <Error Text="MetalamaFormatOutput should be 'True' when MetalamaDebugTransformedCode is 'True', but it was '$(MetalamaFormatOutput)'. The defaulting logic must be in .targets, not .props."
+           Condition="'$(MetalamaFormatOutput)' != 'True'" />
+  </Target>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue594/Issue594.sln
+++ b/Metalama.Framework/src/tests/Standalone/Issue594/Issue594.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34916.146
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Issue594", "Issue594.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Metalama.Framework/src/tests/Standalone/Issue594/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue594/Program.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+internal class Program
+{
+    [Log]
+    private static void Main()
+    {
+        Console.WriteLine( "Hello" );
+    }
+}
+
+internal class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Entering {meta.Target.Method}" );
+
+        return meta.Proceed();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #594. Moves the conditional logic that defaults `MetalamaFormatOutput=True` when `MetalamaDebugTransformedCode=True` from `Metalama.Framework.props` to `Metalama.Framework.targets`.

MSBuild `.props` files are evaluated **before** the project file, while `.targets` files are evaluated **after**. This means if a user sets `MetalamaDebugTransformedCode=True` in their project file, the `.props` logic has already evaluated and `MetalamaFormatOutput` won't be correctly defaulted.

## Changes

- **Removed** from `Metalama.Framework.props`: the `PropertyGroup` that defaulted `MetalamaFormatOutput` when `MetalamaDebugTransformedCode=True`
- **Added** to `Metalama.Framework.targets`: the same `PropertyGroup`, placed after the `MetalamaEnabled` defaulting logic
- **Added** standalone regression test `Issue594` that validates the fix

## Progress

- [x] Reproduce the bug (standalone test that fails)
- [x] Implement fix (move logic from .props to .targets)
- [x] Build and test (zero warnings, all tests pass)
- [x] Finalize

## Test plan

- [x] Standalone test `Issue594` verifies that `MetalamaFormatOutput` is correctly set to `True` when `MetalamaDebugTransformedCode=True` is set in the project file
- [x] Verify existing `LamaDebug` standalone test still passes
- [x] Full build with zero warnings
- [x] Full test suite passes