### PR TITLE
Report diagnostic for duplicate aspect types instead of ArgumentException (#614)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TemplateClassFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TemplateClassFactory.cs
@@ -99,9 +99,23 @@ internal abstract class TemplateClassFactory<T>
 
         foreach ( var aspectType in aspectTypeData )
         {
-            // IMPORTANT: At design time, when a project is being renamed, we can get duplicate aspect types while project dependency tree is being updated.
-            //            Two dependency projects referencing the same assembly may not be synchronized, causing two CompileTimeProjects to exist
-            //            for one assembly (same aspects, two different assembly names).
+            if ( aspectTypeDataDictionary.TryGetValue( aspectType.TypeName, out var existingEntry ) )
+            {
+                // At design time, when a project is being renamed, we can get duplicate aspect types while project dependency tree is being updated.
+                // Two dependency projects referencing the same assembly may not be synchronized, causing two CompileTimeProjects to exist
+                // for one assembly (same aspects, two different assembly names). In this case, we silently overwrite with the latest entry.
+                // However, if two versions of the same assembly provide the same type, report a diagnostic.
+                if ( existingEntry.Project != null && aspectType.Project != null
+                     && existingEntry.Project.RunTimeIdentity.Name == aspectType.Project.RunTimeIdentity.Name
+                     && existingEntry.Project.RunTimeIdentity.Version != aspectType.Project.RunTimeIdentity.Version )
+                {
+                    diagnosticAdder.Report(
+                        TemplatingDiagnosticDescriptors.DuplicateAspectTypeInCompilation.CreateRoslynDiagnostic(
+                            Location.None,
+                            aspectType.TypeName ) );
+                }
+            }
+
             aspectTypeDataDictionary[aspectType.TypeName] = aspectType;
         }
 
@@ -122,18 +136,27 @@ internal abstract class TemplateClassFactory<T>
         CompileTimeProject compileTimeProject,
         IDiagnosticAdder diagnosticAdder )
     {
-        var aspectTypesDiagnostics = types
-            .SelectAsImmutableArray( t => (Symbol: t, ReflectionName: t.GetReflectionFullName().AssertNotNull()) )
-            .ToDictionary(
-                t => t.ReflectionName,
-                t => new TemplateClassData(
-                    compileTimeProject,
-                    t.ReflectionName,
-                    t.Symbol,
-                    compileTimeProject.GetType( t.ReflectionName ),
-                    templateReflectionContext ) );
+        var aspectTypesDictionary = new Dictionary<string, TemplateClassData>();
 
-        return this.GetClasses( aspectTypesDiagnostics, diagnosticAdder, serviceProvider );
+        foreach ( var t in types.SelectAsImmutableArray( t => (Symbol: t, ReflectionName: t.GetReflectionFullName().AssertNotNull()) ) )
+        {
+            if ( !aspectTypesDictionary.TryAdd(
+                    t.ReflectionName,
+                    new TemplateClassData(
+                        compileTimeProject,
+                        t.ReflectionName,
+                        t.Symbol,
+                        compileTimeProject.GetType( t.ReflectionName ),
+                        templateReflectionContext ) ) )
+            {
+                diagnosticAdder.Report(
+                    TemplatingDiagnosticDescriptors.DuplicateAspectTypeInCompilation.CreateRoslynDiagnostic(
+                        Location.None,
+                        t.ReflectionName ) );
+            }
+        }
+
+        return this.GetClasses( aspectTypesDictionary, diagnosticAdder, serviceProvider );
     }
 
     private IReadOnlyList<T> GetClasses(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
@@ -675,5 +675,15 @@ namespace Metalama.Framework.Engine.Templating
                     + "run-time code cannot be generated. Use a compile-time null check (e.g. an 'if' statement) instead of the '?.' operator.",
                     _category,
                     Error );
+
+        internal static readonly DiagnosticDefinition<string> DuplicateAspectTypeInCompilation
+            = new(
+                "LAMA0290",
+                "Multiple aspect types with the same name were found in the compilation.",
+                "The aspect type '{0}' was found in multiple referenced assemblies. "
+                + "This typically happens when two versions of the same assembly are loaded. "
+                + "Remove one of the conflicting assembly references.",
+                _category,
+                Error );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/DuplicateAspectTypeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/DuplicateAspectTypeTests.cs
@@ -28,15 +28,14 @@ public sealed class DuplicateAspectTypeTests : UnitTestClass
     }
 
     /// <summary>
-    /// Tests that when two versions of the same assembly provide the same aspect type name,
-    /// TemplateClassFactory reports a diagnostic error instead of throwing an ArgumentException.
-    /// This is the scenario from issue #614.
+    /// Tests that when duplicate aspect type entries are passed to the test-only <c>GetClasses</c>
+    /// overload, it reports LAMA0290 instead of throwing <see cref="System.ArgumentException"/>.
+    /// This covers the scenario from issue #614, where two versions of the same assembly are loaded
+    /// and both provide the same aspect type name.
     /// </summary>
     [Fact]
     public void DuplicateAspectTypeFromDifferentAssemblies_ReportsDiagnostic()
     {
-        // Create two assemblies with the same type name but different assembly names.
-        // This simulates the scenario where two versions of the same library are loaded.
         const string aspectCode = @"
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
@@ -48,7 +47,6 @@ namespace TestNamespace
 
         using var testContext = this.CreateTestContext();
 
-        // Create the main compilation that contains the aspect type.
         var compilation = testContext.CreateCompilationModel( aspectCode );
 
         var serviceProvider = testContext.ServiceProvider;
@@ -68,23 +66,19 @@ namespace TestNamespace
             new AspectDriverFactory( compilation, ImmutableArray<object>.Empty, serviceProvider ),
             compilation.CompilationContext );
 
