### PR TITLE
Fix implementing introduced generic interface on introduced generic type (#598)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.Members.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.Members.cs
@@ -54,7 +54,13 @@ public sealed partial class CompilationModel
         where TCollection : IUpdatableCollection
     {
         Invariant.Assert( !(requestMutableCollection && !this.IsMutable) );
-        Invariant.Assert( declaration.IsDefinition );
+
+        // Normalize to definition ref. Callers like IntroducedNamedType may pass a constructed ref
+        // (e.g. Test<int>) whose generic context is handled by the collection's facade, not by this dictionary.
+        if ( !declaration.IsDefinition )
+        {
+            declaration = declaration.DefinitionRef;
+        }
 
         // If the model is mutable, we need to return a mutable collection because it may be mutated after the
         // front-end collection is returned.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/IntroducedGenericContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/IntroducedGenericContext.cs
@@ -45,9 +45,7 @@ internal sealed class IntroducedGenericContext : GenericContext
         }
         else
         {
-            // The type parameter does not belong to this context's definition and there is no parent context.
-            // Return the type parameter unmapped, consistent with SymbolGenericContext behavior.
-            return typeParameter;
+            throw new ArgumentOutOfRangeException();
         }
     }
 
@@ -66,9 +64,7 @@ internal sealed class IntroducedGenericContext : GenericContext
         }
         else
         {
-            // The type parameter does not belong to this context's definition and there is no parent context.
-            // Return the type parameter unmapped, consistent with SymbolGenericContext behavior.
-            return compilation.Factory.GetIType( typeParameterSymbol );
+            throw new ArgumentOutOfRangeException();
         }
     }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/IntroducedGenericContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/GenericContexts/IntroducedGenericContext.cs
@@ -45,7 +45,9 @@ internal sealed class IntroducedGenericContext : GenericContext
         }
         else
         {
-            throw new ArgumentOutOfRangeException();
+            // The type parameter does not belong to this context's definition and there is no parent context.
+            // Return the type parameter unmapped, consistent with SymbolGenericContext behavior.
+            return typeParameter;
         }
     }
 
@@ -64,7 +66,9 @@ internal sealed class IntroducedGenericContext : GenericContext
         }
         else
         {
-            throw new ArgumentOutOfRangeException();
+            // The type parameter does not belong to this context's definition and there is no parent context.
+            // Return the type parameter unmapped, consistent with SymbolGenericContext behavior.
+            return compilation.Factory.GetIType( typeParameterSymbol );
         }
     }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
@@ -207,7 +207,16 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
         => new TypeParameterList( this, this._namedTypeBuilderData.TypeParameters.Select( t => t.ToRef() ).ToReadOnlyList() );
 
     [Memo]
-    public IReadOnlyList<IType> TypeArguments => this._namedTypeBuilderData.TypeParameters.SelectAsImmutableArray( t => this.MapType( t.ToRef() ) );
+    public IReadOnlyList<IType> TypeArguments
+        => this._namedTypeBuilderData.TypeParameters.SelectAsImmutableArray(
+            t =>
+            {
+                // First resolve the type parameter without context to get the ITypeParameter declaration.
+                var typeParam = (IType) t.ToRef().GetTarget( this.Compilation );
+
+                // Then map it through the generic context, which substitutes e.g. T -> int.
+                return this.GenericContext.Map( typeParam ) ?? typeParam;
+            } );
 
     public bool IsGeneric => this._namedTypeBuilderData.TypeParameters.Length > 0;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
@@ -51,12 +51,12 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
     public IImplementedInterfaceCollection AllImplementedInterfaces
         => new AllImplementedInterfacesCollection(
             this,
-            this.Compilation.GetAllInterfaceImplementationCollection( this.Ref.DefinitionRef, false ) );
+            this.Compilation.GetAllInterfaceImplementationCollection( this.Ref, false ) );
 
     public IImplementedInterfaceCollection ImplementedInterfaces
         => new ImplementedInterfacesCollection(
             this,
-            this.Compilation.GetInterfaceImplementationCollection( this.Ref.DefinitionRef, false ) );
+            this.Compilation.GetInterfaceImplementationCollection( this.Ref, false ) );
 
     INamespace INamedType.Namespace => this.ContainingNamespace;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs
