### PR TITLE
Fix leading comments lost when aspect applied to field

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -526,8 +526,9 @@ internal sealed partial class LinkerInjectionStep
                         injectedMember.Transformation?.AspectInstance.AspectClass.GeneratedCodeAnnotation
                         ?? FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
-                // When a field is promoted to a property, transfer the field's comment trivia to the property
-                // (the property is the public member).
+                // When a field is promoted to a property, transfer the field's trivia:
+                // - XML doc comments go to the property (public semantic).
+                // - Regular comments and directives stay with the backing field (private implementation detail).
                 if ( injectedMember is { Semantic: InjectedMemberSemantic.Introduction, Kind: DeclarationKind.Property }
                      && injectedMember.Transformation is IReplaceMemberTransformation { ReplacedMember: ISymbolRef<IField> replacedFieldRef } )
                 {
@@ -535,9 +536,14 @@ internal sealed partial class LinkerInjectionStep
 
                     if ( fieldSyntaxReference?.GetSyntax().Parent?.Parent is { RawKind: (int) SyntaxKind.FieldDeclaration } and FieldDeclarationSyntax fieldDeclaration )
                     {
-                        var commentTrivia = TriviaHelper.GetCommentTrivia( fieldDeclaration );
+                        var docTrivia = TriviaHelper.GetDocumentationTrivia( fieldDeclaration );
 
-                        injectedNode = TriviaHelper.WithCommentTrivia( injectedNode, commentTrivia );
+                        injectedNode = TriviaHelper.WithDocumentationTrivia( injectedNode, docTrivia );
+
+                        // Mark the property with non-doc trivia so the rewriting driver can transfer it to the backing field.
+                        var nonDocTrivia = TriviaHelper.GetNonDocumentationTrivia( fieldDeclaration );
+
+                        injectedNode = TriviaHelper.WithFieldNonDocTriviaAnnotation( injectedNode, nonDocTrivia );
                     }
                 }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -526,9 +526,9 @@ internal sealed partial class LinkerInjectionStep
                         injectedMember.Transformation?.AspectInstance.AspectClass.GeneratedCodeAnnotation
                         ?? FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
-                // When a field is promoted to a property, transfer the field's trivia:
-                // - XML doc comments go to the property (public semantic).
-                // - Regular comments and directives stay with the backing field (private implementation detail).
+                // When a field is promoted to a property, transfer XML doc comments from the field to the property
+                // (the public semantic). Regular comments and directives stay with the backing field and are handled
+                // in LinkerRewritingDriver.Properties.cs when the backing field is generated.
                 if ( injectedMember is { Semantic: InjectedMemberSemantic.Introduction, Kind: DeclarationKind.Property }
                      && injectedMember.Transformation is IReplaceMemberTransformation { ReplacedMember: ISymbolRef<IField> replacedFieldRef } )
                 {
@@ -539,11 +539,6 @@ internal sealed partial class LinkerInjectionStep
                         var docTrivia = TriviaHelper.GetDocumentationTrivia( fieldDeclaration );
 
                         injectedNode = TriviaHelper.WithDocumentationTrivia( injectedNode, docTrivia );
-
-                        // Mark the property with non-doc trivia so the rewriting driver can transfer it to the backing field.
-                        var nonDocTrivia = TriviaHelper.GetNonDocumentationTrivia( fieldDeclaration );
-
-                        injectedNode = TriviaHelper.WithFieldNonDocTriviaAnnotation( injectedNode, nonDocTrivia );
                     }
                 }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -526,7 +526,7 @@ internal sealed partial class LinkerInjectionStep
                         injectedMember.Transformation?.AspectInstance.AspectClass.GeneratedCodeAnnotation
                         ?? FormattingAnnotations.SystemGeneratedCodeAnnotation );
 
-                // When a field is promoted to a property, transfer the field's doc comment trivia to the property
+                // When a field is promoted to a property, transfer the field's comment trivia to the property
                 // (the property is the public member).
                 if ( injectedMember is { Semantic: InjectedMemberSemantic.Introduction, Kind: DeclarationKind.Property }
                      && injectedMember.Transformation is IReplaceMemberTransformation { ReplacedMember: ISymbolRef<IField> replacedFieldRef } )
