### PR TITLE
Fix invalid SyntaxTreeChangeKind merge combination (#630)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/SyntaxTreeChange.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/SyntaxTreeChange.cs
@@ -148,6 +148,8 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                 (SyntaxTreeChangeKind.Removed, SyntaxTreeChangeKind.Added) when newChange.NewHash == this.OldHash => SyntaxTreeChangeKind.None,
                 (SyntaxTreeChangeKind.Removed, SyntaxTreeChangeKind.Changed) => SyntaxTreeChangeKind.Changed,
                 (SyntaxTreeChangeKind.Changed, SyntaxTreeChangeKind.Changed) => SyntaxTreeChangeKind.Changed,
+                (SyntaxTreeChangeKind.Changed, SyntaxTreeChangeKind.Added) when newChange.NewHash != this.OldHash => SyntaxTreeChangeKind.Changed,
+                (SyntaxTreeChangeKind.Changed, SyntaxTreeChangeKind.Added) when newChange.NewHash == this.OldHash => SyntaxTreeChangeKind.None,
                 _ => throw new AssertionFailedException(
                     $"Invalid SyntaxTreeChangeKind combination: ({this.SyntaxTreeChangeKind}, {newChange.SyntaxTreeChangeKind})." )
             };

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.DesignTime.Pipeline;
 using Metalama.Framework.DesignTime.Pipeline.Diff;
+using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Immutable;
 using Xunit;
@@ -18,7 +19,7 @@ public sealed class SyntaxTreeChangeMergeTests
     private static SyntaxTreeVersion CreateSyntaxTreeVersion( string code, bool hasCompileTimeCode = false, string path = "code.cs" )
     {
         var tree = CSharpSyntaxTree.ParseText( code, path: path );
-        var hash = (ulong) code.GetHashCode( System.StringComparison.Ordinal );
+        var hash = (ulong) code.GetHashCodeOrdinal();
 
         return new SyntaxTreeVersion( tree, hasCompileTimeCode, hash, ImmutableArray<Framework.DesignTime.Pipeline.Dependencies.TypeDependencyKey>.Empty );
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
@@ -15,72 +15,284 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
 /// </summary>
 public sealed class SyntaxTreeChangeMergeTests
 {
-    private static SyntaxTreeVersion CreateSyntaxTreeVersion( string code, string path = "code.cs" )
+    private static SyntaxTreeVersion CreateSyntaxTreeVersion( string code, bool hasCompileTimeCode = false, string path = "code.cs" )
     {
         var tree = CSharpSyntaxTree.ParseText( code, path: path );
         var hash = (ulong) code.GetHashCode( System.StringComparison.Ordinal );
 
-        return new SyntaxTreeVersion( tree, false, hash, ImmutableArray<Framework.DesignTime.Pipeline.Dependencies.TypeDependencyKey>.Empty );
+        return new SyntaxTreeVersion( tree, hasCompileTimeCode, hash, ImmutableArray<Framework.DesignTime.Pipeline.Dependencies.TypeDependencyKey>.Empty );
+    }
+
+    private static SyntaxTreeChange CreateChange(
+        SyntaxTreeChangeKind changeKind,
+        CompileTimeChangeKind compileTimeChangeKind,
+        in SyntaxTreeVersion oldVersion,
+        in SyntaxTreeVersion newVersion,
+        string path = "code.cs" )
+        => new( path, changeKind, compileTimeChangeKind, oldVersion, newVersion );
+
+    // --- SyntaxTreeChangeKind transition tests ---
+
+    [Fact]
+    public void Merge_Added_Then_Changed_Produces_Added()
+    {
+        var newVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var changedVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, newVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, newVersion, changedVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.Added, merged.SyntaxTreeChangeKind );
     }
 
     [Fact]
-    public void MergeChangedAndAdded()
+    public void Merge_Added_Then_Removed_Produces_None()
     {
-        // Regression test for https://github.com/metalama/Metalama/issues/630
-        // This combination can occur during merging of referenced project changes
-        // when the same file appears as Changed in the first diff and Added in the second diff.
+        var newVersion = CreateSyntaxTreeVersion( "class C { }" );
 
-        var oldVersion = CreateSyntaxTreeVersion( "class C {}", "code.cs" );
-        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", "code.cs" );
-        var newVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }", "code.cs" );
+        var first = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, newVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, newVersion, default );
 
-        var firstChange = new SyntaxTreeChange(
-            "code.cs",
-            SyntaxTreeChangeKind.Changed,
-            CompileTimeChangeKind.None,
-            oldVersion,
-            intermediateVersion );
+        var merged = first.Merge( second );
 
-        var secondChange = new SyntaxTreeChange(
-            "code.cs",
-            SyntaxTreeChangeKind.Added,
-            CompileTimeChangeKind.None,
-            default,
-            newVersion );
+        Assert.Equal( SyntaxTreeChangeKind.None, merged.SyntaxTreeChangeKind );
+    }
 
