### PR TITLE
Add [AttributeUsage] to IntroduceDependencyAttribute (#646)

### DIFF
--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/IntroduceDependencyAttribute.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/IntroduceDependencyAttribute.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using System;
 using JetBrains.Annotations;
 using Metalama.Extensions.DependencyInjection.Implementation;
 using Metalama.Framework.Aspects;
@@ -28,6 +29,7 @@ namespace Metalama.Extensions.DependencyInjection;
 /// <seealso cref="DependencyInjectionExtensions"/>
 /// <seealso href="@dependency-injection"/>
 [PublicAPI]
+[AttributeUsage( AttributeTargets.Field | AttributeTargets.Property )]
 public class IntroduceDependencyAttribute : DeclarativeAdviceAttribute
 {
     private bool? _isLazy;


### PR DESCRIPTION
## Summary

Fixes #646.

`IntroduceDependencyAttribute` extends `DeclarativeAdviceAttribute` (which has no `[AttributeUsage]` restriction), so it defaulted to `AttributeTargets.All`. This allowed the attribute to be placed on methods, types, events, etc., which is invalid — it should only be applicable to fields and properties within aspect classes.

**Fix**: Added `[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]` to `IntroduceDependencyAttribute`, consistent with how `FieldOrPropertyAspect` (the base class of `DependencyAttribute`) restricts its targets.

## Checklist

- [x] Implement fix (add `[AttributeUsage]`)
- [x] Run DI aspect tests (38/38 passed)
- [x] Run ServiceLocator DI aspect tests (12/12 passed)
- [x] Full `Build.ps1 build` with zero warnings
- [x] Full `Build.ps1 test`
- [x] Mark PR as ready

## Test plan

- [x] Verify all existing `Metalama.Extensions.DependencyInjection.AspectTests` pass
- [x] Verify all existing `Metalama.Extensions.DependencyInjection.ServiceLocator.AspectTests` pass
- [x] Full test suite with `Build.ps1 test`