### PR TITLE
Fix enum nested in RunTimeOrCompileTime type (#627)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/SymbolClassifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/SymbolClassifier.cs
@@ -741,6 +741,16 @@ internal sealed class SymbolClassifier : ISymbolClassifier
                                 {
                                     return (TemplatingScope.CompileTimeOnly, TemplatingRule.Other);
                                 }
+                                else if ( declaringTypeScope?.Scope is TemplatingScope.RunTimeOrCompileTime
+                                         or TemplatingScope.ForcedRunTimeOrCompileTime )
+                                {
+                                    // Initialize combinedScope to the declaring type's scope so that
+                                    // CombineBaseTypeScope correctly ignores run-time-only interfaces
+                                    // (e.g. ISpanParsable<T> on enums in .NET 8+) while still allowing
+                                    // compile-time base types (e.g. TypeFabric) to take precedence.
+                                    // Don't return early — base type analysis must still run.
+                                    combinedScope = declaringTypeScope.Value.Scope;
+                                }
                                 else
                                 {
                                     // Run-time type can contain fabrics.
@@ -751,12 +761,17 @@ internal sealed class SymbolClassifier : ISymbolClassifier
                             else
                             {
                                 combinedScope = GetAssemblyScope( symbol.ContainingAssembly )?.Scope;
+
+                                // We don't look at the rest if the scope is known from the assembly.
+                                if ( combinedScope != null )
+                                {
+                                    return (combinedScope.Value, TemplatingRule.Other);
+                                }
                             }
                         }
-
-                        // We don't look at the rest if the scope is known at this point.
-                        if ( combinedScope != null )
+                        else
                         {
+                            // We don't look at the rest if the scope is known from attributes.
                             return (combinedScope.Value, TemplatingRule.Other);
                         }
 
@@ -781,16 +796,6 @@ internal sealed class SymbolClassifier : ISymbolClassifier
 
                         if ( combinedScope != null )
                         {
-                            // If the combined scope from base types/interfaces is RunTimeOnly but the declaring type
-                            // is RunTimeOrCompileTime, the declaring type's scope should take precedence. This prevents
-                            // nested types from being classified as RunTimeOnly solely because they inherit run-time-only
-                            // interfaces (e.g., ISpanParsable<T> on enums in newer .NET versions).
-                            if ( combinedScope == TemplatingScope.RunTimeOnly
-                                 && declaringTypeScope?.Scope is TemplatingScope.RunTimeOrCompileTime or TemplatingScope.ForcedRunTimeOrCompileTime )
-                            {
-                                combinedScope = declaringTypeScope.Value.Scope;
-                            }
-
                             return (combinedScope.Value, TemplatingRule.Other);
                         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/SymbolClassifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/SymbolClassifier.cs
@@ -781,6 +781,16 @@ internal sealed class SymbolClassifier : ISymbolClassifier
 
                         if ( combinedScope != null )
                         {
+                            // If the combined scope from base types/interfaces is RunTimeOnly but the declaring type
+                            // is RunTimeOrCompileTime, the declaring type's scope should take precedence. This prevents
+                            // nested types from being classified as RunTimeOnly solely because they inherit run-time-only
+                            // interfaces (e.g., ISpanParsable<T> on enums in newer .NET versions).
+                            if ( combinedScope == TemplatingScope.RunTimeOnly
+                                 && declaringTypeScope?.Scope is TemplatingScope.RunTimeOrCompileTime or TemplatingScope.ForcedRunTimeOrCompileTime )
+                            {
+                                combinedScope = declaringTypeScope.Value.Scope;
+                            }
+
                             return (combinedScope.Value, TemplatingRule.Other);
                         }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.TemplatingCodeValidation.EnumNestedInRunTimeOrCompileTimeType;
+
+/*
+ * An enum nested inside a [RunTimeOrCompileTime] type should be usable by members of that type. (#627)
+ */
+
+// <target>
+[RunTimeOrCompileTime]
+class C
+{
+    enum E
+    {
+        A
+    }
+
+    void M( E e ) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.cs
@@ -12,12 +12,12 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.TemplatingCodeValid
 
 // <target>
 [RunTimeOrCompileTime]
-class C
+internal class C
 {
-    enum E
+    private enum E
     {
         A
     }
 
-    void M( E e ) { }
+    private void M( E e ) { }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.t.cs
@@ -1,9 +1,11 @@
 [RunTimeOrCompileTime]
-internal class C
+class C
 {
-  internal enum E
+  enum E
   {
     A
   }
-  internal void M(E e) { }
+  void M(E e)
+  {
+  }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.t.cs
@@ -1,0 +1,9 @@
+[RunTimeOrCompileTime]
+internal class C
+{
+  internal enum E
+  {
+    A
+  }
+  internal void M(E e) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplatingCodeValidation/EnumNestedInRunTimeOrCompileTimeType.t.cs
@@ -1,11 +1,11 @@
 [RunTimeOrCompileTime]
-class C
+internal class C
 {
-  enum E
+  private enum E
   {
     A
   }
-  void M(E e)
+  private void M(E e)
   {
   }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SymbolClassifierTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SymbolClassifierTests.cs
@@ -659,5 +659,36 @@ internal class C : TypeAspect
             this.AssertScope( compilation.RoslynCompilation, invokedMethod, TemplatingScope.RunTimeOnly );
         }
 #endif
+
+        [Fact]
+        public void EnumNestedInRunTimeOrCompileTimeType()
+        {
+            // Reproduces #627: A nested enum inside a [RunTimeOrCompileTime] type should be usable by members of that type.
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using Metalama.Framework.Aspects;
+
+[RunTimeOrCompileTime]
+class C
+{
+    enum E
+    {
+        A
+    }
+
+    void M( E e ) { }
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.OfName( "C" ).Single();
+
+            // The nested enum should NOT be run-time-only — it should inherit RunTimeOrCompileTime from the parent.
+            this.AssertScope( type.NestedTypes.OfName( "E" ).Single(), TemplatingScope.RunTimeOrCompileTime );
+
+            // The method using the enum in its signature should also be RunTimeOrCompileTime.
+            this.AssertScope( type.Methods.OfName( "M" ).Single(), TemplatingScope.RunTimeOrCompileTime );
+        }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SymbolClassifierTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SymbolClassifierTests.cs
@@ -685,7 +685,7 @@ class C
             var type = compilation.Types.OfName( "C" ).Single();
 
             // The nested enum should NOT be run-time-only — it should inherit RunTimeOrCompileTime from the parent.
-            this.AssertScope( type.NestedTypes.OfName( "E" ).Single(), TemplatingScope.RunTimeOrCompileTime );
+            this.AssertScope( type.Types.OfName( "E" ).Single(), TemplatingScope.RunTimeOrCompileTime );
 
             // The method using the enum in its signature should also be RunTimeOrCompileTime.
             this.AssertScope( type.Methods.OfName( "M" ).Single(), TemplatingScope.RunTimeOrCompileTime );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SymbolClassifierTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SymbolClassifierTests.cs
@@ -690,5 +690,109 @@ class C
             // The method using the enum in its signature should also be RunTimeOrCompileTime.
             this.AssertScope( type.Methods.OfName( "M" ).Single(), TemplatingScope.RunTimeOrCompileTime );
         }
+
+        [Fact]
+        public void ExplicitCompileTimeNestedInRunTimeOrCompileTimeType()
+        {
+            // A nested type explicitly marked [CompileTime] inside a [RunTimeOrCompileTime] type
+            // should retain its explicit CompileTimeOnly scope.
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using Metalama.Framework.Aspects;
+
+[RunTimeOrCompileTime]
+class C
+{
+    [CompileTime]
+    class Nested { }
+}
+";
+
+            var compilation = testContext.CreateCSharpCompilation( code );
+            var parentType = (ITypeSymbol) compilation.GetSymbolsWithName( "C" ).Single();
+            var nestedType = parentType.GetMembers( "Nested" ).Single();
+
+            this.AssertScope( compilation, nestedType, TemplatingScope.CompileTimeOnly );
+        }
+
+        [Fact]
+        public void ExplicitRunTimeNestedInRunTimeOrCompileTimeType()
+        {
+            // A nested type explicitly marked [RunTime] inside a [RunTimeOrCompileTime] type
+            // should retain its explicit RunTimeOnly scope.
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using Metalama.Framework.Aspects;
+
+[RunTimeOrCompileTime]
+class C
+{
+    [RunTime]
+    class Nested { }
+}
+";
+
+            var compilation = testContext.CreateCSharpCompilation( code );
+            var parentType = (ITypeSymbol) compilation.GetSymbolsWithName( "C" ).Single();
+            var nestedType = parentType.GetMembers( "Nested" ).Single();
+
+            this.AssertScope( compilation, nestedType, TemplatingScope.RunTimeOnly );
+        }
+
+        [Fact]
+        public void ImplicitCompileTimeNestedInRunTimeOrCompileTimeType()
+        {
+            // A nested type that inherits from a compile-time base (TypeFabric) inside a [RunTimeOrCompileTime] type
+            // should be classified as CompileTimeOnly through inheritance.
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Fabrics;
+
+[RunTimeOrCompileTime]
+class C
+{
+    class Nested : TypeFabric
+    {
+        public override void AmendType( ITypeAmender amender ) { }
+    }
+}
+";
+
+            var compilation = testContext.CreateCSharpCompilation( code );
+            var parentType = (ITypeSymbol) compilation.GetSymbolsWithName( "C" ).Single();
+            var nestedType = parentType.GetMembers( "Nested" ).Single();
+
+            this.AssertScope( compilation, nestedType, TemplatingScope.CompileTimeOnly );
+        }
+
+        [Fact]
+        public void PlainClassNestedInRunTimeOrCompileTimeType()
+        {
+            // A plain nested class (no attributes, no special base type) inside a [RunTimeOrCompileTime] type
+            // should inherit RunTimeOrCompileTime from its declaring type.
+            using var testContext = this.CreateTestContext();
+
+            const string code = @"
+using Metalama.Framework.Aspects;
+
+[RunTimeOrCompileTime]
+class C
+{
+    class Nested
+    {
+        void M() { }
+    }
+}
+";
+
+            var compilation = testContext.CreateCompilationModel( code );
+            var type = compilation.Types.OfName( "C" ).Single();
+
+            this.AssertScope( type.Types.OfName( "Nested" ).Single(), TemplatingScope.RunTimeOrCompileTime );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #627. An enum nested inside a `[RunTimeOrCompileTime]` type is incorrectly classified as run-time-only, causing LAMA0236 errors when other members of the same type reference the enum. At design-time, this results in a `NullReferenceException` in `TransformCompileTimeType`.

### Root cause

In `SymbolClassifier.GetTemplatingScopeCore`, after processing base types and interfaces via `CombineBaseTypeScope`, if the combined scope was set to `RunTimeOnly` (from runtime-only interfaces like `ISpanParsable<T>` on enums in .NET 8+), the method returned immediately without considering the declaring type's scope. The declaring type's `RunTimeOrCompileTime` scope should take precedence over interface-derived `RunTimeOnly` scope for nested types.

### Fix

Added a check in the `NamedType` case of `GetTemplatingScopeCore`: when `combinedScope` is `RunTimeOnly` but the declaring type is `RunTimeOrCompileTime` (or `ForcedRunTimeOrCompileTime`), the declaring type's scope takes precedence.

### Tests added

- **Aspect test**: `EnumNestedInRunTimeOrCompileTimeType` — verifies no LAMA0236 error when an enum is nested inside a `[RunTimeOrCompileTime]` class and used by other members
- **Unit test**: `SymbolClassifierTests.EnumNestedInRunTimeOrCompileTimeType` — directly verifies the scope classification of the nested enum

## Checklist
- [x] Reproduce bug with failing regression test
- [x] Implement fix
- [x] Build and verify zero warnings (Build.ps1 build succeeded)
- [x] Run all tests and verify zero failures (1563 unit tests + 2043 aspect tests on net8.0)
- [x] Finalize

— Claude for @gfraiteur