-        // This should not throw. The merged result should be Changed (file existed in original and exists in final).
-        var merged = firstChange.Merge( secondChange );
+    [Fact]
+    public void Merge_Added_Then_Added_Produces_Added()
+    {
+        var newVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var readdedVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, newVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, readdedVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.Added, merged.SyntaxTreeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_Changed_Then_Changed_Produces_Changed()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
 
         Assert.Equal( SyntaxTreeChangeKind.Changed, merged.SyntaxTreeChangeKind );
-        Assert.Equal( "code.cs", merged.FilePath );
     }
 
     [Fact]
-    public void MergeChangedAndAddedWithSameHash()
+    public void Merge_Changed_Then_Removed_Produces_Removed()
     {
-        // When the final content is the same as the original, the merge should produce None.
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var changedVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
 
-        var oldVersion = CreateSyntaxTreeVersion( "class C {}", "code.cs" );
-        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", "code.cs" );
-        var newVersion = CreateSyntaxTreeVersion( "class C {}", "code.cs" );
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, oldVersion, changedVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, changedVersion, default );
 
-        var firstChange = new SyntaxTreeChange(
-            "code.cs",
-            SyntaxTreeChangeKind.Changed,
-            CompileTimeChangeKind.None,
-            oldVersion,
-            intermediateVersion );
+        var merged = first.Merge( second );
 
-        var secondChange = new SyntaxTreeChange(
-            "code.cs",
-            SyntaxTreeChangeKind.Added,
-            CompileTimeChangeKind.None,
-            default,
-            newVersion );
+        Assert.Equal( SyntaxTreeChangeKind.Removed, merged.SyntaxTreeChangeKind );
+    }
 
-        var merged = firstChange.Merge( secondChange );
+    [Fact]
+    public void Merge_Changed_Then_Added_DifferentHash_Produces_Changed()
+    {
+        // Regression test for https://github.com/metalama/Metalama/issues/630
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var newVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }" );
 
