### PR TITLE
Fix non-deterministic field initialization order in DI (#602)

### DIFF
--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue602.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue602.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+// https://github.com/metalama/Metalama/issues/602
+
+namespace Metalama.Extensions.DependencyInjection.AspectTests.Bugs.Issue602;
+
+public interface IServiceA { }
+
+public interface IServiceB { }
+
+public interface IServiceC { }
+
+public interface IServiceD { }
+
+public interface IServiceE { }
+
+// <target>
+public class TargetClass
+{
+    [Dependency]
+    private readonly IServiceA _serviceA;
+
+    [Dependency]
+    private readonly IServiceB _serviceB;
+
+    [Dependency]
+    private readonly IServiceC _serviceC;
+
+    [Dependency]
+    private readonly IServiceD _serviceD;
+
+    [Dependency]
+    private readonly IServiceE _serviceE;
+}

--- a/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue602.t.cs
+++ b/Metalama.Extensions/src/tests/Metalama.Extensions.DependencyInjection.AspectTests/Bugs/Issue602.t.cs
@@ -1,0 +1,21 @@
+public class TargetClass
+{
+  [Dependency]
+  private readonly IServiceA _serviceA;
+  [Dependency]
+  private readonly IServiceB _serviceB;
+  [Dependency]
+  private readonly IServiceC _serviceC;
+  [Dependency]
+  private readonly IServiceD _serviceD;
+  [Dependency]
+  private readonly IServiceE _serviceE;
+  public TargetClass([AspectGenerated] IServiceA? serviceA = null, [AspectGenerated] IServiceB? serviceB = null, [AspectGenerated] IServiceC? serviceC = null, [AspectGenerated] IServiceD? serviceD = null, [AspectGenerated] IServiceE? serviceE = null)
+  {
+    this._serviceA = serviceA ?? throw new System.ArgumentNullException(nameof(serviceA));
+    this._serviceB = serviceB ?? throw new System.ArgumentNullException(nameof(serviceB));
+    this._serviceC = serviceC ?? throw new System.ArgumentNullException(nameof(serviceC));
+    this._serviceD = serviceD ?? throw new System.ArgumentNullException(nameof(serviceD));
+    this._serviceE = serviceE ?? throw new System.ArgumentNullException(nameof(serviceE));
+  }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -625,7 +625,8 @@ internal sealed partial class LinkerInjectionStep
                         DeclarationKind.NamedType when s.ContextDeclaration is INamedType => 1,
                         _ => throw new AssertionFailedException( $"Unexpected declaration: '{s.ContextDeclaration}'." )
                     } )
-                .ThenBy( s => (s.ContextDeclaration as IMember)?.ToDisplayString() );
+                .ThenBy( s => (s.ContextDeclaration as IMember)?.ToDisplayString() )
+                .ThenBy( s => s.Statement.ToFullString(), StringComparer.Ordinal );
 
         /// <summary>
         /// Orders contract statements ensuring:

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -625,7 +625,7 @@ internal sealed partial class LinkerInjectionStep
                         DeclarationKind.NamedType when s.ContextDeclaration is INamedType => 1,
                         _ => throw new AssertionFailedException( $"Unexpected declaration: '{s.ContextDeclaration}'." )
                     } )
-                .ThenBy( s => (s.ContextDeclaration as IMember)?.ToDisplayString() )
+                .ThenBy( s => (s.ContextDeclaration as IMember)?.ToDisplayString(), StringComparer.Ordinal )
                 .ThenBy( s => s.Transformation.AdviceOrderingIndices.OrderWithinPipeline )
                 .ThenBy( s => s.Transformation.AdviceOrderingIndices.OrderWithinPipelineStepAndType )
                 .ThenBy( s => s.Transformation.AdviceOrderingIndices.OrderWithinPipelineStepAndTypeAndAspectInstance )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -626,6 +626,9 @@ internal sealed partial class LinkerInjectionStep
                         _ => throw new AssertionFailedException( $"Unexpected declaration: '{s.ContextDeclaration}'." )
                     } )
                 .ThenBy( s => (s.ContextDeclaration as IMember)?.ToDisplayString() )
+                .ThenBy( s => s.Transformation.AdviceOrderingIndices.OrderWithinPipeline )
+                .ThenBy( s => s.Transformation.AdviceOrderingIndices.OrderWithinPipelineStepAndType )
+                .ThenBy( s => s.Transformation.AdviceOrderingIndices.OrderWithinPipelineStepAndTypeAndAspectInstance )
                 .ThenBy( s => s.Statement.ToFullString(), StringComparer.Ordinal );
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes #602 — DI field initialization order is non-deterministic.

**Root cause**: In `LinkerInjectionStep.TransformationCollection.OrderInitializerStatements`, when multiple `[Dependency]` fields are pulled into the same constructor, each initializer statement shares the same `ContextDeclaration` (the constructor). The `ThenBy` on `ToDisplayString()` produces equal keys for all, so the final order depends on insertion order, which can be non-deterministic due to concurrent transformation processing via `RunConcurrentlyAsync`.

**Fix**: Added `AdviceOrderingIndices` (ascending) as intermediate tiebreakers after the existing `ContextDeclaration` sorting to preserve intended aspect ordering, followed by `Statement.ToFullString()` with `StringComparer.Ordinal` as the final deterministic tiebreaker.

**Regression test**: `Issue602.cs` in `Metalama.Extensions.DependencyInjection.AspectTests/Bugs/` with 5 `[Dependency]` fields verifying deterministic alphabetical initialization order.

## Checklist

- [x] Reproduce bug with regression test
- [x] Implement fix
- [x] Verify DI aspect tests pass (38/38)
- [x] Full Build.ps1 build — zero warnings
- [x] Full Build.ps1 test — all tests pass
- [x] Finalize PR

— Claude for @gfraiteur