### PR TITLE
Fix ImplementInterface Ignore on introduced type when base implements interface

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/IntroducedRef.Strategy.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/IntroducedRef.Strategy.cs
@@ -34,13 +34,17 @@ internal sealed partial class IntroducedRef<T>
         {
             add( i );
         }
+
+        // Also include all interfaces from the base type.
+        if ( resolvedNameType.BaseType is { } baseType )
+        {
+            baseType.EnumerateAllImplementedInterfaces( add );
+        }
     }
 
     public override void EnumerateImplementedInterfaces( Action<IFullRef<INamedType>> add )
     {
         Invariant.Assert( this is IRef<INamedType> );
-
-        // BUG: EnumerateAllImplementedInterfaces and EnumerateImplementedInterfaces should not have the same implementation.
 
         var resolvedNameType = (NamedTypeBuilderData) this.BuilderData;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedType_Ignore_BaseImplements.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedType_Ignore_BaseImplements.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.IntroducedType_Ignore_BaseImplements;
+
+/*
+ * Tests that ImplementInterface with OverrideStrategy.Ignore on an introduced type does NOT add the interface
+ * when the base type of the introduced type already implements that interface (issue #625).
+ */
+
+public interface ITestInterface
+{
+    void TestMethod();
+}
+
+public class BaseType : ITestInterface
+{
+    public void TestMethod()
+    {
+        Console.WriteLine( "Base implementation" );
+    }
+}
+
+public class IntroductionAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var type = builder.IntroduceClass(
+            "TestType",
+            buildType: t => { t.BaseType = (INamedType) TypeFactory.GetType( typeof(BaseType) ); } );
+
+        type.ImplementInterface( typeof(ITestInterface), whenExists: OverrideStrategy.Ignore );
+    }
+
+    [InterfaceMember]
+    public void TestMethod()
+    {
+        Console.WriteLine( "Introduced implementation" );
+    }
+}
+
+// <target>
+[IntroductionAttribute]
+public class TargetType { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedType_Ignore_BaseImplements.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/InterfaceImplementation/IntroducedType_Ignore_BaseImplements.t.cs
@@ -1,0 +1,7 @@
+[IntroductionAttribute]
+public class TargetType
+{
+  class TestType : global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.InterfaceImplementation.IntroducedType_Ignore_BaseImplements.BaseType
+  {
+  }
+}


### PR DESCRIPTION
Fixes #625

## Summary
- When `ImplementInterface` is called with `OverrideStrategy.Ignore` on an introduced type (via `IntroduceClass`), and the base type of the introduced type already implements the interface, the advice should be silently ignored. Instead, it was still trying to add the interface because `EnumerateAllImplementedInterfaces` in `IntroducedRef.Strategy.cs` did not include interfaces inherited from the base type.

## Root Cause
In `IntroducedRef.Strategy.cs`, `EnumerateAllImplementedInterfaces` and `EnumerateImplementedInterfaces` had identical implementations — both only returned directly implemented interfaces from `NamedTypeBuilderData.ImplementedInterfaces`. The `EnumerateAllImplementedInterfaces` method was missing recursion into the base type's interfaces. This meant that when `ImplementInterfaceAdvice` checked `AllImplementedInterfaces` to determine whether to ignore the advice, it didn't see interfaces inherited from the base type of introduced types.

## Fix
Added base type interface enumeration to `EnumerateAllImplementedInterfaces` in `IntroducedRef.Strategy.cs`, matching the behavior of `SymbolRef.Strategy.cs` which correctly uses Roslyn's `AllInterfaces` (recursive) vs `Interfaces` (direct only).

## Checklist
- [x] Reproduce bug with regression test
- [x] Implement fix
- [x] Run all tests in the solution
- [x] Build with `Build.ps1 build`
- [x] Run `Build.ps1 test` and verify zero warnings
- [x] Finalize

— Claude for @gfraiteur