@@ -51,12 +51,12 @@ internal sealed class IntroducedNamedType : IntroducedMemberOrNamedType, INamedT
     public IImplementedInterfaceCollection AllImplementedInterfaces
         => new AllImplementedInterfacesCollection(
             this,
-            this.Compilation.GetAllInterfaceImplementationCollection( this.Ref, false ) );
+            this.Compilation.GetAllInterfaceImplementationCollection( this.Ref.DefinitionRef, false ) );
 
     public IImplementedInterfaceCollection ImplementedInterfaces
         => new ImplementedInterfacesCollection(
             this,
-            this.Compilation.GetInterfaceImplementationCollection( this.Ref, false ) );
+            this.Compilation.GetInterfaceImplementationCollection( this.Ref.DefinitionRef, false ) );
 
     INamespace INamedType.Namespace => this.ContainingNamespace;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/IntroducedRef.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/IntroducedRef.cs
@@ -144,7 +144,10 @@ internal sealed partial class IntroducedRef<T> : FullRef<T>, IIntroducedRef
         }
         else
         {
-            throw new InvalidOperationException( "Cannot combine two non-empty generic contexts." );
+            // Both contexts are non-empty. Combine them by mapping this ref's generic context
+            // through the passed context. E.g., if this ref has {T->U} and the passed context
+            // is {U->int}, the result is {T->int}.
+            return this._genericContext.Map( (GenericContext) genericContext, this.RefFactory );
         }
     }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.cs
@@ -2,13 +2,20 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+#if TEST_OPTIONS
+// @IncludeAllSeverities
+#endif
+
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.IntroducedGenericInterfaceOnIntroducedGenericType;
 
 public class IntroductionAttribute : TypeAspect
 {
+    private static readonly DiagnosticDefinition<string> _info = new( "MY001", Severity.Warning, "{0}" );
+
     public override void BuildAspect( IAspectBuilder<INamedType> builder )
     {
         // Introduce interface ITest<T>.
@@ -28,9 +35,36 @@ public class IntroductionAttribute : TypeAspect
             } );
 
         // Make class Test<U> : ITest<U>.
-        // This fails with an assertion when populating AllImplementedInterfaces for ITest<U> (which is a type instance, not the definition).
         testImplementation.ImplementInterface(
             testInterface.Declaration.MakeGenericInstance( testImplementation.Declaration.TypeParameters[0] ) );
+
+        // Verify AllImplementedInterfaces and ImplementedInterfaces on the definition Test<U>.
+        var definition = testImplementation.Declaration;
+
+        foreach ( var iface in definition.AllImplementedInterfaces )
+        {
+            builder.Diagnostics.Report( _info.WithArguments( $"Test<U>.AllImplementedInterfaces: {iface.Name}<{iface.TypeArguments[0]}>" ) );
+        }
+
+        foreach ( var iface in definition.ImplementedInterfaces )
+        {
+            builder.Diagnostics.Report( _info.WithArguments( $"Test<U>.ImplementedInterfaces: {iface.Name}<{iface.TypeArguments[0]}>" ) );
+        }
+
+        // Create a bound type Test<int> and verify that AllImplementedInterfaces and ImplementedInterfaces
+        // return bound interface types (ITest<int>), not the generic type instance (ITest<T>).
+        var intType = builder.Target.Compilation.Factory.GetSpecialType( SpecialType.Int32 );
+        var boundType = definition.MakeGenericInstance( intType );
+
+        foreach ( var iface in boundType.AllImplementedInterfaces )
+        {
+            builder.Diagnostics.Report( _info.WithArguments( $"Test<int>.AllImplementedInterfaces: {iface.Name}<{iface.TypeArguments[0]}>" ) );
+        }
+
+        foreach ( var iface in boundType.ImplementedInterfaces )
+        {
+            builder.Diagnostics.Report( _info.WithArguments( $"Test<int>.ImplementedInterfaces: {iface.Name}<{iface.TypeArguments[0]}>" ) );
+        }
     }
 }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.IntroducedGenericInterfaceOnIntroducedGenericType;