@@ -535,9 +535,9 @@ internal sealed partial class LinkerInjectionStep
 
                     if ( fieldSyntaxReference?.GetSyntax().Parent?.Parent is { RawKind: (int) SyntaxKind.FieldDeclaration } and FieldDeclarationSyntax fieldDeclaration )
                     {
-                        var docTrivia = TriviaHelper.GetDocumentationTrivia( fieldDeclaration );
+                        var commentTrivia = TriviaHelper.GetCommentTrivia( fieldDeclaration );
 
-                        injectedNode = TriviaHelper.WithDocumentationTrivia( injectedNode, docTrivia );
+                        injectedNode = TriviaHelper.WithCommentTrivia( injectedNode, commentTrivia );
                     }
                 }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -74,8 +74,9 @@ namespace Metalama.Framework.Engine.Linking
                          {
                              ReplacedMember: ISymbolRef replacedFieldSymbolRef
                          }
-                         && replacedFieldSymbolRef.Symbol.GetPrimarySyntaxReference()?.GetSyntax().Parent?.Parent
-                             is { RawKind: (int) SyntaxKind.FieldDeclaration } and FieldDeclarationSyntax originalFieldDeclaration )
+                         && replacedFieldSymbolRef.Symbol.GetPrimarySyntaxReference()
+                             ?.GetSyntax()
+                             .FirstAncestorOrSelf<FieldDeclarationSyntax>() is { } originalFieldDeclaration )
                     {
                         var nonDocTrivia = TriviaHelper.GetNonDocumentationTrivia( originalFieldDeclaration );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -66,6 +66,17 @@ namespace Metalama.Framework.Engine.Linking
                         symbol,
                         generationContext );
 
+                    // When a field is promoted to a property, non-documentation trivia (regular comments, directives)
+                    // should stay with the backing field rather than moving to the property.
+                    if ( TriviaHelper.TryGetFieldNonDocTrivia( propertyDeclaration, out var nonDocTriviaString )
+                         && nonDocTriviaString != null )
+                    {
+                        var existingTrivia = backingField.GetLeadingTrivia();
+                        var nonDocTrivia = ParseLeadingTrivia( nonDocTriviaString );
+
+                        backingField = backingField.WithRequiredLeadingTrivia( nonDocTrivia.AddRange( existingTrivia ) );
+                    }
+
                     members.Add( backingField );
                 }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -2,9 +2,11 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Formatting;
 using Metalama.Framework.Engine.Linking.Substitution;
 using Metalama.Framework.Engine.SyntaxGeneration;
+using Metalama.Framework.Engine.Transformations;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -68,13 +70,21 @@ namespace Metalama.Framework.Engine.Linking
 
                     // When a field is promoted to a property, non-documentation trivia (regular comments, directives)
                     // should stay with the backing field rather than moving to the property.
-                    if ( TriviaHelper.TryGetFieldNonDocTrivia( propertyDeclaration, out var nonDocTriviaString )
-                         && nonDocTriviaString != null )
+                    if ( this.InjectionRegistry.GetTransformationForSymbol( symbol ) is IReplaceMemberTransformation
+                         {
+                             ReplacedMember: ISymbolRef replacedFieldSymbolRef
+                         }
+                         && replacedFieldSymbolRef.Symbol.GetPrimarySyntaxReference()?.GetSyntax().Parent?.Parent
+                             is { RawKind: (int) SyntaxKind.FieldDeclaration } and FieldDeclarationSyntax originalFieldDeclaration )
                     {
-                        var existingTrivia = backingField.GetLeadingTrivia();
-                        var nonDocTrivia = ParseLeadingTrivia( nonDocTriviaString );
+                        var nonDocTrivia = TriviaHelper.GetNonDocumentationTrivia( originalFieldDeclaration );
 
-                        backingField = backingField.WithRequiredLeadingTrivia( nonDocTrivia.AddRange( existingTrivia ) );
+                        if ( nonDocTrivia.Count > 0 )
+                        {
+                            var existingTrivia = backingField.GetLeadingTrivia();
+
+                            backingField = backingField.WithRequiredLeadingTrivia( nonDocTrivia.AddRange( existingTrivia ) );
+                        }
                     }
 
                     members.Add( backingField );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
