### PR TITLE
Add regression test for invalid array base type syntax (#649)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SemanticModelAnalyzerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SemanticModelAnalyzerTests.cs
@@ -349,6 +349,43 @@ namespace Metalama.Framework.Tests.UnitTests.Templating
         }
 
         [Fact]
+        public void InvalidBaseTypeArraySyntax_DoesNotThrow()
+        {
+            // Regression test for https://github.com/metalama/Metalama/issues/649
+            // When a class uses invalid "array" syntax in base type (e.g. OverrideMethodAspect[]),
+            // Roslyn parses the base type as ArrayTypeSymbol. The validator should not crash.
+            using var testContext = this.CreateTestContext();
+
+            var compilation = testContext.CreateCSharpCompilation(
+                """
+                using Metalama.Framework.Aspects;
+
+                public class SECall : OverrideMethodAspect[]
+                {
+                }
+
+                public class SECall2 : OverrideMethodAspect[c]
+                {
+                }
+                """,
+                ignoreErrors: true );
+
+            List<Diagnostic> diagnostics = new();
+            var syntaxTree = compilation.SyntaxTrees[0];
+            var semanticModel = compilation.GetSemanticModel( syntaxTree );
+
+            // This should not throw an InvalidCastException.
+            TemplatingCodeValidator.Validate(
+                testContext.ServiceProvider,
+                semanticModel,
+                diagnostics.Add,
+                null,
+                false,
+                false,
+                testContext.CancellationToken );
+        }
+
+        [Fact]
         public void WellKnownTypesNotReported()
         {
             using var testContext = this.CreateTestContext();


### PR DESCRIPTION
## Summary
- Add regression test verifying that `TemplatingCodeValidator` handles invalid "array" syntax in base type lists (e.g., `OverrideMethodAspect[]` and `OverrideMethodAspect[c]`) without throwing `InvalidCastException`.
- The bug described in #649 appears to have been already fixed in the current codebase. The existing code in `VerifyTypeDeclaration` correctly checks `baseTypeSymbol?.Kind != SymbolKind.NamedType` before casting.

Closes #649.

## Checklist
- [x] Understand the issue
- [x] Write regression test
- [x] Verify test passes (bug already fixed)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Run tests (1600 passed, 0 failed)
- [x] Finalize PR

## Test plan
- [x] Unit test `InvalidBaseTypeArraySyntax_DoesNotThrow` verifies the validator doesn't crash on `OverrideMethodAspect[]` and `OverrideMethodAspect[c]` base types
- [x] All 1600 unit tests in `Metalama.Framework.Tests.UnitTests` pass
- [x] All 12 `SemanticModelAnalyzerTests` pass
