### PR TITLE
Handle [method:] on primary constructors (#640)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.AttributeDiscoveryVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.AttributeDiscoveryVisitor.cs
@@ -124,7 +124,7 @@ namespace Metalama.Framework.Engine.CodeModel
                                     IndexAttribute( accessor, RefTargetKind.Default );
                                 }
                             }
-                            else if ( declaration is TypeDeclarationSyntax { ParameterList: { } } )
+                            else if ( declaration is TypeDeclarationSyntax typeDeclaration && typeDeclaration.GetParameterList() != null )
                             {
                                 // [method: ...] on a type declaration with a primary constructor targets the primary constructor.
                                 IndexAttribute( declaration, RefTargetKind.PrimaryConstructor );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.AttributeDiscoveryVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.AttributeDiscoveryVisitor.cs
@@ -124,6 +124,11 @@ namespace Metalama.Framework.Engine.CodeModel
                                     IndexAttribute( accessor, RefTargetKind.Default );
                                 }
                             }
+                            else if ( declaration is TypeDeclarationSyntax { ParameterList: { } } )
+                            {
+                                // [method: ...] on a type declaration with a primary constructor targets the primary constructor.
+                                IndexAttribute( declaration, RefTargetKind.PrimaryConstructor );
+                            }
 
                             break;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Symbols.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Factories/DeclarationFactory.Symbols.cs
@@ -394,6 +394,7 @@ public partial class DeclarationFactory
                     return targetKind switch
                     {
                         RefTargetKind.StaticConstructor => type.StaticConstructor,
+                        RefTargetKind.PrimaryConstructor => type.PrimaryConstructor,
                         RefTargetKind.Default => type,
                         _ => throw new AssertionFailedException( $"Invalid DeclarationRefTargetKind: {targetKind}." )
                     };

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/FullRef.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/FullRef.cs
@@ -87,7 +87,7 @@ internal abstract partial class FullRef<T> : BaseRef<T>, IFullRef<T>
 
                 if ( primaryConstructor != null )
                 {
-                    return new ResolvedAttributeRef( primaryConstructor.GetAttributes(), primaryConstructor, RefTargetKind.PrimaryConstructor );
+                    return new ResolvedAttributeRef( primaryConstructor.GetAttributes(), primaryConstructor, RefTargetKind.Default );
                 }
 
                 return new ResolvedAttributeRef( ImmutableArray<AttributeData>.Empty, namedType, RefTargetKind.PrimaryConstructor );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/FullRef.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/FullRef.cs
@@ -82,6 +82,16 @@ internal abstract partial class FullRef<T> : BaseRef<T>, IFullRef<T>
                 // Roslyn does not expose the backing field of an event, so we don't have access to its attributes.
                 return new ResolvedAttributeRef( ImmutableArray<AttributeData>.Empty, @event, RefTargetKind.Field );
 
+            case RefTargetKind.PrimaryConstructor when this.GetSymbolIgnoringRefKind( this.CompilationContext ) is { Kind: SymbolKind.NamedType } and INamedTypeSymbol namedType:
+                var primaryConstructor = namedType.InstanceConstructors.FirstOrDefault( c => c.IsPrimaryConstructor() );
+
+                if ( primaryConstructor != null )
+                {
+                    return new ResolvedAttributeRef( primaryConstructor.GetAttributes(), primaryConstructor, RefTargetKind.PrimaryConstructor );
+                }
+
+                return new ResolvedAttributeRef( ImmutableArray<AttributeData>.Empty, namedType, RefTargetKind.PrimaryConstructor );
+
             default:
                 var symbol = this.GetSymbol( this.CompilationContext, true );
                 var attributes = symbol.GetAttributes();
@@ -136,6 +146,9 @@ internal abstract partial class FullRef<T> : BaseRef<T>, IFullRef<T>
             (RefTargetKind.Property, SymbolKind.Parameter) when symbol is IParameterSymbol parameter => parameter.ContainingType.GetMembers( symbol.Name )
                 .OfType<IPropertySymbol>()
                 .Single(),
+            (RefTargetKind.PrimaryConstructor, SymbolKind.NamedType) when symbol is INamedTypeSymbol namedType =>
+                namedType.InstanceConstructors.FirstOrDefault( c => c.IsPrimaryConstructor() )
+                ?? throw new AssertionFailedException( $"The type '{namedType}' does not have a primary constructor." ),
             _ => throw new AssertionFailedException( $"Don't know how to get the symbol kind {this.TargetKind} for a {symbol.Kind}." )
         };
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/RefExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/RefExtensions.cs
@@ -90,6 +90,7 @@ public static class RefExtensions
             RefTargetKind.PropertyGet => [typeof(IMethod)],
             RefTargetKind.PropertySet => [typeof(IMethod)],
             RefTargetKind.StaticConstructor => [typeof(IConstructor)],
