### PR TITLE
Add regression test for recursive pattern in template (#620)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug620.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug620.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug620;
+
+public class TheAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        // Test compile-time recursive pattern (property pattern) in is expression.
+        var method = meta.Target.Method;
+
+        // Simple property pattern
+        var isSpecial = method is IMethod { Name: "M1" };
+
+        // Nested property pattern (the exact pattern from the issue)
+        var hasTargetDeclaringType = method is IMethod { DeclaringType: INamedType { Name: "Target" } };
+
+        // Property pattern with type check
+        var p = meta.Target.Parameters[0];
+        var isIntParam = p is IParameter { Type: INamedType { SpecialType: SpecialType.Int32 } };
+
+        Console.WriteLine( isSpecial );
+        Console.WriteLine( hasTargetDeclaringType );
+        Console.WriteLine( isIntParam );
+
+        return meta.Proceed();
+    }
+}
+
+// <target>
+internal class Target
+{
+    [TheAspect]
+    internal void M1( int x ) => throw new NotImplementedException();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug620.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug620.t.cs
@@ -1,0 +1,12 @@
+internal class Target
+{
+  [TheAspect]
+  internal void M1(int x)
+  {
+    global::System.Console.WriteLine(true);
+    global::System.Console.WriteLine(true);
+    global::System.Console.WriteLine(true);
+    throw new NotImplementedException();
+    return;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds regression test for issue #620 (exception in template compiler for compile-time recursive pattern in template)
- The bug was already fixed on `develop/2026.1` (likely as a consequence of the fix for #989 or subsequent template compiler improvements)
- The test verifies that compile-time property patterns (recursive patterns) work correctly in templates, including:
  - Simple property pattern: `method is IMethod { Name: "M1" }`
  - Nested property pattern: `method is IMethod { DeclaringType: INamedType { Name: "Target" } }`
  - Property pattern with enum: `p is IParameter { Type: INamedType { SpecialType: SpecialType.Int32 } }`

Closes #620

## Checklist
- [x] Understand the issue
- [x] Create regression test
- [x] Verify test passes (bug already fixed)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Run `Build.ps1 test` (all tests pass, 0 failures)
- [x] Finalize PR