### PR TITLE
Fix IConstructor.InitializerKind for implicit base() calls (#610)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceConstructor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceConstructor.cs
@@ -76,7 +76,9 @@ namespace Metalama.Framework.Engine.CodeModel.Source
 
         [Memo]
         public ConstructorInitializerKind InitializerKind
-            => this.GetPrimaryDeclarationSyntax()?.Kind() switch
+            => this.MethodSymbol.MethodKind == RoslynMethodKind.StaticConstructor
+                ? ConstructorInitializerKind.None
+                : this.GetPrimaryDeclarationSyntax()?.Kind() switch
             {
                 null => this.MethodSymbol.ContainingType.IsValueType ? ConstructorInitializerKind.None : ConstructorInitializerKind.Base,
                 SyntaxKind.ConstructorDeclaration when this.GetPrimaryDeclarationSyntax() is ConstructorDeclarationSyntax { Initializer: null } =>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceConstructor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Source/SourceConstructor.cs
@@ -78,9 +78,9 @@ namespace Metalama.Framework.Engine.CodeModel.Source
         public ConstructorInitializerKind InitializerKind
             => this.GetPrimaryDeclarationSyntax()?.Kind() switch
             {
-                null => ConstructorInitializerKind.None,
+                null => this.MethodSymbol.ContainingType.IsValueType ? ConstructorInitializerKind.None : ConstructorInitializerKind.Base,
                 SyntaxKind.ConstructorDeclaration when this.GetPrimaryDeclarationSyntax() is ConstructorDeclarationSyntax { Initializer: null } =>
-                    ConstructorInitializerKind.None,
+                    this.MethodSymbol.ContainingType.IsValueType ? ConstructorInitializerKind.None : ConstructorInitializerKind.Base,
                 SyntaxKind.ConstructorDeclaration when this.GetPrimaryDeclarationSyntax() is ConstructorDeclarationSyntax { Initializer: { } initializer }
                                                        && initializer.IsKind( SyntaxKind.ThisConstructorInitializer ) =>
                     ConstructorInitializerKind.This,
@@ -88,11 +88,11 @@ namespace Metalama.Framework.Engine.CodeModel.Source
                                                        && initializer.IsKind( SyntaxKind.BaseConstructorInitializer ) =>
                     ConstructorInitializerKind.Base,
                 { IsTypeDeclaration: true } when this.GetPrimaryDeclarationSyntax() is TypeDeclarationSyntax { BaseList: null } =>
-                    ConstructorInitializerKind.None,
+                    this.MethodSymbol.ContainingType.IsValueType ? ConstructorInitializerKind.None : ConstructorInitializerKind.Base,
                 { IsTypeDeclaration: true } when this.GetPrimaryDeclarationSyntax() is TypeDeclarationSyntax { BaseList: { } baseList } =>
                     baseList.Types.Any( bt => bt.IsKind( SyntaxKind.PrimaryConstructorBaseType ) )
                         ? ConstructorInitializerKind.Base
-                        : ConstructorInitializerKind.None,
+                        : this.MethodSymbol.ContainingType.IsValueType ? ConstructorInitializerKind.None : ConstructorInitializerKind.Base,
                 _ => throw new AssertionFailedException( $"Unexpected initializer for '{this}'." )
             };
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/ConstructorInitializerKind.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/ConstructorInitializerKind.cs
@@ -24,13 +24,14 @@ namespace Metalama.Framework.Code
     public enum ConstructorInitializerKind
     {
         /// <summary>
-        /// The constructor has no explicit initializer (no <c>: base(...)</c> or <c>: this(...)</c> clause).
-        /// The C# compiler implicitly calls the parameterless base class constructor.
+        /// The constructor has no initializer calling a base or sibling constructor. This only applies to value types (structs).
+        /// For reference types (classes), the C# compiler always implicitly calls a base constructor, so <see cref="Base"/> is returned instead.
         /// </summary>
         None,
 
         /// <summary>
-        /// The constructor has a <c>: base(...)</c> initializer that invokes a constructor of the base class.
+        /// The constructor invokes a constructor of the base class, either explicitly via a <c>: base(...)</c> initializer
+        /// or implicitly when the constructor has no explicit initializer and the declaring type is a reference type.
         /// </summary>
         Base,
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/ConstructorInitializerKind.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/ConstructorInitializerKind.cs
@@ -24,14 +24,15 @@ namespace Metalama.Framework.Code
     public enum ConstructorInitializerKind
     {
         /// <summary>
-        /// The constructor has no initializer calling a base or sibling constructor. This only applies to value types (structs).
-        /// For reference types (classes), the C# compiler always implicitly calls a base constructor, so <see cref="Base"/> is returned instead.
+        /// The constructor has no initializer calling a base or sibling constructor. This applies to value types (structs)
+        /// and static constructors, which never have a <c>base</c> or <c>this</c> initializer. For instance constructors of reference types (classes),
+        /// the C# compiler always implicitly calls a base constructor, so <see cref="Base"/> is returned instead.
         /// </summary>
         None,
 
         /// <summary>
         /// The constructor invokes a constructor of the base class, either explicitly via a <c>: base(...)</c> initializer
-        /// or implicitly when the constructor has no explicit initializer and the declaring type is a reference type.
+        /// or implicitly when the instance constructor has no explicit initializer and the declaring type is a reference type.
         /// </summary>
         Base,
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/ConstructorInitializerKindTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/ConstructorInitializerKindTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Code;
+using Metalama.Testing.UnitTesting;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CodeModel;
+
+public sealed class ConstructorInitializerKindTests : UnitTestClass
+{
+    [Fact]
+    public void Class_NoExplicitInitializer_ReturnsBase()
+    {
+        // A class constructor with no explicit initializer implicitly calls base().
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            class SomeClass
+            {
+                public SomeClass() { }
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "SomeClass" ).Single();
+        var constructor = type.Constructors.Single();
+
+        Assert.Equal( ConstructorInitializerKind.Base, constructor.InitializerKind );
+    }
+
+    [Fact]
+    public void Class_ExplicitThis_ReturnsThis()
+    {
+        // A class constructor with explicit : this() should return This.
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            class SomeClass
+            {
+                private readonly string _name;
+
+                public SomeClass() : this( "" ) { }
+
+                public SomeClass( string name )
+                {
+                    this._name = name;
+                }
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "SomeClass" ).Single();
+        var ctorNoParam = type.Constructors.Single( c => c.Parameters.Count == 0 );
+        var ctorWithParam = type.Constructors.Single( c => c.Parameters.Count == 1 );
+
+        Assert.Equal( ConstructorInitializerKind.This, ctorNoParam.InitializerKind );
+        Assert.Equal( ConstructorInitializerKind.Base, ctorWithParam.InitializerKind );
+    }
+
+    [Fact]
+    public void Class_ExplicitBase_ReturnsBase()
+    {
+        // A class constructor with explicit : base() should return Base.
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            class BaseClass
+            {
+                public BaseClass( int x ) { }
+            }
+
+            class DerivedClass : BaseClass
+            {
+                public DerivedClass() : base( 42 ) { }
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "DerivedClass" ).Single();
+        var constructor = type.Constructors.Single();
+
+        Assert.Equal( ConstructorInitializerKind.Base, constructor.InitializerKind );
+    }
+
+    [Fact]
+    public void Struct_NoExplicitInitializer_ReturnsNone()
+    {
+        // A struct constructor with no explicit initializer truly has no base call.
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            struct SomeStruct
+            {
+                public int Value;
+                public SomeStruct( int value )
+                {
+                    this.Value = value;
+                }
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "SomeStruct" ).Single();
+        var constructor = type.Constructors.Single( c => c.Parameters.Count == 1 );
+
+        Assert.Equal( ConstructorInitializerKind.None, constructor.InitializerKind );
+    }
+
+    [Fact]
+    public void Class_ImplicitConstructor_ReturnsBase()
+    {
+        // The compiler-generated implicit constructor of a class calls base().
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            class SomeClass
+            {
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "SomeClass" ).Single();
+        var constructor = type.Constructors.Single();
+
+        Assert.Equal( ConstructorInitializerKind.Base, constructor.InitializerKind );
+    }
+
+    [Fact]
+    public void Class_DerivedNoExplicitInitializer_ReturnsBase()
+    {
+        // A derived class constructor without explicit initializer implicitly calls base().
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            class BaseClass { }
+
+            class DerivedClass : BaseClass
+            {
+                public DerivedClass() { }
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "DerivedClass" ).Single();
+        var constructor = type.Constructors.Single();
+
+        Assert.Equal( ConstructorInitializerKind.Base, constructor.InitializerKind );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/ConstructorInitializerKindTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/ConstructorInitializerKindTests.cs
@@ -149,4 +149,25 @@ public sealed class ConstructorInitializerKindTests : UnitTestClass
 
         Assert.Equal( ConstructorInitializerKind.Base, constructor.InitializerKind );
     }
+
+    [Fact]
+    public void Class_StaticConstructor_ReturnsNone()
+    {
+        // A static constructor never calls base() or this().
+        using var testContext = this.CreateTestContext();
+
+        const string code = """
+            class SomeClass
+            {
+                static SomeClass() { }
+            }
+            """;
+
+        var compilation = testContext.CreateCompilationModel( code );
+        var type = compilation.Types.OfName( "SomeClass" ).Single();
+        var staticCtor = type.StaticConstructor;
+
+        Assert.NotNull( staticCtor );
+        Assert.Equal( ConstructorInitializerKind.None, staticCtor!.InitializerKind );
+    }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/PrimaryConstructorTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/PrimaryConstructorTests.cs
@@ -385,16 +385,20 @@ record struct D(int x) {}
 
             var compilation = testContext.CreateCompilationModel( code );
 
+            var expectedKindForNoExplicitInitializer = kind.ContainsOrdinal( "struct" )
+                ? ConstructorInitializerKind.None
+                : ConstructorInitializerKind.Base;
+
             var noInitializer = compilation.Types.OfName( "NoInitializer" ).Single();
-            Assert.Equal( ConstructorInitializerKind.None, noInitializer.PrimaryConstructor.AssertNotNull().InitializerKind );
+            Assert.Equal( expectedKindForNoExplicitInitializer, noInitializer.PrimaryConstructor.AssertNotNull().InitializerKind );
 
             var @interface = compilation.Types.OfName( "Interface" ).Single();
-            Assert.Equal( ConstructorInitializerKind.None, @interface.PrimaryConstructor.AssertNotNull().InitializerKind );
+            Assert.Equal( expectedKindForNoExplicitInitializer, @interface.PrimaryConstructor.AssertNotNull().InitializerKind );
 
             if ( !kind.ContainsOrdinal( "struct" ) )
             {
                 var derivedSimple = compilation.Types.OfName( "DerivedSimple" ).Single();
-                Assert.Equal( ConstructorInitializerKind.None, derivedSimple.PrimaryConstructor.AssertNotNull().InitializerKind );
+                Assert.Equal( ConstructorInitializerKind.Base, derivedSimple.PrimaryConstructor.AssertNotNull().InitializerKind );
 
                 var derivedInitializer = compilation.Types.OfName( "DerivedInitializer" ).Single();
                 Assert.Equal( ConstructorInitializerKind.Base, derivedInitializer.PrimaryConstructor.AssertNotNull().InitializerKind );


### PR DESCRIPTION
## Summary

Fixes #610 — `IConstructor.InitializerKind` returns `None` when `base()` is implicitly called by the C# compiler for reference type constructors.

**Problem**: For reference type (class) constructors that don't have an explicit `: base()` or `: this()` clause, `InitializerKind` returns `None`. However, the C# compiler implicitly inserts a `base()` call for all class constructors. Only value types (structs) and static constructors should return `None`.

**Fix**: Updated `SourceConstructor.InitializerKind` to:
1. Short-circuit to `None` for static constructors (which never chain to `base()`/`this()`).
2. Check `ContainingType.IsValueType` for instance constructors — returns `Base` for reference types and `None` only for value types when there is no explicit initializer.

Also updated the `ConstructorInitializerKind` enum XML documentation to clarify the semantics for static constructors.

**Breaking change**: Code that relied on `InitializerKind == ConstructorInitializerKind.None` for class constructors without an explicit initializer will now see `ConstructorInitializerKind.Base` instead.

## Changes

- `SourceConstructor.cs`: Added static constructor guard; returns `Base` for reference types without explicit initializer
- `ConstructorInitializerKind.cs`: Updated XML documentation to clarify that `None` applies to value types and static constructors
- `ConstructorInitializerKindTests.cs`: 7 regression tests covering classes, structs, implicit constructors, derived classes, and static constructors
- `PrimaryConstructorTests.cs`: Updated `InitializerKind()` test to expect `Base` for non-struct primary constructors

## Test plan

- [x] New unit tests for `ConstructorInitializerKind` covering all scenarios (7 tests)
- [x] Updated existing `PrimaryConstructorTests.InitializerKind` test
- [x] All unit tests pass (net8.0 + net48)
- [x] All aspect tests pass (net8.0 + net48)
- [x] All linker and template tests pass
- [x] Full `Build.ps1 build` succeeds with zero warnings
- [x] Full `Build.ps1 test` succeeds with zero failures

## Progress checklist

- [x] Reproduce bug with failing regression tests
- [x] Implement fix
- [x] Address review feedback (static constructor handling)
- [x] Build and test
- [x] Finalize

— Claude for @PostSharpAgent