### PR TITLE
Restrict CacheAttribute to methods only (#603)

### DIFF
--- a/Metalama.Patterns/src/Metalama.Patterns.Caching.Aspects/CacheAttribute.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Caching.Aspects/CacheAttribute.cs
@@ -35,6 +35,7 @@ namespace Metalama.Patterns.Caching.Aspects;
 /// <para>To invalidate a cached method, see <see cref="InvalidateCacheAttribute"/> and the <see cref="CachingServiceExtensions.Invalidate{TReturn,TParam1}"/> method.</para>
 /// </remarks>
 [PublicAPI]
+[AttributeUsage( AttributeTargets.Method )]
 public sealed class CacheAttribute : CachingBaseAttribute, IAspect<IMethod>
 {
     void IEligible<IMethod>.BuildEligibility( IEligibilityBuilder<IMethod> builder )


### PR DESCRIPTION
## Summary

Fixes #603.

`CacheAttribute` was missing `[AttributeUsage(AttributeTargets.Method)]`, which meant it defaulted to `AttributeTargets.All`. This allowed users to write `[assembly: Cache]`, which compiled but then produced a confusing Metalama error (`LAMA0003: Aspect 'Cache' cannot be applied to project, because this aspect does not implement the 'IAspect<ICompilation>' interface`).

The fix adds the missing `[AttributeUsage(AttributeTargets.Method)]` attribute to `CacheAttribute`, consistent with `InvalidateCacheAttribute` which already has this restriction.

**Note:** The issue title mentions `InvalidateCacheAttribute`, but that attribute already had the correct `[AttributeUsage(AttributeTargets.Method)]`. The actual bug was in the closely related `CacheAttribute`.

## Changes

- Added `[AttributeUsage(AttributeTargets.Method)]` to `CacheAttribute`

## Checklist

- [x] Reproduce bug (confirmed `[assembly: Cache]` compiles and produces LAMA0003)
- [x] Implement fix
- [x] Run caching aspect tests (30/30 passed)
- [x] Run caching unit tests (454/454 passed, 4 skipped)
- [x] Full `Build.ps1 build` (zero warnings)
- [x] Full `Build.ps1 test` (all passed, 2 pre-existing standalone timeouts)
- [x] Finalize PR

— Claude for @gfraiteur