### PR TITLE
Fix namespace fabric resolution in design-time pipeline (#595)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
@@ -15,6 +15,7 @@ using Metalama.Framework.Engine.Utilities.UserCode;
 using Metalama.Framework.Fabrics;
 using Metalama.Framework.Project;
 using System;
+using System.Threading.Tasks;
 
 namespace Metalama.Framework.Engine.Fabrics;
 
@@ -40,7 +41,18 @@ internal abstract partial class FabricDriver
             fabricManager.ServiceProvider,
             targetDeclaration,
             CompilationModelVersion.Final,
-            ( action, context ) => action( targetDeclaration.GetTarget( context.Compilation ), 0, context ) )
+            ( action, context ) =>
+            {
+                var target = targetDeclaration.GetTargetOrNull( context.Compilation );
+
+                if ( target == null )
+                {
+                    // The target declaration may not be resolvable in a partial compilation (design-time scenario).
+                    return Task.CompletedTask;
+                }
+
+                return action( target, 0, context );
+            } )
         {
             this._project = project;
             this._fabricInstance = fabricInstance;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
@@ -43,12 +43,24 @@ internal abstract partial class FabricDriver
             CompilationModelVersion.Final,
             ( action, context ) =>
             {
-                var target = targetDeclaration.GetTargetOrNull( context.Compilation );
+                T target;
 
-                if ( target == null )
+                if ( context.Compilation.IsPartial )
                 {
-                    // The target declaration may not be resolvable in a partial compilation (design-time scenario).
-                    return Task.CompletedTask;
+                    var targetOrNull = targetDeclaration.GetTargetOrNull( context.Compilation );
+
+                    if ( targetOrNull == null )
+                    {
+                        // The target declaration may not be resolvable in a partial compilation (design-time scenario).
+                        return Task.CompletedTask;
+                    }
+
+                    target = targetOrNull;
+                }
+                else
+                {
+                    // In complete compilations, fail fast when the target declaration cannot be resolved.
+                    target = targetDeclaration.GetTarget( context.Compilation );
                 }
 
                 return action( target, 0, context );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
@@ -2306,6 +2306,16 @@ partial class A<T, U>
                         public string Method2() => "hello";
                     }
                 }
+                """,
+            ["other.cs"] =
+                """
+                namespace MyApp.Other
+                {
+                    class OtherClass
+                    {
+                        public void DoWork() { }
+                    }
+                }
                 """
         };
 
@@ -2316,23 +2326,24 @@ partial class A<T, U>
         // First execution with full compilation should succeed.
         Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out _ ) );
 
-        // Simulate a change to just the target file (design-time partial compilation scenario).
-        // This triggers partial re-execution where only the modified syntax tree is processed,
-        // and the namespace symbol may not be resolvable.
-        var modifiedTargetCode = """
-                                 namespace MyApp.Fabrics
-                                 {
-                                     class TargetClass
-                                     {
-                                         public void Method1() { }
-                                         public string Method2() => "hello";
-                                         public int Method3() => 42;
-                                     }
-                                 }
-                                 """;
+        // Simulate a change to a file in a different namespace (design-time partial compilation scenario).
+        // The modified file is in MyApp.Other, so the partial compilation does not include the
+        // fabric's target namespace (MyApp.Fabrics), which previously caused SymbolNotFoundException.
+        var modifiedOtherCode = """
+                                namespace MyApp.Other
+                                {
+                                    class OtherClass
+                                    {
+                                        public void DoWork() { }
+                                        public int DoMoreWork() => 42;
+                                    }
+                                }
+                                """;
 
-        var newTree = CSharpSyntaxTree.ParseText( modifiedTargetCode, path: "target.cs" );
-        var compilation2 = compilation.ReplaceSyntaxTree( compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" ), newTree );
+        var originalOtherTree = compilation.SyntaxTrees.Single( t => t.FilePath == "other.cs" );
+        var parseOptions = (CSharpParseOptions) originalOtherTree.Options;
+        var newTree = CSharpSyntaxTree.ParseText( modifiedOtherCode, parseOptions, path: "other.cs" );
+        var compilation2 = compilation.ReplaceSyntaxTree( originalOtherTree, newTree );
 
         Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation2, default, out _ ) );
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
@@ -2239,7 +2239,7 @@ partial class A<T, U>
                     {
                         public override void AmendType( ITypeAmender amender )
                             => amender.AddAspect<MyAspect>();
-                    } 
+                    }
                 }
                 """
         };