-        // Get the aspect type symbol.
         var aspectTypeSymbol = compilation.Types.OfName( "MyAspect" ).Single().GetSymbol();
 
-        // Pass the same type symbol twice to simulate duplicate entries from different assemblies.
-        // This triggers the duplicate key scenario in the ToDictionary call.
+        // Pass the same type symbol twice to simulate duplicate entries (same reflection name from different assemblies).
         var diagnostics = new DiagnosticBag();
 
-        // After the fix, this should report a diagnostic instead of throwing.
-        var aspectTypes = aspectTypeFactory.GetClasses(
+        // Before the fix, this would throw ArgumentException from ToDictionary.
+        // After the fix, it should report a diagnostic and continue.
+        _ = aspectTypeFactory.GetClasses(
             serviceProvider,
             compilation.CompilationContext,
             ImmutableArray.Create( aspectTypeSymbol, aspectTypeSymbol ),
             compileTimeProject,
             diagnostics );
-
-        // Verify we get a diagnostic error about duplicate aspect types instead of an exception.
-        Assert.NotEmpty( diagnostics );
 
         Assert.Contains(
             diagnostics,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/DuplicateAspectTypeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/DuplicateAspectTypeTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Extensibility;
+using Metalama.Framework.Engine.Services;
+using Metalama.Testing.UnitTesting;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.Aspects;
+
+public sealed class DuplicateAspectTypeTests : UnitTestClass
+{
+    public DuplicateAspectTypeTests( ITestOutputHelper logger ) : base( logger, false ) { }
+
+    protected override void ConfigureServices( IAdditionalServiceCollection services )
+    {
+        base.ConfigureServices( services );
+        services.AddProjectService( new PipelineExtensionProvider( ImmutableArray<PipelineExtension>.Empty ) );
+    }
+
+    /// <summary>
+    /// Tests that when two versions of the same assembly provide the same aspect type name,
+    /// TemplateClassFactory reports a diagnostic error instead of throwing an ArgumentException.
+    /// This is the scenario from issue #614.
+    /// </summary>
+    [Fact]
+    public void DuplicateAspectTypeFromDifferentAssemblies_ReportsDiagnostic()
+    {
+        // Create two assemblies with the same type name but different assembly names.
+        // This simulates the scenario where two versions of the same library are loaded.
+        const string aspectCode = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+namespace TestNamespace
+{
+    public class MyAspect : TypeAspect { }
+}
+";
+
+        using var testContext = this.CreateTestContext();
+
+        // Create the main compilation that contains the aspect type.
+        var compilation = testContext.CreateCompilationModel( aspectCode );
+
+        var serviceProvider = testContext.ServiceProvider;
+        var compileTimeDomain = testContext.Domain;
+
+        var compileTimeProjectRepository = CompileTimeProjectRepository.Create(
+                compileTimeDomain,
+                serviceProvider,
+                compilation.RoslynCompilation,
+                NullDiagnosticAdder.Instance )
+            .AssertNotNull();
+
+        var compileTimeProject = compileTimeProjectRepository.RootProject;
+        serviceProvider = serviceProvider.WithCompileTimeProjectServices( compileTimeProjectRepository );
+
+        var aspectTypeFactory = new AspectClassFactory(
+            new AspectDriverFactory( compilation, ImmutableArray<object>.Empty, serviceProvider ),
+            compilation.CompilationContext );
+
+        // Get the aspect type symbol.
+        var aspectTypeSymbol = compilation.Types.OfName( "MyAspect" ).Single().GetSymbol();
+
+        // Pass the same type symbol twice to simulate duplicate entries from different assemblies.
+        // This triggers the duplicate key scenario in the ToDictionary call.
+        var diagnostics = new DiagnosticBag();
+
+        // After the fix, this should report a diagnostic instead of throwing.
+        var aspectTypes = aspectTypeFactory.GetClasses(
+            serviceProvider,
+            compilation.CompilationContext,
+            ImmutableArray.Create( aspectTypeSymbol, aspectTypeSymbol ),
+            compileTimeProject,
+            diagnostics );
+
+        // Verify we get a diagnostic error about duplicate aspect types instead of an exception.
+        Assert.NotEmpty( diagnostics );
+
+        Assert.Contains(
+            diagnostics,
+            d => d.Id == "LAMA0290" );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #614 - When two versions of the same assembly are loaded in the pipeline, `TemplateClassFactory.GetClasses()` throws an `ArgumentException: An item with the same key has already been added` instead of reporting a proper diagnostic.

## Changes

- [x] Add regression test that reproduces the `ArgumentException` in `TemplateClassFactory.GetClasses()`
- [x] Add new diagnostic `LAMA0290` for duplicate aspect type names in the compilation
- [x] Fix `TemplateClassFactory.GetClasses()` test-only overload to handle duplicates gracefully
- [x] Fix main `GetClasses()` to report diagnostic when duplicate type names come from different assemblies
- [x] Build and test
- [x] Address review feedback
- [x] Finalize

## Test plan

- [x] New unit test `DuplicateAspectTypeFromDifferentAssemblies_ReportsDiagnostic` verifies that a diagnostic is reported instead of an exception
- [x] All existing tests pass (`Build.ps1 build` + `Build.ps1 test` both pass with zero warnings)

-- Claude for @PostSharpAgent