### PR TITLE
Add regression tests for field pseudo-accessor override (#600)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Fabrics;
+using System.Linq;
+
+#pragma warning disable CS0169
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.ChildAspects.Issue600;
+
+internal class Aspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod() => meta.Proceed();
+}
+
+// <target>
+internal class TargetClass
+{
+    private object _targetField;
+
+    private class Fabric : TypeFabric
+    {
+        public override void AmendType( ITypeAmender amender )
+        {
+            amender.Select( t => t.Fields.Single() ).Select( f => f.SetMethod! ).AddAspect<Aspect>();
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600.t.cs
@@ -1,0 +1,22 @@
+internal class TargetClass
+{
+  private global::System.Object _targetField1 = default !;
+  private global::System.Object _targetField
+  {
+    get
+    {
+      return this._targetField1;
+    }
+    set
+    {
+      this._targetField1 = value;
+      return;
+    }
+  }
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  private class Fabric : TypeFabric
+  {
+    public override void AmendType(ITypeAmender amender) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  }
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600_GetMethod.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600_GetMethod.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Fabrics;
+using System.Linq;
+
+#pragma warning disable CS0169
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.ChildAspects.Issue600_GetMethod;
+
+internal class Aspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod() => meta.Proceed();
+}
+
+// <target>
+internal class TargetClass
+{
+    private object _targetField;
+
+    private class Fabric : TypeFabric
+    {
+        public override void AmendType( ITypeAmender amender )
+        {
+            amender.Select( t => t.Fields.Single() ).Select( f => f.GetMethod! ).AddAspect<Aspect>();
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600_GetMethod.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/ChildAspects/Issue600_GetMethod.t.cs
@@ -1,0 +1,21 @@
+internal class TargetClass
+{
+  private global::System.Object _targetField1 = default !;
+  private global::System.Object _targetField
+  {
+    get
+    {
+      return this._targetField1;
+    }
+    set
+    {
+      this._targetField1 = value;
+    }
+  }
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  private class Fabric : TypeFabric
+  {
+    public override void AmendType(ITypeAmender amender) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  }
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+}


### PR DESCRIPTION
## Summary

- Adds regression tests confirming that `OverrideMethodAspect` can be applied via `AddAspect<T>()` to field pseudo-accessors (both `SetMethod` and `GetMethod`) from a `TypeFabric`.
- The bug described in #600 (LAMA0039 error when adding `OverrideMethodAspect` to field accessor) appears to have been resolved by prior changes related to #828/#1253 (field pseudo-accessor `IsImplicitlyDeclared` handling).
- These tests serve as regression guards to prevent this issue from recurring.

## Checklist

- [x] Reproduce bug (confirmed already fixed on develop/2026.1)
- [x] Add regression tests
- [x] Build with `Build.ps1 build`
- [x] Run `Build.ps1 test`
- [x] Zero warnings verified
- [x] Finalize PR

## Test plan

- [x] `Issue600` test passes: `OverrideMethodAspect` applied to field `SetMethod` via `TypeFabric.AddAspect`
- [x] `Issue600_GetMethod` test passes: `OverrideMethodAspect` applied to field `GetMethod` via `TypeFabric.AddAspect`

— Claude for @PostSharpAgent