+            RefTargetKind.PrimaryConstructor => [typeof(IConstructor)],
             RefTargetKind.PropertySetParameter => [typeof(IParameter)],
             RefTargetKind.PropertyGetReturnParameter => [typeof(IParameter)],
             RefTargetKind.PropertySetReturnParameter => [typeof(IParameter)],

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/RefTargetKind.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/RefTargetKind.cs
@@ -26,6 +26,7 @@ namespace Metalama.Framework.Engine.CodeModel.References
         EventRaiseParameter,
         EventRaiseReturnParameter,
         NamedType,
-        ExtensionBlock
+        ExtensionBlock,
+        PrimaryConstructor
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/RefTargetKindExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/References/RefTargetKindExtensions.cs
@@ -50,6 +50,7 @@ internal static class RefTargetKindExtensions
             RefTargetKind.EventRaiseReturnParameter => DeclarationKind.Parameter,
             RefTargetKind.NamedType => DeclarationKind.NamedType,
             RefTargetKind.ExtensionBlock => DeclarationKind.ExtensionBlock,
+            RefTargetKind.PrimaryConstructor => DeclarationKind.Constructor,
             _ => throw new ArgumentOutOfRangeException( nameof(kind), kind, null )
         };
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
@@ -44,6 +44,7 @@ public static partial class SerializableDeclarationIdProvider
                 (IEvent @event, nameof(RefTargetKind.EventRaise)) => @event.RaiseMethod,
                 (IEvent @event, nameof(RefTargetKind.EventRaiseParameter)) => @event.RaiseMethod?.Parameters[0],
                 (IEvent @event, nameof(RefTargetKind.EventRaiseReturnParameter)) => @event.RaiseMethod?.ReturnParameter,
+                (INamedType type, nameof(RefTargetKind.PrimaryConstructor)) => type.PrimaryConstructor,
                 _ => null
             };
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities;
+using Metalama.Framework.Engine.Utilities.Roslyn;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Globalization;
@@ -69,6 +70,8 @@ public static partial class SerializableDeclarationIdProvider
                 (SymbolKind.Method, "TypeParameter") when parent is IMethodSymbol method => method.TypeParameters[ordinal],
                 (SymbolKind.NamedType, "TypeParameter") when parent is INamedTypeSymbol type => type.TypeParameters[ordinal],
                 (SymbolKind.Property, "Parameter") when parent is IPropertySymbol property => property.Parameters[ordinal],