@@ -88,47 +88,4 @@ internal static class TriviaHelper
         return member.WithRequiredLeadingTrivia( documentationTrivia.AddRange( existingTrivia ) );
     }
 
-    /// <summary>
-    /// A syntax annotation used to mark a property whose backing field should receive non-documentation trivia
-    /// from the original field declaration.
-    /// </summary>
-    public static readonly string FieldNonDocTriviaAnnotationKind = "Metalama.FieldNonDocTrivia";
-
-    /// <summary>
-    /// Marks a member with an annotation indicating it has associated non-documentation trivia
-    /// that should be transferred to the backing field.
-    /// </summary>
-    public static T WithFieldNonDocTriviaAnnotation<T>( T member, SyntaxTriviaList nonDocTrivia )
-        where T : MemberDeclarationSyntax
-    {
-        if ( nonDocTrivia.Count == 0 )
-        {
-            return member;
-        }
-
-        // Serialize the trivia to a string representation so it can be carried by the annotation.
-        var triviaString = nonDocTrivia.ToFullString();
-
-        return member.WithAdditionalAnnotations( new SyntaxAnnotation( FieldNonDocTriviaAnnotationKind, triviaString ) );
-    }
-
-    /// <summary>
-    /// Tries to get the non-documentation trivia stored in a syntax annotation on a member.
-    /// Returns true if the annotation was found, and outputs the trivia string.
-    /// </summary>
-    public static bool TryGetFieldNonDocTrivia( MemberDeclarationSyntax member, out string? triviaString )
-    {
-        var annotation = member.GetAnnotations( FieldNonDocTriviaAnnotationKind );
-
-        foreach ( var a in annotation )
-        {
-            triviaString = a.Data;
-
-            return true;
-        }
-
-        triviaString = null;
-
-        return false;
-    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
@@ -13,13 +13,36 @@ namespace Metalama.Framework.Engine.Linking;
 internal static class TriviaHelper
 {
     /// <summary>
-    /// Extracts comment trivia (regular comments and XML documentation comments) from a field declaration.
-    /// Returns the comment trivia list (including associated whitespace), or an empty list if none is found.
+    /// Extracts XML documentation comment trivia from a field declaration.
+    /// Returns the documentation trivia list, or an empty list if none is found.
     /// </summary>
-    public static SyntaxTriviaList GetCommentTrivia( FieldDeclarationSyntax fieldDeclaration )
+    public static SyntaxTriviaList GetDocumentationTrivia( FieldDeclarationSyntax fieldDeclaration )
     {
         var leadingTrivia = fieldDeclaration.GetLeadingTrivia();
-        var commentTrivia = new List<SyntaxTrivia>();
+        var docCommentTrivia = new List<SyntaxTrivia>();
+
+        foreach ( var trivia in leadingTrivia )
+        {
+            if ( trivia.IsKind( SyntaxKind.SingleLineDocumentationCommentTrivia )
+                 || trivia.IsKind( SyntaxKind.MultiLineDocumentationCommentTrivia ) )
+            {
+                docCommentTrivia.Add( trivia );
+            }
+        }
+
+        return new SyntaxTriviaList( docCommentTrivia );
+    }
+
+    /// <summary>
+    /// Extracts non-documentation comment trivia (regular comments and directives) from a field declaration.
+    /// Returns the trivia list with associated whitespace, or an empty list if none is found.
+    /// When a field is promoted to a property, these trivia should stay with the backing field
+    /// (they are associated with the private implementation detail, not the public member).
+    /// </summary>
+    public static SyntaxTriviaList GetNonDocumentationTrivia( FieldDeclarationSyntax fieldDeclaration )
+    {
+        var leadingTrivia = fieldDeclaration.GetLeadingTrivia();
+        var result = new List<SyntaxTrivia>();
 
         for ( var i = 0; i < leadingTrivia.Count; i++ )
         {
@@ -27,42 +50,85 @@ internal static class TriviaHelper
 
             if ( trivia.IsKind( SyntaxKind.SingleLineCommentTrivia )
                  || trivia.IsKind( SyntaxKind.MultiLineCommentTrivia )
-                 || trivia.IsKind( SyntaxKind.SingleLineDocumentationCommentTrivia )
-                 || trivia.IsKind( SyntaxKind.MultiLineDocumentationCommentTrivia ) )
+                 || trivia.IsDirective )
             {
                 // Include the whitespace trivia before the comment for proper indentation.
-                if ( commentTrivia.Count == 0 && i > 0 && leadingTrivia[i - 1].IsKind( SyntaxKind.WhitespaceTrivia ) )
+                if ( result.Count == 0 && i > 0 && leadingTrivia[i - 1].IsKind( SyntaxKind.WhitespaceTrivia ) )
                 {
-                    commentTrivia.Add( leadingTrivia[i - 1] );
+                    result.Add( leadingTrivia[i - 1] );
                 }
 
-                commentTrivia.Add( trivia );
+                result.Add( trivia );
 
                 // Include the end-of-line trivia after the comment.
                 if ( i + 1 < leadingTrivia.Count && leadingTrivia[i + 1].IsKind( SyntaxKind.EndOfLineTrivia ) )
                 {
-                    commentTrivia.Add( leadingTrivia[i + 1] );
+                    result.Add( leadingTrivia[i + 1] );
                 }
             }
         }
 
-        return new SyntaxTriviaList( commentTrivia );
+        return new SyntaxTriviaList( result );
     }
 
     /// <summary>
-    /// Adds comment trivia to the leading trivia of a member declaration.
-    /// The comment trivia is prepended before the member's existing leading trivia.
+    /// Adds documentation trivia to the leading trivia of a member declaration.
+    /// The documentation trivia is prepended before the member's existing leading trivia.
     /// </summary>
-    public static T WithCommentTrivia<T>( T member, SyntaxTriviaList commentTrivia )
+    public static T WithDocumentationTrivia<T>( T member, SyntaxTriviaList documentationTrivia )
         where T : MemberDeclarationSyntax
     {
-        if ( commentTrivia.Count == 0 )
+        if ( documentationTrivia.Count == 0 )
         {
             return member;
         }
 
         var existingTrivia = member.GetLeadingTrivia();
 
-        return member.WithRequiredLeadingTrivia( commentTrivia.AddRange( existingTrivia ) );
+        return member.WithRequiredLeadingTrivia( documentationTrivia.AddRange( existingTrivia ) );
+    }
+
+    /// <summary>
+    /// A syntax annotation used to mark a property whose backing field should receive non-documentation trivia
+    /// from the original field declaration.
+    /// </summary>
+    public static readonly string FieldNonDocTriviaAnnotationKind = "Metalama.FieldNonDocTrivia";
+
+    /// <summary>
+    /// Marks a member with an annotation indicating it has associated non-documentation trivia
+    /// that should be transferred to the backing field.
+    /// </summary>
+    public static T WithFieldNonDocTriviaAnnotation<T>( T member, SyntaxTriviaList nonDocTrivia )
+        where T : MemberDeclarationSyntax
+    {
+        if ( nonDocTrivia.Count == 0 )
+        {
+            return member;
+        }
+
+        // Serialize the trivia to a string representation so it can be carried by the annotation.
+        var triviaString = nonDocTrivia.ToFullString();
+
+        return member.WithAdditionalAnnotations( new SyntaxAnnotation( FieldNonDocTriviaAnnotationKind, triviaString ) );
+    }
+
+    /// <summary>
+    /// Tries to get the non-documentation trivia stored in a syntax annotation on a member.
+    /// Returns true if the annotation was found, and outputs the trivia string.
+    /// </summary>
+    public static bool TryGetFieldNonDocTrivia( MemberDeclarationSyntax member, out string? triviaString )
+    {
+        var annotation = member.GetAnnotations( FieldNonDocTriviaAnnotationKind );
+
+        foreach ( var a in annotation )
+        {
+            triviaString = a.Data;
+
+            return true;
+        }
+
+        triviaString = null;
+
+        return false;
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
@@ -13,40 +13,56 @@ namespace Metalama.Framework.Engine.Linking;
 internal static class TriviaHelper
 {
     /// <summary>
-    /// Extracts XML documentation comment trivia from a field declaration.
-    /// Returns the documentation trivia list, or an empty list if none is found.
+    /// Extracts comment trivia (regular comments and XML documentation comments) from a field declaration.
+    /// Returns the comment trivia list (including associated whitespace), or an empty list if none is found.
     /// </summary>
-    public static SyntaxTriviaList GetDocumentationTrivia( FieldDeclarationSyntax fieldDeclaration )
+    public static SyntaxTriviaList GetCommentTrivia( FieldDeclarationSyntax fieldDeclaration )
     {
         var leadingTrivia = fieldDeclaration.GetLeadingTrivia();
-        var docCommentTrivia = new List<SyntaxTrivia>();
+        var commentTrivia = new List<SyntaxTrivia>();
 
-        foreach ( var trivia in leadingTrivia )
+        for ( var i = 0; i < leadingTrivia.Count; i++ )
         {
-            if ( trivia.IsKind( SyntaxKind.SingleLineDocumentationCommentTrivia )
+            var trivia = leadingTrivia[i];
+
+            if ( trivia.IsKind( SyntaxKind.SingleLineCommentTrivia )
+                 || trivia.IsKind( SyntaxKind.MultiLineCommentTrivia )
+                 || trivia.IsKind( SyntaxKind.SingleLineDocumentationCommentTrivia )
                  || trivia.IsKind( SyntaxKind.MultiLineDocumentationCommentTrivia ) )
             {
-                docCommentTrivia.Add( trivia );
+                // Include the whitespace trivia before the comment for proper indentation.
+                if ( commentTrivia.Count == 0 && i > 0 && leadingTrivia[i - 1].IsKind( SyntaxKind.WhitespaceTrivia ) )
+                {
+                    commentTrivia.Add( leadingTrivia[i - 1] );
+                }
+
+                commentTrivia.Add( trivia );
+
+                // Include the end-of-line trivia after the comment.
+                if ( i + 1 < leadingTrivia.Count && leadingTrivia[i + 1].IsKind( SyntaxKind.EndOfLineTrivia ) )
+                {
+                    commentTrivia.Add( leadingTrivia[i + 1] );
+                }
             }
         }
 
-        return new SyntaxTriviaList( docCommentTrivia );
+        return new SyntaxTriviaList( commentTrivia );
     }
 
     /// <summary>
-    /// Adds documentation trivia to the leading trivia of a member declaration.
-    /// The documentation trivia is prepended before the member's existing leading trivia.
+    /// Adds comment trivia to the leading trivia of a member declaration.
+    /// The comment trivia is prepended before the member's existing leading trivia.
     /// </summary>
-    public static T WithDocumentationTrivia<T>( T member, SyntaxTriviaList documentationTrivia )
+    public static T WithCommentTrivia<T>( T member, SyntaxTriviaList commentTrivia )
         where T : MemberDeclarationSyntax
     {
-        if ( documentationTrivia.Count == 0 )
+        if ( commentTrivia.Count == 0 )
         {
             return member;
         }
 
         var existingTrivia = member.GetLeadingTrivia();
 
-        return member.WithRequiredLeadingTrivia( documentationTrivia.AddRange( existingTrivia ) );
+        return member.WithRequiredLeadingTrivia( commentTrivia.AddRange( existingTrivia ) );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/TriviaHelper.cs
@@ -53,7 +53,7 @@ internal static class TriviaHelper
                  || trivia.IsDirective )
             {
                 // Include the whitespace trivia before the comment for proper indentation.
-                if ( result.Count == 0 && i > 0 && leadingTrivia[i - 1].IsKind( SyntaxKind.WhitespaceTrivia ) )
+                if ( i > 0 && leadingTrivia[i - 1].IsKind( SyntaxKind.WhitespaceTrivia ) )
                 {
                     result.Add( leadingTrivia[i - 1] );
                 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Eligibility/ConstFieldGetter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Eligibility/ConstFieldGetter.t.cs
@@ -3,6 +3,7 @@ public class TheClass
   // C should not be modified.
   public const int C = 4;
   private global::System.Int32 _f;
+  // The other fields should be modified.
   public global::System.Int32 F
   {
     get

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Eligibility/ConstFieldGetter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Eligibility/ConstFieldGetter.t.cs
@@ -2,8 +2,8 @@ public class TheClass
 {
   // C should not be modified.
   public const int C = 4;
-  private global::System.Int32 _f;
   // The other fields should be modified.
+  private global::System.Int32 _f;
   public global::System.Int32 F
   {
     get

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_AllOverridden.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_AllOverridden.t.cs
@@ -2,6 +2,7 @@
 internal class TargetClass
 {
   private global::System.Int32 _a;
+  // Comment before.
   public global::System.Int32 A
   {
     get
@@ -16,6 +17,7 @@ internal class TargetClass
     }
   }
   private global::System.Int32 _b;
+  // Comment before.
   public global::System.Int32 B
   {
     get
@@ -30,6 +32,7 @@ internal class TargetClass
     }
   }
   private global::System.Int32 _c;
+  // Comment before.
   public global::System.Int32 C
   {
     get

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_AllOverridden.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_AllOverridden.t.cs
@@ -1,8 +1,8 @@
 [Test]
 internal class TargetClass
 {
-  private global::System.Int32 _a;
   // Comment before.
+  private global::System.Int32 _a;
   public global::System.Int32 A
   {
     get
@@ -16,8 +16,8 @@ internal class TargetClass
       this._a = value;
     }
   }
-  private global::System.Int32 _b;
   // Comment before.
+  private global::System.Int32 _b;
   public global::System.Int32 B
   {
     get
@@ -31,8 +31,8 @@ internal class TargetClass
       this._b = value;
     }
   }
-  private global::System.Int32 _c;
   // Comment before.
+  private global::System.Int32 _c;
   public global::System.Int32 C
   {
     get

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_OneOverridden.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_OneOverridden.t.cs
@@ -4,6 +4,7 @@ internal class TargetClass
   // Comment before.
   public int A, C;
   private global::System.Int32 _b;
+  // Comment before.
   public global::System.Int32 B
   {
     get

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_OneOverridden.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_OneOverridden.t.cs
@@ -3,8 +3,8 @@ internal class TargetClass
 {
   // Comment before.
   public int A, C;
-  private global::System.Int32 _b;
   // Comment before.
+  private global::System.Int32 _b;
   public global::System.Int32 B
   {
     get

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_Trivias.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_Trivias.t.cs
@@ -18,6 +18,7 @@ internal class TargetClass
   int D, F // Comment after variable declarator
   ; // Comment after first list.
   private global::System.Int32 _e;
+  // Comment before first list (one overridden).
   /// <summary>
   /// Doc comment for D, E, F.
   /// </summary>
@@ -35,6 +36,7 @@ internal class TargetClass
     }
   }
   private global::System.Int32 _g;
+  // Comment before first list (all overridden).
   /// <summary>
   /// Doc comment for G, H, I.
   /// </summary>
@@ -52,6 +54,7 @@ internal class TargetClass
     }
   }
   private global::System.Int32 _h;
+  // Comment before first list (all overridden).
   /// <summary>
   /// Doc comment for G, H, I.
   /// </summary>
@@ -69,6 +72,7 @@ internal class TargetClass
     }
   }
   private global::System.Int32 _i;
+  // Comment before first list (all overridden).
   /// <summary>
   /// Doc comment for G, H, I.
   /// </summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_Trivias.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/MultipleDeclarators_Trivias.t.cs
@@ -17,8 +17,8 @@ internal class TargetClass
  // Comment before variable declarator.
   int D, F // Comment after variable declarator
   ; // Comment after first list.
-  private global::System.Int32 _e;
   // Comment before first list (one overridden).
+  private global::System.Int32 _e;
   /// <summary>
   /// Doc comment for D, E, F.
   /// </summary>
@@ -35,8 +35,8 @@ internal class TargetClass
       this._e = value;
     }
   }
-  private global::System.Int32 _g;
   // Comment before first list (all overridden).
+  private global::System.Int32 _g;
   /// <summary>
   /// Doc comment for G, H, I.
   /// </summary>
@@ -53,8 +53,8 @@ internal class TargetClass
       this._g = value;
     }
   }
-  private global::System.Int32 _h;
   // Comment before first list (all overridden).
+  private global::System.Int32 _h;
   /// <summary>
   /// Doc comment for G, H, I.
   /// </summary>
@@ -71,8 +71,8 @@ internal class TargetClass
       this._h = value;
     }
   }