+
+public class IntroductionAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Introduce interface ITest<T>.
+        var testInterface = builder.IntroduceInterface(
+            "ITest",
+            buildType: b =>
+            {
+                b.AddTypeParameter( "T" );
+            } );
+
+        // Introduce class Test<U>.
+        var testImplementation = builder.IntroduceClass(
+            "Test",
+            buildType: b =>
+            {
+                b.AddTypeParameter( "U" );
+            } );
+
+        // Make class Test<U> : ITest<U>.
+        // This fails with an assertion when populating AllImplementedInterfaces for ITest<U> (which is a type instance, not the definition).
+        testImplementation.ImplementInterface(
+            testInterface.Declaration.MakeGenericInstance( testImplementation.Declaration.TypeParameters[0] ) );
+    }
+}
+
+// <target>
+[IntroductionAttribute]
+public class TargetType { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.t.cs
@@ -1,3 +1,7 @@
+// Warning MY001 on `TargetType`: `Test<U>.AllImplementedInterfaces: ITest<TargetType.Test<U>/U>`
+// Warning MY001 on `TargetType`: `Test<U>.ImplementedInterfaces: ITest<TargetType.Test<U>/U>`
+// Warning MY001 on `TargetType`: `Test<int>.AllImplementedInterfaces: ITest<int>`
+// Warning MY001 on `TargetType`: `Test<int>.ImplementedInterfaces: ITest<int>`
 [IntroductionAttribute]
 public class TargetType
 {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedGenericInterfaceOnIntroducedGenericType.t.cs
@@ -1,0 +1,10 @@
+[IntroductionAttribute]
+public class TargetType
+{
+  interface ITest<T>
+  {
+  }
+  class Test<U> : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.IntroducedGenericInterfaceOnIntroducedGenericType.TargetType.ITest<U>
+  {
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #598 - Implementing introduced generic interface on an introduced generic type fails on assertion.

**Root cause:** Multiple bugs in generic context handling for introduced types:

1. **CompilationModel.GetMemberCollection** asserted `declaration.IsDefinition`, but `IntroducedNamedType` passes `this.Ref` which can be a constructed ref (e.g., `Test<int>`). Fixed to normalize non-definition refs to their definition, since the dictionary is keyed by definition refs and the generic context is handled by the collection's facade.

2. **IntroducedRef.SelectGenericContext** threw `InvalidOperationException` when both the ref's context and the passed context were non-empty (e.g., `ITest<U>` ref has context `{T→U}`, and `Test<int>` passes context `{U→int}`). Fixed to compose contexts using `GenericContext.Map()`, producing the correct composed context `{T→int}`.

3. **IntroducedNamedType.TypeArguments** used `MapType(t.ToRef())` which created an `IntroducedTypeParameter` with context instead of actually performing the substitution. Fixed to resolve the type parameter first, then map through the generic context.

**Files changed:**
- `CompilationModel.Members.cs` - Normalize non-definition refs in `GetMemberCollection`
- `IntroducedRef.cs` - Combine non-empty generic contexts instead of throwing
- `IntroducedNamedType.cs` - Fix `TypeArguments` resolution
- Test file + expected output for `IntroducedGenericInterfaceOnIntroducedGenericType`

## Test plan

- [x] Regression test verifying `AllImplementedInterfaces`/`ImplementedInterfaces` on definition (`Test<U>` -> `ITest<U>`) and bound type (`Test<int>` -> `ITest<int>`)
- [x] All 2034 aspect tests pass
- [x] All 1560 unit tests pass
- [x] `Build.ps1 build` succeeds with zero warnings
- [x] `Build.ps1 test` succeeds