### PR TITLE
Fix HierarchicalOptionsManager assertion failure (#659)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/HierarchicalOptions/HierarchicalOptionsManager.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/HierarchicalOptions/HierarchicalOptionsManager.cs
@@ -13,6 +13,7 @@ using Metalama.Framework.Options;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -139,31 +140,28 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
         {
             var optionTypeName = option.Options.GetType().FullName.AssertNotNull();
 
-            var optionTypeNode = this.GetOptionTypeNode( optionTypeName );
-
             // The option type may not be registered if the type could not be resolved during initialization
             // (e.g., during design-time when the compilation is in an inconsistent state).
-            optionTypeNode?.AddOptionsInstance( option, diagnosticSink );
+            if ( this.TryGetOptionTypeNode( optionTypeName, out var optionTypeNode ) )
+            {
+                optionTypeNode.AddOptionsInstance( option, diagnosticSink );
+            }
         }
     }
 
-    private OptionTypeNode? GetOptionTypeNode( string optionTypeName )
+    private bool TryGetOptionTypeNode( string optionTypeName, [NotNullWhen( true )] out OptionTypeNode? node )
     {
         if ( !this.IsInitialized )
         {
             throw new InvalidOperationException( $"The {nameof(HierarchicalOptionsManager)} has not been initialized." );
         }
 
-        this._optionTypes.TryGetValue( optionTypeName, out var optionTypeNode );
-
-        return optionTypeNode;
+        return this._optionTypes.TryGetValue( optionTypeName, out node );
     }
 
     public IHierarchicalOptions? GetOptions( IDeclaration declaration, Type optionsType )
     {
-        var optionTypeNode = this.GetOptionTypeNode( optionsType.FullName.AssertNotNull() );
-
-        if ( optionTypeNode == null )
+        if ( !this.TryGetOptionTypeNode( optionsType.FullName.AssertNotNull(), out var optionTypeNode ) )
         {
             // The option type may not be registered if the type could not be resolved during initialization
             // (e.g., during design-time when the compilation is in an inconsistent state).
@@ -180,5 +178,10 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
             .SelectMany( s => s.Value.GetInheritableOptions( compilation, withSyntaxTree ) );
 
     internal void SetAspectOptions( IDeclaration declaration, IHierarchicalOptions options )
-        => this.GetOptionTypeNode( options.GetType().FullName.AssertNotNull() )?.SetAspectOptions( declaration, options );
+    {
+        if ( this.TryGetOptionTypeNode( options.GetType().FullName.AssertNotNull(), out var optionTypeNode ) )
+        {
+            optionTypeNode.SetAspectOptions( declaration, options );
+        }
+    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/HierarchicalOptions/HierarchicalOptionsManager.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/HierarchicalOptions/HierarchicalOptionsManager.cs
@@ -123,7 +123,9 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
         {
             this._externalOptionsProvider = externalOptionsProvider;
 
-            // We have to create OptionType nodes now while we have an IDiagnosticAdder. 
+            // We have to create OptionType nodes now while we have an IDiagnosticAdder.
+            // Some external option types may not be resolvable (e.g., during design-time when the compilation
+            // is in an inconsistent state), so we skip those silently.
             foreach ( var optionType in externalOptionsProvider.GetOptionTypes() )
             {
                 _ = this.GetOptionTypeNode( optionType );
@@ -147,21 +149,20 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
 
             var optionTypeNode = this.GetOptionTypeNode( optionTypeName );
 
-            optionTypeNode.AddOptionsInstance( option, diagnosticSink );
+            // The option type may not be registered if the type could not be resolved during initialization
+            // (e.g., during design-time when the compilation is in an inconsistent state).
+            optionTypeNode?.AddOptionsInstance( option, diagnosticSink );
         }
     }
 
-    private OptionTypeNode GetOptionTypeNode( string optionTypeName )
+    private OptionTypeNode? GetOptionTypeNode( string optionTypeName )
     {
         if ( !this.IsInitialized )
         {
             throw new InvalidOperationException( $"The {nameof(HierarchicalOptionsManager)} has not been initialized." );
         }
 
-        if ( !this._optionTypes.TryGetValue( optionTypeName, out var optionTypeNode ) )
-        {
-            throw new AssertionFailedException( $"The option type '{optionTypeName}' is not a part of the current project." );
-        }
+        this._optionTypes.TryGetValue( optionTypeName, out var optionTypeNode );
 
         return optionTypeNode;
     }
@@ -169,6 +170,14 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
     public IHierarchicalOptions GetOptions( IDeclaration declaration, Type optionsType )
     {
         var optionTypeNode = this.GetOptionTypeNode( optionsType.FullName.AssertNotNull() );
+
+        if ( optionTypeNode == null )
+        {
+            // The option type may not be registered if the type could not be resolved during initialization
+            // (e.g., during design-time when the compilation is in an inconsistent state).
+            // Return a default instance created via the parameterless constructor.
+            return (IHierarchicalOptions) Activator.CreateInstance( optionsType ).AssertNotNull();
+        }
 
         return optionTypeNode.GetOptions( declaration ).AssertNotNull();
     }
@@ -179,5 +188,5 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
             .SelectMany( s => s.Value.GetInheritableOptions( compilation, withSyntaxTree ) );
 
     internal void SetAspectOptions( IDeclaration declaration, IHierarchicalOptions options )
-        => this.GetOptionTypeNode( options.GetType().FullName.AssertNotNull() ).SetAspectOptions( declaration, options );
+        => this.GetOptionTypeNode( options.GetType().FullName.AssertNotNull() )?.SetAspectOptions( declaration, options );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/HierarchicalOptions/HierarchicalOptionsManager.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/HierarchicalOptions/HierarchicalOptionsManager.cs
@@ -122,14 +122,6 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
         if ( externalOptionsProvider != null )
         {
             this._externalOptionsProvider = externalOptionsProvider;
-
-            // We have to create OptionType nodes now while we have an IDiagnosticAdder.
-            // Some external option types may not be resolvable (e.g., during design-time when the compilation
-            // is in an inconsistent state), so we skip those silently.
-            foreach ( var optionType in externalOptionsProvider.GetOptionTypes() )
-            {
-                _ = this.GetOptionTypeNode( optionType );
-            }
         }
 
         return Task.WhenAll( sources.Select( s => this.AddSourceAsync( s, compilationModel, diagnosticSink, cancellationToken ) ) );
@@ -167,7 +159,7 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
         return optionTypeNode;
     }
 
-    public IHierarchicalOptions GetOptions( IDeclaration declaration, Type optionsType )
+    public IHierarchicalOptions? GetOptions( IDeclaration declaration, Type optionsType )
     {
         var optionTypeNode = this.GetOptionTypeNode( optionsType.FullName.AssertNotNull() );
 
@@ -175,8 +167,8 @@ public sealed partial class HierarchicalOptionsManager : IHierarchicalOptionsMan
         {
             // The option type may not be registered if the type could not be resolved during initialization
             // (e.g., during design-time when the compilation is in an inconsistent state).
-            // Return a default instance created via the parameterless constructor.
-            return (IHierarchicalOptions) Activator.CreateInstance( optionsType ).AssertNotNull();
+            // Callers handle null via the null-coalescing pattern (e.g., ?? new TOptions()).
+            return null;
         }
 
         return optionTypeNode.GetOptions( declaration ).AssertNotNull();

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/HierarchicalOptionsManagerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/HierarchicalOptionsManagerTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Code;
+using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.HierarchicalOptions;
+using Metalama.Framework.Options;
+using Metalama.Testing.UnitTesting;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Options;
+
+/// <summary>
+/// Tests for <see cref="HierarchicalOptionsManager"/> behavior when option types are unresolvable.
+/// Regression tests for https://github.com/metalama/Metalama/issues/659.
+/// </summary>
+public sealed class HierarchicalOptionsManagerTests : UnitTestClass
+{
+    [Fact]
+    public async Task ExternalProviderWithUnresolvableType()
+    {
+        // Regression test for #659: When an IExternalHierarchicalOptionsProvider returns an option type
+        // that was not registered during initialization (because the type could not be resolved),
+        // HierarchicalOptionsManager should not throw AssertionFailedException.
+
+        using var context = this.CreateTestContext();
+
+        var manager = new HierarchicalOptionsManager( context.ServiceProvider );
+
+        // Initialize with an empty project (no option types to register) but with an external provider
+        // that returns an unresolvable type name. This simulates the scenario where a referenced assembly's
+        // manifest lists option types that can't be resolved in the current compilation.
+        await manager.InitializeAsync(
+            CompileTimeProject.Empty,
+            sources: [],
+            new UnresolvableExternalOptionsProvider(),
+            compilationModel: null!,
+            diagnosticSink: null!,
+            cancellationToken: default );
+    }
+
+    /// <summary>
+    /// Mock <see cref="IExternalHierarchicalOptionsProvider"/> that returns a type name
+    /// which does not exist in the compilation, simulating a stale or inconsistent manifest.
+    /// </summary>
+    private sealed class UnresolvableExternalOptionsProvider : IExternalHierarchicalOptionsProvider
+    {
+        public IEnumerable<string> GetOptionTypes() => ["NonExistent.StaleOptionsType"];
+
+        public bool TryGetOptions( IDeclaration declaration, string optionsType, [NotNullWhen( true )] out IHierarchicalOptions? options )
+        {
+            options = null;
+
+            return false;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/HierarchicalOptionsManagerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/HierarchicalOptionsManagerTests.cs
@@ -9,6 +9,7 @@ using Metalama.Framework.Options;
 using Metalama.Testing.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -29,6 +30,8 @@ public sealed class HierarchicalOptionsManagerTests : UnitTestClass
 
         using var context = this.CreateTestContext();
 
+        var compilationModel = context.CreateCompilationModel( "public class C { }" );
+
         var manager = new HierarchicalOptionsManager( context.ServiceProvider );
 
         // Initialize with an empty project (no option types to register) but with an external provider
@@ -38,9 +41,15 @@ public sealed class HierarchicalOptionsManagerTests : UnitTestClass
             CompileTimeProject.Empty,
             sources: [],
             new UnresolvableExternalOptionsProvider(),
-            compilationModel: null!,
+            compilationModel,
             diagnosticSink: null!,
             cancellationToken: default );
+
+        // Verify that GetOptions returns null for an unregistered option type instead of throwing.
+        var declaration = compilationModel.Types.Single();
+        var options = manager.GetOptions( declaration, typeof(UnresolvableOptions) );
+
+        Assert.Null( options );
     }
 
     /// <summary>
@@ -57,5 +66,16 @@ public sealed class HierarchicalOptionsManagerTests : UnitTestClass
 
             return false;
         }
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IHierarchicalOptions"/> implementation used to test that
+    /// <see cref="HierarchicalOptionsManager.GetOptions"/> handles unregistered option types gracefully.
+    /// </summary>
+    private sealed class UnresolvableOptions : IHierarchicalOptions
+    {
+        public object ApplyChanges( object changes, in ApplyChangesContext context ) => this;
+
+        public IHierarchicalOptions? GetDefaultOptions( OptionsInitializationContext context ) => null;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #659: `HierarchicalOptionsManager.GetOptionType` throws `AssertionFailedException: The reference to Type must not be null.`

The original assertion (`GetCompileTimeType(...).AssertNotNull()`) in `GetOptionType` was already fixed in a previous commit (0899ba0a7a). However, the fix was incomplete — downstream consumers via `GetOptionTypeNode` still throw `AssertionFailedException` when the option type is not found in the registry (because it was skipped during initialization when `GetOptionType` returned null).

### Changes

- **`TryGetOptionTypeNode`**: Refactored from `GetOptionTypeNode` returning nullable to `bool TryGetOptionTypeNode(string, [NotNullWhen(true)] out OptionTypeNode?)` pattern
- **`InitializeAsync`**: Removed no-op external provider loop (after refactoring, the loop was not creating nodes)
- **`AddSourceAsync.AddOption`**: Skips options whose type could not be registered
- **`GetOptions`**: Returns `null` when the type is not registered (consistent with `IHierarchicalOptionsManager` interface contract; callers use `?? new TOptions()` pattern)
- **`SetAspectOptions`**: Silently skips when the type is not registered

### Regression Test

`HierarchicalOptionsManagerTests.ExternalProviderWithUnresolvableType` — tests `HierarchicalOptionsManager.InitializeAsync` with a mock `IExternalHierarchicalOptionsProvider` that returns an unresolvable type name, then verifies `GetOptions` returns null for unregistered types. Uses a real `CompilationModel` from the test context.

### Checklist

- [x] Implement fix for `GetOptionTypeNode` assertion
- [x] Add regression test
- [x] Verify test fails without fix and passes with fix
- [x] Address review feedback (TryGet pattern, Copilot suggestions)
- [x] Build passes with zero warnings
- [x] All tests pass
- [ ] TeamCity CI build validates the full build and test suite

## Test plan

- [x] `HierarchicalOptionsManagerTests.ExternalProviderWithUnresolvableType` — regression test for #659
- [x] All existing Options unit tests pass (15/15)
- [x] `Build.ps1 build` — zero warnings
- [x] `Build.ps1 test` — all tests pass, zero warnings
- [ ] TeamCity CI build