-  private global::System.Int32 _i;
   // Comment before first list (all overridden).
+  private global::System.Int32 _i;
   /// <summary>
   /// Doc comment for G, H, I.
   /// </summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias.t.cs
@@ -19,6 +19,7 @@ internal class TargetClass
     }
   }
   private global::System.Int32 _fieldWithComment;
+  // Regular comment before field.
   /// <summary>
   /// A field with a regular comment.
   /// </summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias.t.cs
@@ -18,8 +18,8 @@ internal class TargetClass
       this._field = value;
     }
   }
-  private global::System.Int32 _fieldWithComment;
   // Regular comment before field.
+  private global::System.Int32 _fieldWithComment;
   /// <summary>
   /// A field with a regular comment.
   /// </summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.cs
@@ -8,7 +8,10 @@ using Metalama.Framework.Aspects;
 namespace Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment
 {
     /*
-     * Tests that leading comments are preserved when an aspect is applied to a field.
+     * Tests that when a field is promoted to a property by an aspect:
+     * - Regular comments (// and block comments) stay with the backing field (not moved to the property).
+     * - XML documentation comments (///) are transferred to the property (public semantic).
+     * - When both regular and doc comments are present, they are split correctly.
      */
 
     public class OverrideAttribute : OverrideFieldOrPropertyAspect
@@ -45,5 +48,18 @@ namespace Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_L
         /* Block comment before field. */
         [Override]
         public int BlockCommentField;
+
+        /// <summary>
+        /// XML doc comment on field.
+        /// </summary>
+        [Override]
+        public int DocCommentField;
+
+        // Regular comment before doc.
+        /// <summary>
+        /// Mixed: regular + doc comment.
+        /// </summary>
+        [Override]
+        public int MixedComments;
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment
+{
+    /*
+     * Tests that leading comments are preserved when an aspect is applied to a field.
+     */
+
+    public class OverrideAttribute : OverrideFieldOrPropertyAspect
+    {
+        public override dynamic? OverrideProperty
+        {
+            get
+            {
+                Console.WriteLine( "This is the overridden getter." );
+
+                return meta.Proceed();
+            }
+
+            set
+            {
+                Console.WriteLine( "This is the overridden setter." );
+                meta.Proceed();
+            }
+        }
+    }
+
+    // <target>
+    internal class TargetClass
+    {
+        // Applied on a field.
+        [Override]
+        public string LastName;
+
+        // First comment.
+        // Second comment.
+        [Override]
+        public int MultipleComments;
+
+        /* Block comment before field. */
+        [Override]
+        public int BlockCommentField;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.t.cs
@@ -1,0 +1,52 @@
+internal class TargetClass
+{
+  private global::System.String _lastName = default !;
+  // Applied on a field.
+  [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
+  public global::System.String LastName
+  {
+    get
+    {
+      global::System.Console.WriteLine("This is the overridden getter.");
+      return this._lastName;
+    }
+    set
+    {
+      global::System.Console.WriteLine("This is the overridden setter.");
+      this._lastName = value;
+    }
+  }
+  private global::System.Int32 _multipleComments;
+  // First comment.
+  // Second comment.
+  [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
+  public global::System.Int32 MultipleComments
+  {
+    get
+    {
+      global::System.Console.WriteLine("This is the overridden getter.");
+      return this._multipleComments;
+    }
+    set
+    {
+      global::System.Console.WriteLine("This is the overridden setter.");
+      this._multipleComments = value;
+    }
+  }
+  private global::System.Int32 _blockCommentField;
+  /* Block comment before field. */
+  [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
+  public global::System.Int32 BlockCommentField
+  {
+    get
+    {
+      global::System.Console.WriteLine("This is the overridden getter.");
+      return this._blockCommentField;
+    }
+    set
+    {
+      global::System.Console.WriteLine("This is the overridden setter.");
+      this._blockCommentField = value;
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Overrides/Fields/Trivias_LeadingComment.t.cs
@@ -1,7 +1,7 @@
 internal class TargetClass
 {
-  private global::System.String _lastName = default !;
   // Applied on a field.
+  private global::System.String _lastName = default !;
   [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
   public global::System.String LastName
   {
@@ -16,9 +16,9 @@ internal class TargetClass
       this._lastName = value;
     }
   }
-  private global::System.Int32 _multipleComments;
   // First comment.
   // Second comment.
+  private global::System.Int32 _multipleComments;
   [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
   public global::System.Int32 MultipleComments
   {
@@ -33,8 +33,8 @@ internal class TargetClass
       this._multipleComments = value;
     }
   }
-  private global::System.Int32 _blockCommentField;
   /* Block comment before field. */
+  private global::System.Int32 _blockCommentField;
   [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
   public global::System.Int32 BlockCommentField
   {
@@ -47,6 +47,43 @@ internal class TargetClass
     {
       global::System.Console.WriteLine("This is the overridden setter.");
       this._blockCommentField = value;
+    }
+  }
+  private global::System.Int32 _docCommentField;
+  /// <summary>
+  /// XML doc comment on field.
+  /// </summary>
+  [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
+  public global::System.Int32 DocCommentField
+  {
+    get
+    {
+      global::System.Console.WriteLine("This is the overridden getter.");
+      return this._docCommentField;
+    }
+    set
+    {
+      global::System.Console.WriteLine("This is the overridden setter.");
+      this._docCommentField = value;
+    }
+  }
+  // Regular comment before doc.
+  private global::System.Int32 _mixedComments;
+  /// <summary>
+  /// Mixed: regular + doc comment.
+  /// </summary>
+  [global::Metalama.Framework.IntegrationTests.Aspects.Overrides.Fields.Trivias_LeadingComment.OverrideAttribute]
+  public global::System.Int32 MixedComments
+  {
+    get
+    {
+      global::System.Console.WriteLine("This is the overridden getter.");
+      return this._mixedComments;
+    }
+    set
+    {
+      global::System.Console.WriteLine("This is the overridden setter.");
+      this._mixedComments = value;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #609: Leading comments are lost when an aspect is applied to a field
- When `OverrideFieldOrPropertyAspect` is applied to a field, the field is promoted to a property with a backing field. Previously, only XML documentation comments were transferred to the property — regular comments were dropped entirely.
- Per review: XML doc comments should stick to the property (public semantic), while regular comments and directives should stay with the backing field (private implementation detail).

## Changes
- `TriviaHelper.cs`: Provides `GetDocumentationTrivia()` (XML doc → property) and `GetNonDocumentationTrivia()` (regular comments/directives → backing field) as simple extraction helpers with no annotation machinery. Whitespace trivia is captured for each comment/directive to preserve indentation of multi-line comment blocks.
- `LinkerInjectionStep.Rewriter.cs`: Transfers XML doc comments from the original field to the injected property.
- `LinkerRewritingDriver.Properties.cs`: When generating the backing field, looks up the original field declaration via `InjectionRegistry.GetTransformationForSymbol()` → `IReplaceMemberTransformation.ReplacedMember` and applies non-doc trivia directly. Uses `FirstAncestorOrSelf<FieldDeclarationSyntax>()` for robust ancestor lookup.
- Updated 6 existing test expected outputs to place regular comments on the backing field.
- Regression test `Trivias_LeadingComment` covers: single-line comments, multiple comments, block comments, XML doc comments, and mixed (regular + doc) comments.

## Progress
- [x] Reproduce bug with failing regression test
- [x] Implement fix in linker (initial: all comments to property)
- [x] Address review feedback: split doc vs. non-doc trivia
- [x] Remove annotation-based approach per review; use InjectionRegistry lookup instead
- [x] Address Copilot review feedback (indentation for multi-line comments, FirstAncestorOrSelf)
- [x] Update affected test expectations
- [x] Build - zero warnings
- [x] Test - all tests pass
- [x] Finalize

## Test plan
- Regression test `Trivias_LeadingComment` verifies trivia placement for:
  - Single-line comment (`// Applied on a field.`) -> backing field
  - Multiple single-line comments -> backing field
  - Block comments (`/* ... */`) -> backing field
  - XML doc comments (`/// <summary>...`) -> property
  - Mixed regular + doc comments -> split correctly (regular -> backing field, doc -> property)
- Updated existing tests confirm no regressions in comment/trivia preservation