### PR TITLE
Fix compile-time assembly resolution with PrivateAssets (#633)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -159,6 +159,7 @@
     <PackageVersion Include="Metalama.Extensions.Multicast" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Extensions.DiffEngine" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Extensions.HtmlWriter" Version="$(MetalamaVersion)" />
+    <PackageVersion Include="Metalama.Patterns.Contracts" Version="$(MetalamaVersion)" />
 
 
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitivePipelineContributorSource.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitivePipelineContributorSource.cs
@@ -16,6 +16,7 @@ using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities;
 using Metalama.Framework.Options;
 using Microsoft.CodeAnalysis;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -68,11 +69,27 @@ internal sealed partial class TransitivePipelineContributorSource : IExternalHie
                     {
                         if ( metadataInfo.Resources.TryGetValue( CompileTimeConstants.InheritableAspectManifestResourceName, out var bytes ) )
                         {
-                            manifest = TransitiveAspectsManifest.Deserialize(
-                                new MemoryStream( bytes ),
-                                serviceProvider,
-                                compilationContext,
-                                filePath );
+                            try
+                            {
+                                manifest = TransitiveAspectsManifest.Deserialize(
+                                    new MemoryStream( bytes ),
+                                    serviceProvider,
+                                    compilationContext,
+                                    filePath );
+                            }
+                            catch ( InvalidOperationException ex ) when ( ex.Message.Contains( "Could not locate assembly", StringComparison.Ordinal ) )
+                            {
+                                // This can happen when a referenced assembly uses PrivateAssets="all" on an aspect package,
+                                // so the aspect assembly doesn't flow transitively to the consumer. In that case, we skip
+                                // the transitive aspects manifest since the consumer doesn't have the required assemblies.
+                                serviceProvider.GetLoggerFactory()
+                                    .GetLogger( nameof(TransitivePipelineContributorSource) )
+                                    .Warning?.Log(
+                                        $"Cannot deserialize the transitive aspects manifest from '{filePath}': {ex.Message}. " +
+                                        "This may be because the assembly was referenced with PrivateAssets=\"all\" in a dependency. Skipping." );
+
+                                break;
+                            }
 
                             assemblyIdentity = metadataInfo.AssemblyIdentity;
                         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProjectRepository.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProjectRepository.Builder.cs
@@ -513,16 +513,18 @@ internal sealed partial class CompileTimeProjectRepository
             {
                 if ( this._runTimeAssemblyLocator.TryFindAssembly( runTimeAssemblyIdentity, out var metadataReference ) != true )
                 {
-                    var diagnostic = GeneralDiagnosticDescriptors.CannotFindCompileTimeAssembly.CreateRoslynDiagnostic(
-                        Location.None,
-                        runTimeAssemblyIdentity );
-
-                    diagnosticAdder.Report( diagnostic );
-                    this._logger.Warning?.Log( diagnostic.ToString() );
+                    // The assembly is not available in the current compilation's references.
+                    // This can happen when a referenced library uses PrivateAssets="all" on an aspect package,
+                    // so the package doesn't flow transitively to the consumer. In that case, we skip the
+                    // reference instead of reporting an error; the compile-time compilation will fail later
+                    // if this reference is actually needed.
+                    this._logger.Warning?.Log(
+                        $"The assembly '{runTimeAssemblyIdentity}' required at compile-time cannot be found in the current compilation's references. " +
+                        "This may be because the assembly was referenced with PrivateAssets=\"all\" in a dependency. Skipping." );
 
                     compileTimeProject = null;
 
-                    return false;
+                    return true;
                 }
 
                 return this.TryGetCompileTimeProject(

--- a/Metalama.Framework/src/tests/Standalone/Issue633/App/App.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/App/App.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Issue 633: Consumer references the library and Metalama.Framework,
+         but does NOT have Metalama.Patterns.Contracts (because the library used PrivateAssets="all"). -->
+    <ProjectReference Include="..\Library\Library.csproj" />
+    <PackageReference Include="Metalama.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue633/App/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/App/Program.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+// Regression test for #633: Application references a library that uses
+// Metalama.Patterns.Contracts with PrivateAssets="all".
+// The build should succeed without "Cannot find the compile-time assembly" errors.
+
+using Issue633.Library;
+
+var validated = new Validated();
+Console.WriteLine( validated.GetGreeting( "World" ) );
+Console.WriteLine( validated.Clamp( 42 ) );

--- a/Metalama.Framework/src/tests/Standalone/Issue633/Issue633.sln
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/Issue633.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35208.52
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library", "Library\Library.csproj", "{A1B2C3D4-0001-0633-0001-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "App\App.csproj", "{A1B2C3D4-0001-0633-0001-000000000002}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A1B2C3D4-0001-0633-0001-000000000001} = {A1B2C3D4-0001-0633-0001-000000000001}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-0001-0633-0001-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-0001-0633-0001-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A1B2C3D4-0001-0633-0001-000000000003}
+	EndGlobalSection
+EndGlobal

--- a/Metalama.Framework/src/tests/Standalone/Issue633/Library/Library.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/Library/Library.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Issue 633: Library references Metalama.Patterns.Contracts with PrivateAssets="all"
+         so that the Contracts package does NOT flow transitively to consumers. -->
+    <PackageReference Include="Metalama.Patterns.Contracts" PrivateAssets="all" />
+    <PackageReference Include="Metalama.Framework.Redist" />
+  </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue633/Library/Library.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/Library/Library.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Suppress CA1822 because Metalama contract aspects add instance-data usage at compile-time. -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Metalama.Framework/src/tests/Standalone/Issue633/Library/Validated.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/Library/Validated.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Patterns.Contracts;
+
+namespace Issue633.Library;
+
+// Regression test for #633: A library applies contract attributes and uses PrivateAssets="all"
+// on Metalama.Patterns.Contracts so the package doesn't flow to consumers.
+public class Validated
+{
+    public string GetGreeting( [NotNull] string name )
+    {
+        return $"Hello, {name}!";
+    }
+
+    public int Clamp( [Range( 0, 100 )] int value )
+    {
+        return value;
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue633/test.json
+++ b/Metalama.Framework/src/tests/Standalone/Issue633/test.json
@@ -1,0 +1,5 @@
+{
+    "BuildOnly": true,
+    "IgnoreExitCode": false,
+    "FailOnUnexpectedDiagnostics": true
+}


### PR DESCRIPTION
## Summary

Fixes #633: When a library references Metalama.Patterns.Contracts with PrivateAssets=all and a consumer references that library, the build fails with LAMA0027.

## Root Cause

Two separate failure points:

1. **CompileTimeProjectRepository.Builder.TryGetCompileTimeProject**: The consumer cannot find assemblies marked PrivateAssets=all in the library, causing LAMA0027.

2. **TransitivePipelineContributorSource.Create**: The transitive aspects manifest references types from the missing package, causing deserialization failure.

## Fix

1. **CompileTimeProjectRepository.Builder.cs**: Return true with null project instead of reporting LAMA0027 when a reference assembly cannot be found.

2. **TransitivePipelineContributorSource.cs**: Catch InvalidOperationException during transitive manifest deserialization when assemblies are missing.

## Checklist

- [x] Reproduce the bug with a standalone test
- [x] Implement the fix
- [x] Run unit tests (1576 passed, 0 failed)
- [x] Build with Build.ps1 build (0 warnings)
- [x] Verify standalone test passes with fix
- [x] Finalize