### PR TITLE
Add regression test for [Template] on local function (#612)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/IntroduceAttributeInIntroducedMethod.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/IntroduceAttributeInIntroducedMethod.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.LocalFunctions.IntroduceAttributeInIntroducedMethod;
+
+internal class Aspect : TypeAspect
+{
+    [Introduce]
+    public void IntroducedMethod()
+    {
+        LocalFunction();
+
+        [Introduce]
+        void LocalFunction()
+        {
+        }
+    }
+}
+
+internal class TargetCode
+{
+    // <target>
+    [Aspect]
+    private class Target
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/IntroduceAttributeInIntroducedMethod.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/IntroduceAttributeInIntroducedMethod.t.cs
@@ -1,0 +1,2 @@
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0285 on `Introduce`: `The 'IntroduceAttribute' attribute is not allowed on a local function.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/TemplateInIntroducedMethod.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/TemplateInIntroducedMethod.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.LocalFunctions.TemplateInIntroducedMethod;
+
+internal class Aspect : TypeAspect
+{
+    [Introduce]
+    public void IntroducedMethod()
+    {
+        LocalFunction();
+
+        [Template]
+        void LocalFunction()
+        {
+        }
+    }
+}
+
+internal class TargetCode
+{
+    // <target>
+    [Aspect]
+    private class Target
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/TemplateInIntroducedMethod.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/LocalFunctions/TemplateInIntroducedMethod.t.cs
@@ -1,0 +1,2 @@
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0285 on `Template`: `The 'TemplateAttribute' attribute is not allowed on a local function.`


### PR DESCRIPTION
## Summary
- Adds regression tests for issue #612: applying `[Template]` or `[Introduce]` on a local function inside an `[Introduce]`d method in a `TypeAspect`
- The bug (ArgumentNullException) has already been fixed in develop/2026.1 - the tests verify the correct `LAMA0285` diagnostic is emitted
- The existing `Template.cs` test only covered `OverrideMethodAspect`; these new tests cover the `TypeAspect` + `[Introduce]` code path from the original report

## Test cases added
1. `TemplateInIntroducedMethod` — `[Template]` on local function in introduced method
2. `IntroduceAttributeInIntroducedMethod` — `[Introduce]` on local function in introduced method

## Checklist
- [x] Understand the issue
- [x] Write regression tests
- [x] Verify tests pass (bug already fixed, LAMA0285 emitted correctly)
- [x] Run full test suite (22 suites, 0 failures)
- [x] Build.ps1 build (0 warnings)
- [x] Build.ps1 test (0 test failures)
- [x] Finalize PR

Closes #612