-        // The file content went back to the original, so the net change is None.
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, newVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.Changed, merged.SyntaxTreeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_Changed_Then_Added_SameHash_Produces_None()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var revertedVersion = CreateSyntaxTreeVersion( "class C { }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, revertedVersion );
+
+        var merged = first.Merge( second );
+
         Assert.Equal( SyntaxTreeChangeKind.None, merged.SyntaxTreeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_Removed_Then_Added_DifferentHash_Produces_Changed()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var newVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, oldVersion, default );
+        var second = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, newVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.Changed, merged.SyntaxTreeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_Removed_Then_Added_SameHash_Produces_None()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var restoredVersion = CreateSyntaxTreeVersion( "class C { }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, oldVersion, default );
+        var second = CreateChange( SyntaxTreeChangeKind.Added, CompileTimeChangeKind.None, default, restoredVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.None, merged.SyntaxTreeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_Removed_Then_Changed_Produces_Changed()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var changedVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, oldVersion, default );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, default, changedVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.Changed, merged.SyntaxTreeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_Removed_Then_Removed_Produces_Removed()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, oldVersion, default );
+        var second = CreateChange( SyntaxTreeChangeKind.Removed, CompileTimeChangeKind.None, default, default );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( SyntaxTreeChangeKind.Removed, merged.SyntaxTreeChangeKind );
+    }
+
+    // --- CompileTimeChangeKind transition tests ---
+
+    [Fact]
+    public void Merge_CompileTime_None_Then_NewlyCompileTime()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }", hasCompileTimeCode: true );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NewlyCompileTime, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.NewlyCompileTime, merged.CompileTimeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_CompileTime_None_Then_NoLongerCompileTime()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NoLongerCompileTime, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.NoLongerCompileTime, merged.CompileTimeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_CompileTime_NewlyCompileTime_Then_None()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", hasCompileTimeCode: true );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }", hasCompileTimeCode: true );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NewlyCompileTime, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.None, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.NewlyCompileTime, merged.CompileTimeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_CompileTime_NewlyCompileTime_Then_NoLongerCompileTime_Produces_None()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", hasCompileTimeCode: true );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NewlyCompileTime, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NoLongerCompileTime, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.None, merged.CompileTimeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_CompileTime_NewlyCompileTime_Then_NewlyCompileTime()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", hasCompileTimeCode: true );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }", hasCompileTimeCode: true );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NewlyCompileTime, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NewlyCompileTime, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.NewlyCompileTime, merged.CompileTimeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_CompileTime_NoLongerCompileTime_Then_NewlyCompileTime_Produces_None()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }", hasCompileTimeCode: true );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }", hasCompileTimeCode: true );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NoLongerCompileTime, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NewlyCompileTime, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.None, merged.CompileTimeChangeKind );
+    }
+
+    [Fact]
+    public void Merge_CompileTime_NoLongerCompileTime_Then_NoLongerCompileTime()
+    {
+        var oldVersion = CreateSyntaxTreeVersion( "class C { }", hasCompileTimeCode: true );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }" );
+        var finalVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }" );
+
+        var first = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NoLongerCompileTime, oldVersion, intermediateVersion );
+        var second = CreateChange( SyntaxTreeChangeKind.Changed, CompileTimeChangeKind.NoLongerCompileTime, intermediateVersion, finalVersion );
+
+        var merged = first.Merge( second );
+
+        Assert.Equal( CompileTimeChangeKind.NoLongerCompileTime, merged.CompileTimeChangeKind );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.DesignTime.Pipeline.Diff;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
+
+/// <summary>
+/// Tests for <see cref="SyntaxTreeChange.Merge"/>.
+/// </summary>
+public sealed class SyntaxTreeChangeMergeTests
+{
+    private static SyntaxTreeVersion CreateSyntaxTreeVersion( string code, string path = "code.cs" )
+    {
+        var tree = CSharpSyntaxTree.ParseText( code, path: path );
+        var hash = (ulong) code.GetHashCode( System.StringComparison.Ordinal );
+
+        return new SyntaxTreeVersion( tree, false, hash, ImmutableArray<Framework.DesignTime.Pipeline.Dependencies.TypeDependencyKey>.Empty );
+    }
+
+    [Fact]
+    public void MergeChangedAndAdded()
+    {
+        // Regression test for https://github.com/metalama/Metalama/issues/630
+        // This combination can occur during merging of referenced project changes
+        // when the same file appears as Changed in the first diff and Added in the second diff.
+
+        var oldVersion = CreateSyntaxTreeVersion( "class C {}", "code.cs" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", "code.cs" );
+        var newVersion = CreateSyntaxTreeVersion( "class C { int X; int Y; }", "code.cs" );
+
+        var firstChange = new SyntaxTreeChange(
+            "code.cs",
+            SyntaxTreeChangeKind.Changed,
+            CompileTimeChangeKind.None,
+            oldVersion,
+            intermediateVersion );
+
+        var secondChange = new SyntaxTreeChange(
+            "code.cs",
+            SyntaxTreeChangeKind.Added,
+            CompileTimeChangeKind.None,
+            default,
+            newVersion );
+
+        // This should not throw. The merged result should be Changed (file existed in original and exists in final).
+        var merged = firstChange.Merge( secondChange );
+
+        Assert.Equal( SyntaxTreeChangeKind.Changed, merged.SyntaxTreeChangeKind );
+        Assert.Equal( "code.cs", merged.FilePath );
+    }
+
+    [Fact]
+    public void MergeChangedAndAddedWithSameHash()
+    {
+        // When the final content is the same as the original, the merge should produce None.
+
+        var oldVersion = CreateSyntaxTreeVersion( "class C {}", "code.cs" );
+        var intermediateVersion = CreateSyntaxTreeVersion( "class C { int X; }", "code.cs" );
+        var newVersion = CreateSyntaxTreeVersion( "class C {}", "code.cs" );
+
+        var firstChange = new SyntaxTreeChange(
+            "code.cs",
+            SyntaxTreeChangeKind.Changed,
+            CompileTimeChangeKind.None,
+            oldVersion,
+            intermediateVersion );
+
+        var secondChange = new SyntaxTreeChange(
+            "code.cs",
+            SyntaxTreeChangeKind.Added,
+            CompileTimeChangeKind.None,
+            default,
+            newVersion );
+
+        var merged = firstChange.Merge( secondChange );
+
+        // The file content went back to the original, so the net change is None.
+        Assert.Equal( SyntaxTreeChangeKind.None, merged.SyntaxTreeChangeKind );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/metalama/Metalama/issues/630

## Summary

- Adds handling for the `(Changed, Added)` combination in `SyntaxTreeChange.Merge`, which was previously throwing `AssertionFailedException`.
- Adds comprehensive regression tests covering all supported transitions in both `SyntaxTreeChangeKind` and `CompileTimeChangeKind` merge logic.

## Changes

### `SyntaxTreeChange.cs`
Added two new cases to the `Merge` switch expression:
- `(Changed, Added)` where hashes differ → `Changed` (file existed in original, now has different content)
- `(Changed, Added)` where hashes match → `None` (file reverted to original content)

This follows the same pattern as the existing `(Removed, Added)` handling.

### `SyntaxTreeChangeMergeTests.cs` (new)
Comprehensive tests for all `SyntaxTreeChange.Merge` transitions:

**SyntaxTreeChangeKind (11 tests):** Added→Changed, Added→Removed, Added→Added, Changed→Changed, Changed→Removed, Changed→Added (diff hash), Changed→Added (same hash), Removed→Added (diff hash), Removed→Added (same hash), Removed→Changed, Removed→Removed.

**CompileTimeChangeKind (7 tests):** None→NewlyCompileTime, None→NoLongerCompileTime, NewlyCompileTime→None, NewlyCompileTime→NoLongerCompileTime, NewlyCompileTime→NewlyCompileTime, NoLongerCompileTime→NewlyCompileTime, NoLongerCompileTime→NoLongerCompileTime.

## Progress

- [x] Reproduce bug with failing regression test
- [x] Implement fix in `SyntaxTreeChange.Merge`
- [x] Run all tests in the solution
- [x] Build with `Build.ps1 build` and verify zero warnings
- [x] Add comprehensive tests for all supported transitions (review feedback)
- [x] Finalize PR

## Test plan

- [x] All 18 `SyntaxTreeChangeMergeTests` pass
- [x] All existing unit tests continue to pass
- [x] `Build.ps1 build` succeeds with zero warnings