### PR TITLE
Add regression tests for explicit interface members on introduced types (#601)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_Declarative_IntroducedType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_Declarative_IntroducedType.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_Declarative_IntroducedType;
+
+/*
+ * Tests that declarative explicit interface members ([InterfaceMember(IsExplicit = true)]) work on introduced types (issue #601).
+ */
+
+public interface IInterface
+{
+    int InterfaceMethod();
+
+    int Property { get; set; }
+}
+
+public class IntroductionAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var type = builder.IntroduceClass( "TestType" );
+        type.ImplementInterface( typeof(IInterface) );
+    }
+
+    [InterfaceMember( IsExplicit = true )]
+    public int InterfaceMethod()
+    {
+        Console.WriteLine( "This is introduced interface member." );
+
+        return meta.Proceed();
+    }
+
+    [InterfaceMember( IsExplicit = true )]
+    public int Property
+    {
+        get
+        {
+            Console.WriteLine( "This is introduced interface member." );
+
+            return meta.Proceed();
+        }
+
+        set
+        {
+            Console.WriteLine( "This is introduced interface member." );
+            meta.Proceed();
+        }
+    }
+}
+
+// <target>
+[Introduction]
+public class TargetClass { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_Declarative_IntroducedType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_Declarative_IntroducedType.t.cs
@@ -1,0 +1,24 @@
+[Introduction]
+public class TargetClass
+{
+  class TestType : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_Declarative_IntroducedType.IInterface
+  {
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_Declarative_IntroducedType.IInterface.Property
+    {
+      get
+      {
+        global::System.Console.WriteLine("This is introduced interface member.");
+        return default(global::System.Int32);
+      }
+      set
+      {
+        global::System.Console.WriteLine("This is introduced interface member.");
+      }
+    }
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_Declarative_IntroducedType.IInterface.InterfaceMethod()
+    {
+      global::System.Console.WriteLine("This is introduced interface member.");
+      return default(global::System.Int32);
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedRootType.TestType.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedRootType.TestType.i.cs
@@ -1,0 +1,23 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedRootType
+{
+  class TestType : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedRootType.IInterface
+  {
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedRootType.IInterface.Property
+    {
+      get
+      {
+        global::System.Console.WriteLine("This is introduced interface member.");
+        return (global::System.Int32)42;
+      }
+      set
+      {
+        global::System.Console.WriteLine("This is introduced interface member.");
+      }
+    }
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedRootType.IInterface.InterfaceMethod(global::System.Int32 i)
+    {
+      global::System.Console.WriteLine("This is introduced interface member.");
+      return i;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedRootType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedRootType.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedRootType;
+
+/*
+ * Tests that explicit interface members can be introduced on introduced root types (issue #601).
+ */
+
+public interface IInterface
+{
+    int InterfaceMethod( int i );
+
+    int Property { get; set; }
+}
+
+public class IntroductionAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var type = builder.With( builder.Target.ContainingNamespace ).IntroduceClass( "TestType" );
+        var explicitImplementation = type.ImplementInterface( typeof(IInterface) ).ExplicitMembers;
+
+        explicitImplementation.IntroduceMethod( nameof(InterfaceMethod) );
+        explicitImplementation.IntroduceProperty( nameof(Property) );
+    }
+
+    [Template]
+    public int InterfaceMethod( int i )
+    {
+        Console.WriteLine( "This is introduced interface member." );
+
+        return i;
+    }
+
+    [Template]
+    public int Property
+    {
+        get
+        {
+            Console.WriteLine( "This is introduced interface member." );
+
+            return 42;
+        }
+
+        set
+        {
+            Console.WriteLine( "This is introduced interface member." );
+        }
+    }
+}
+
+// <target>
+[Introduction]
+public class TargetClass { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedRootType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedRootType.t.cs
@@ -1,0 +1,4 @@
+[Introduction]
+public class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedType.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedType;
+
+/*
+ * Tests that explicit interface members can be introduced on introduced types (issue #601).
+ */
+
+public interface IInterface
+{
+    int InterfaceMethod( int i );
+
+    int Property { get; set; }
+}
+
+public class IntroductionAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var type = builder.IntroduceClass( "TestType" );
+        var explicitImplementation = type.ImplementInterface( typeof(IInterface) ).ExplicitMembers;
+
+        explicitImplementation.IntroduceMethod( nameof(InterfaceMethod) );
+        explicitImplementation.IntroduceProperty( nameof(Property) );
+    }
+
+    [Template]
+    public int InterfaceMethod( int i )
+    {
+        Console.WriteLine( "This is introduced interface member." );
+
+        return i;
+    }
+
+    [Template]
+    public int Property
+    {
+        get
+        {
+            Console.WriteLine( "This is introduced interface member." );
+
+            return 42;
+        }
+
+        set
+        {
+            Console.WriteLine( "This is introduced interface member." );
+        }
+    }
+}
+
+// <target>
+[Introduction]
+public class TargetClass { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/ExplicitMembers_IntroducedType.t.cs
@@ -1,0 +1,24 @@
+[Introduction]
+public class TargetClass
+{
+  class TestType : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedType.IInterface
+  {
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedType.IInterface.Property
+    {
+      get
+      {
+        global::System.Console.WriteLine("This is introduced interface member.");
+        return (global::System.Int32)42;
+      }
+      set
+      {
+        global::System.Console.WriteLine("This is introduced interface member.");
+      }
+    }
+    global::System.Int32 global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.ExplicitMembers_IntroducedType.IInterface.InterfaceMethod(global::System.Int32 i)
+    {
+      global::System.Console.WriteLine("This is introduced interface member.");
+      return i;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #601.

The bug described in #601 (introducing explicit interface members fails for introduced types) has already been fixed in a previous release. This PR adds regression tests to ensure the fix doesn't regress.

Three test cases are added:
- **ExplicitMembers_IntroducedType**: Programmatic explicit interface member implementation on a nested introduced type
- **ExplicitMembers_IntroducedRootType**: Programmatic explicit interface member implementation on a root-level introduced type
- **ExplicitMembers_Declarative_IntroducedType**: Declarative `[InterfaceMember(IsExplicit = true)]` on a nested introduced type

## Checklist
- [x] Understand the issue
- [x] Verify bug is already fixed (confirmed: all 3 test scenarios produce correct output)
- [x] Add regression tests
- [x] Build.ps1 build (passed, zero warnings)
- [x] Build.ps1 test (passed, all test suites green)
- [x] Finalize (PR marked ready for review)

## Test plan
- [x] All 3 new tests pass on net8.0
- [x] Verify full build passes with zero warnings
- [x] Verify all test suites pass