@@ -2249,5 +2249,91 @@ partial class A<T, U>
         using TestDesignTimeAspectPipelineFactory factory = new( testContext );
 
         Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out _ ) );
+    }
+
+    [Fact]
+    public void NamespaceFabric()
+    {
+        // Regression test for https://github.com/metalama/Metalama/issues/595
+        // NamespaceFabric throws SymbolNotFoundException when resolving its target namespace.
+
+        using var testContext = this.CreateTestContext();
+
+        var code = new Dictionary<string, string>()
+        {
+            ["aspect.cs"] =
+                """
+                using System;
+                using Metalama.Framework.Aspects;
+
+                public class LogAspect : OverrideMethodAspect
+                {
+                    public override dynamic? OverrideMethod()
+                    {
+                        Console.WriteLine("logged");
+                        return meta.Proceed();
+                    }
+                }
+                """,
+            ["fabric.cs"] =
+                """
+                using Metalama.Framework.Aspects;
+                using Metalama.Framework.Code;
+                using Metalama.Framework.Fabrics;
+
+                namespace MyApp.Fabrics
+                {
+                    class Fabric : NamespaceFabric
+                    {
+                        public override void AmendNamespace( INamespaceAmender amender )
+                        {
+                            amender
+                                .SelectMany( ns => ns.DescendantsAndSelf() )
+                                .SelectMany( ns => ns.Types )
+                                .SelectMany( t => t.Methods )
+                                .AddAspect<LogAspect>();
+                        }
+                    }
+                }
+                """,
+            ["target.cs"] =
+                """
+                namespace MyApp.Fabrics
+                {
+                    class TargetClass
+                    {
+                        public void Method1() { }
+                        public string Method2() => "hello";
+                    }
+                }
+                """
+        };
+
+        var compilation = testContext.CreateCSharpCompilation( code );
+
+        using TestDesignTimeAspectPipelineFactory factory = new( testContext );
+
+        // First execution with full compilation should succeed.
+        Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out _ ) );
+
+        // Simulate a change to just the target file (design-time partial compilation scenario).
+        // This triggers partial re-execution where only the modified syntax tree is processed,
+        // and the namespace symbol may not be resolvable.
+        var modifiedTargetCode = """
+                                 namespace MyApp.Fabrics
+                                 {
+                                     class TargetClass
+                                     {
+                                         public void Method1() { }
+                                         public string Method2() => "hello";
+                                         public int Method3() => 42;
+                                     }
+                                 }
+                                 """;
+
+        var newTree = CSharpSyntaxTree.ParseText( modifiedTargetCode, path: "target.cs" );
+        var compilation2 = compilation.ReplaceSyntaxTree( compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" ), newTree );
+
+        Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation2, default, out _ ) );
     }
 }


### PR DESCRIPTION
## Summary
Fixes #595 — NamespaceFabric throws `SymbolNotFoundException` when resolving its target namespace in the design-time pipeline.

The bug occurs when the design-time pipeline re-executes after a syntax tree change (partial compilation). The namespace `DeclarationIdRef` cannot be resolved in the partial compilation context, causing an unhandled `SymbolNotFoundException`.

### Root Cause
In `FabricDriver.BaseAmender`, the query adder lambda used `targetDeclaration.GetTarget()` which throws when the namespace symbol cannot be found in a partial compilation. This happens because the namespace `DeclarationIdRef` (e.g., `N:MyApp.Fabrics`) may not be resolvable when only certain syntax trees are included in the partial compilation.

### Fix
Changed the lambda to check `context.Compilation.IsPartial`:
- **Partial compilations** (design-time): Uses `GetTargetOrNull()` with a null guard that returns `Task.CompletedTask` to gracefully skip execution when the target declaration is not resolvable.
- **Full compilations**: Uses `GetTarget()` to fail fast on unexpected missing symbols.

## Checklist
- [x] Reproduce the bug with a failing regression test
- [x] Implement the fix
- [x] Run all tests in the solution
- [x] Build with `Build.ps1 build` -- zero warnings
- [x] Run `Build.ps1 test` -- all tests pass
- [x] Address copilot review feedback per @gfraiteur
- [x] Finalize PR

## Test plan
- [x] New regression test `DesignTimePipelineTests.NamespaceFabric` reproduces the exact exception
- [x] Test modifies a file in a different namespace to ensure the fabric target namespace is absent from partial compilation
- [x] All existing fabric tests pass (38 aspect tests, 11 unit tests)
- [x] Full design-time pipeline test suite passes (34 tests)
- [x] `Build.ps1 build` and `Build.ps1 test` pass with zero warnings