### PR TITLE
Fix delegate run-time template parameter treated as compile-time (#647)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
@@ -1247,7 +1247,12 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
                     SeparatedList( transformedArguments, node.ArgumentList.Arguments.GetSeparators() ),
                     node.ArgumentList.CloseParenToken ) );
 
-            updatedInvocation = updatedInvocation.AddScopeAnnotation( expressionScope );
+            // When the expression is a run-time template parameter (e.g. a delegate), the invocation produces
+            // a run-time value, not another template parameter reference. Use RunTimeOnly so the invocation
+            // gets transformed to syntax factory code.
+            var invocationScope = expressionScope == RunTimeTemplateParameter ? RunTimeOnly : expressionScope;
+
+            updatedInvocation = updatedInvocation.AddScopeAnnotation( invocationScope );
 
             if ( expressionScope == CompileTimeOnlyReturningRuntimeOnly && this._syntaxTreeAnnotationMap.GetExpressionType( node ) is
                     { TypeKind: TypeKind.Dynamic } )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateParameters/IntroduceMethod_DelegateParameter.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateParameters/IntroduceMethod_DelegateParameter.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.TemplateParameters.IntroduceMethod_DelegateParameter;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceMethod( nameof(FuncTemplate) );
+        builder.IntroduceMethod( nameof(ActionTemplate) );
+    }
+
+    [Template]
+    private void FuncTemplate( Func<object> f )
+    {
+        f();
+    }
+
+    [Template]
+    private void ActionTemplate( Action a )
+    {
+        a();
+    }
+}
+
+// <target>
+[MyAspect]
+internal class Target
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateParameters/IntroduceMethod_DelegateParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateParameters/IntroduceMethod_DelegateParameter.t.cs
@@ -1,0 +1,13 @@
+[MyAspect]
+internal class Target
+{
+  private void FuncTemplate(global::System.Func<global::System.Object> f)
+  {
+    f();
+  }
+
+  private void ActionTemplate(global::System.Action a)
+  {
+    a();
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateParameters/IntroduceMethod_DelegateParameter.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/TemplateParameters/IntroduceMethod_DelegateParameter.t.cs
@@ -1,13 +1,12 @@
 [MyAspect]
 internal class Target
 {
-  private void FuncTemplate(global::System.Func<global::System.Object> f)
-  {
-    f();
-  }
-
   private void ActionTemplate(global::System.Action a)
   {
     a();
+  }
+  private void FuncTemplate(global::System.Func<global::System.Object> f)
+  {
+    f();
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #647: Delegate-type parameters (e.g., `Func<object>`, `Action`) in template methods are incorrectly treated as compile-time, causing `CS0149: Method name expected` errors during compile-time compilation.

## Changes
- **`TemplateAnnotator.cs`**: When an invocation expression's target has `RunTimeTemplateParameter` scope, the invocation scope is now set to `RunTimeOnly` instead of inheriting `RunTimeTemplateParameter`. This ensures delegate invocations get properly transformed to syntax factory code.
- **`IntroduceMethod_DelegateParameter.cs`** / **`.t.cs`**: New regression test covering both `Action` and `Func<object>` delegate parameters in introduced methods.

## Progress checklist
- [x] Reproduce bug with regression test
- [x] Implement fix
- [x] Build passes (`Build.ps1 build`)
- [x] All tests pass (`Build.ps1 test`)
- [x] Finalize

## Test plan
- [x] Verify the new `IntroduceMethod_DelegateParameter` test passes after fix
- [x] Run full aspect test suite to ensure no regressions
- [x] Verify `Build.ps1 build` succeeds with zero warnings
- [x] Verify `Build.ps1 test` succeeds with all tests passing