### PR TITLE
Fix empty namespace name in WithNamespace (#617)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
@@ -1898,6 +1898,12 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
             throw new InvalidOperationException();
         }
 
+        // An empty name resolves to the target namespace itself.
+        if ( string.IsNullOrEmpty( name ) )
+        {
+            return this.WithDeclaration( targetNamespace );
+        }
+
         using ( this.WithNonUserCode() )
         {
             return

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
@@ -292,13 +292,16 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
     {
         // We don't validate that the target is "under" the current declaration because some advice type, e.g. annotations, are valid on any target.
 
-        return new AdviceFactory<TNewTarget>(
-            target,
-            this._state,
-            this._templateClassInstance,
-            this._layerName,
-            this._explicitlyImplementedInterfaceType,
-            this._diagnostics );
+        using ( this.WithNonUserCode() )
+        {
+            return new AdviceFactory<TNewTarget>(
+                target,
+                this._state,
+                this._templateClassInstance,
+                this._layerName,
+                this._explicitlyImplementedInterfaceType,
+                this._diagnostics );
+        }
     }
 
     public ICompilation MutableCompilation => this._state.MutableCompilation;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.Foo.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.Foo.i.cs
@@ -1,0 +1,3 @@
+class Foo
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+#pragma warning disable CS8618
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.EmptyNameWithNamespace;
+
+public class IntroductionAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // WithNamespace with an empty string should resolve to the parent namespace (global namespace in this case).
+        var ns = builder.With( builder.Target.Compilation.GlobalNamespace ).WithChildNamespace( "" );
+        var @class = ns.IntroduceClass( "Foo" );
+
+        builder.IntroduceField( "Field", @class.Declaration );
+    }
+}
+
+// <target>
+[IntroductionAttribute]
+public class TargetType { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespace.t.cs
@@ -1,0 +1,5 @@
+[IntroductionAttribute]
+public class TargetType
+{
+  private global::Foo Field;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.Foo.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.Foo.i.cs
@@ -1,0 +1,3 @@
+class Foo
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.EmptyNameWithNamespaceOnCompilation;
+
+// WithNamespace on IAdviser<ICompilation> with an empty string should introduce into the global namespace.
+[assembly: IntroduceTypeAspect]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.EmptyNameWithNamespaceOnCompilation
+{
+    public class IntroduceTypeAspectAttribute : CompilationAspect
+    {
+        public override void BuildAspect( IAspectBuilder<ICompilation> builder )
+        {
+            builder.WithNamespace( "" ).IntroduceClass( "Foo" );
+        }
+    }
+
+    // <target>
+    public class TargetType { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.t.cs
@@ -1,3 +1,4 @@
+[assembly: IntroduceTypeAspect]
 public class TargetType
 {
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/EmptyNameWithNamespaceOnCompilation.t.cs
@@ -1,0 +1,3 @@
+public class TargetType
+{
+}


### PR DESCRIPTION
## Summary

Fixes #617 — `WithNamespace(globalNamespace, "")` generates invalid C# code with an empty namespace block.

When an empty string is passed as a namespace name to `WithNamespace` or `WithChildNamespace`, the generated code contained `namespace { }` (invalid syntax) and references like `global::.Foo` (invalid leading dot).

**Fix:** In `AdviceFactory.WithNamespace`, when the name is empty or null, return an adviser for the target namespace directly instead of creating a new namespace with an empty name. This makes `WithNamespace(x, "")` equivalent to `WithNamespace(x)`, as expected.

## Changes

- `Metalama.Framework.Engine/Advising/AdviceFactory.cs` — Added early return for empty name in `WithNamespace`; added `using (this.WithNonUserCode())` to `WithDeclaration` per review feedback
- Two new regression tests in `Tests/Aspects/Introductions/Namespaces/`:
  - `EmptyNameWithNamespace` — `WithChildNamespace("")` on the global namespace
  - `EmptyNameWithNamespaceOnCompilation` — `builder.WithNamespace("")` on `CompilationAspect`

## Progress

- [x] Reproduce bug with regression tests
- [x] Implement fix
- [x] Run all tests in the solution (2044 AspectTests pass)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Run `Build.ps1 test` (all tests pass)
- [x] Address review feedback (add `WithNonUserCode()` to `WithDeclaration`)
- [x] Finalize PR

— Claude for @gfraiteur