+                (SymbolKind.NamedType, nameof(RefTargetKind.PrimaryConstructor)) when parent is INamedTypeSymbol type =>
+                    type.InstanceConstructors.FirstOrDefault( c => c.IsPrimaryConstructor() ),
                 _ => null
             };
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug640.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug640.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_4_8_0_OR_GREATER)
+#endif
+
+#if ROSLYN_4_8_0_OR_GREATER
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug640;
+
+/*
+ * Tests that a ConstructorAspect applied to a primary constructor using [method:] attribute target
+ * is correctly discovered and applied (#640).
+ */
+
+public class LogAttribute : ConstructorAspect
+{
+    public override void BuildAspect( IAspectBuilder<IConstructor> builder )
+    {
+        builder.Override( nameof(Template) );
+    }
+
+    [Template]
+    public void Template()
+    {
+        Console.WriteLine( "Overridden." );
+        meta.Proceed();
+    }
+}
+
+#pragma warning disable CS9113 // Parameter is unread.
+
+// <target>
+[method: Log]
+internal class C( int i )
+{
+    [Log]
+    public C( string s ) : this( 0 ) { }
+}
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug640.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug640.t.cs
@@ -1,0 +1,5 @@
+[Log]
+public C(int i)
+{
+  global::System.Console.WriteLine("Overridden.");
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -200,7 +200,7 @@ class C(int i)
 
         // Test roundtrip with RefTargetKind.PrimaryConstructor target kind on the type symbol.
         // This is the path used when [method:] attribute target is applied to a type with a primary constructor.
-        var typeSymbol = (INamedTypeSymbol) type.GetSymbol().AssertSymbolNotNull();
+        var typeSymbol = type.GetSymbol().AssertSymbolNotNull();
         var primaryConstructorSymbol = typeSymbol.InstanceConstructors.First( c => c.IsPrimaryConstructor() );
 
         var idWithTargetKind = typeSymbol.GetSerializableId( RefTargetKind.PrimaryConstructor );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -6,6 +6,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Helpers;
+using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.CodeModel.Source.Pseudo;
 using Metalama.Framework.Engine.SerializableIds;
 using Metalama.Framework.Engine.Utilities.Roslyn;
@@ -159,7 +160,7 @@ class C<T>
     public void TestNonNamedTyped()
     {
         const string code = @"
-class C 
+class C
 {
   public int[] F;
 }
@@ -170,5 +171,47 @@ class C
         var field = compilation.Types.Single().Fields.Single();
 
         Roundtrip( compilation, field.Type.GetSymbol().AssertSymbolNotNull(), false );
+    }
+
+    [Fact]
+    public void PrimaryConstructorRoundtrip()
+    {
+        const string code = @"
+#pragma warning disable CS9113
+class C(int i)
+{
+  public C(string s) : this(0) {}
+}
+";
+
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilation( code );
+        var type = compilation.Types.Single();
+        var primaryConstructor = type.PrimaryConstructor;
+
+        if ( primaryConstructor == null )
+        {
+            // Before Roslyn 4.8, non-record primary constructors are not supported.
+            return;
+        }
+
+        // Test standard roundtrip (RefTargetKind.Default) for the primary constructor.
+        Roundtrip( primaryConstructor, compilation, this.TestOutput );
+
+        // Test roundtrip with RefTargetKind.PrimaryConstructor target kind on the type symbol.
+        // This is the path used when [method:] attribute target is applied to a type with a primary constructor.
+        var typeSymbol = (INamedTypeSymbol) type.GetSymbol().AssertSymbolNotNull();
+        var primaryConstructorSymbol = typeSymbol.InstanceConstructors.First( c => c.IsPrimaryConstructor() );
+
+        var idWithTargetKind = typeSymbol.GetSerializableId( RefTargetKind.PrimaryConstructor );
+        this.TestOutput.WriteLine( $"PrimaryConstructor target kind ID: {idWithTargetKind.Id}" );
+
+        // Verify symbol roundtrip via ResolveToSymbolOrNull.
+        var resolvedSymbol = idWithTargetKind.ResolveToSymbolOrNull( compilation.GetCompilationContext() );
+        Assert.Same( primaryConstructorSymbol, resolvedSymbol );
+
+        // Verify declaration roundtrip via ResolveToDeclaration.
+        var resolvedDeclaration = idWithTargetKind.ResolveToDeclaration( compilation.GetCompilationModel() );
+        Assert.Same( primaryConstructor, resolvedDeclaration );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #640: Architecture validation attributes (e.g., `[method: CanOnlyBeUsedFrom(...)]`) placed on type declarations with primary constructors were silently ignored.

**Root cause:** `AttributeDiscoveryVisitor.VisitAttribute()` did not handle the `[method:]` attribute target on `TypeDeclarationSyntax` nodes. It only handled `[method:]` on property/indexer/event declarations.

**Fix:** Added a new `RefTargetKind.PrimaryConstructor` enum value and handled it throughout the attribute discovery and resolution pipeline.

## Changes

- `RefTargetKind.cs`: Added `PrimaryConstructor` enum value
- `CompilationModel.AttributeDiscoveryVisitor.cs`: Core fix — index `[method:]` attributes on type declarations with primary constructors using `GetParameterList()` for Roslyn version compatibility
- `FullRef.cs`: Resolve `PrimaryConstructor` target kind to the primary constructor in both `GetAttributes()` and `ApplyRefKind()`
- `DeclarationFactory.Symbols.cs`: Map `PrimaryConstructor` target kind to `INamedType.PrimaryConstructor`
- `RefTargetKindExtensions.cs`: Map `PrimaryConstructor` to `DeclarationKind.Constructor`
- `RefExtensions.cs`: DEBUG validation for `PrimaryConstructor`
- `SerializableDeclarationIdProvider.ToDeclaration.cs`: Deserialization support for declaration IDs
- `SerializableDeclarationIdProvider.ToSymbol.cs`: Deserialization support for symbol IDs (round-trip)

## Test plan

- [x] Reproduce bug with failing regression test (PR #49 in Metalama.Premium)
- [x] Implement fix
- [x] Add aspect test `Bug640.cs` verifying `[method:]` ConstructorAspect on primary constructor
- [x] Add unit test `PrimaryConstructorRoundtrip` verifying SerializableId/Ref round-trip resolution
- [x] All tests pass on net8.0 and net48
- [x] Metalama `Build.ps1 build` succeeds with zero warnings