### PR TITLE
Fix syntax highlighting for field and property initializers (#663)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/TextSpanClassifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/TextSpanClassifier.cs
@@ -172,7 +172,29 @@ namespace Metalama.Framework.Engine.Formatting
             }
         }
 
-        public override void VisitFieldDeclaration( FieldDeclarationSyntax node ) => this.VisitMember( node, base.VisitFieldDeclaration );
+        public override void VisitFieldDeclaration( FieldDeclarationSyntax node )
+        {
+            if ( node.Declaration.Variables.Any( v => v.IsTemplateFromAnnotation() && v.Initializer != null ) )
+            {
+                this._isInTemplate = true;
+
+                foreach ( var variable in node.Declaration.Variables )
+                {
+                    if ( variable.Initializer != null )
+                    {
+                        this.Mark( variable.Initializer, TextSpanClassification.RunTime );
+                    }
+                }
+
+                base.VisitFieldDeclaration( node );
+
+                this._isInTemplate = false;
+            }
+            else
+            {
+                this.VisitMember( node, base.VisitFieldDeclaration );
+            }
+        }
 
         public override void VisitEventDeclaration( EventDeclarationSyntax node ) => this.VisitMember( node, base.VisitEventDeclaration );
 
@@ -183,8 +205,9 @@ namespace Metalama.Framework.Engine.Formatting
             {
                 this._isInTemplate = true;
 
-                // The code is run-time by default in a template method.
+                // The code is run-time by default in a template property.
                 this.Mark( node.ExpressionBody, TextSpanClassification.RunTime );
+                this.Mark( node.Initializer, TextSpanClassification.RunTime );
 
                 base.VisitPropertyDeclaration( node );
 
@@ -211,7 +234,29 @@ namespace Metalama.Framework.Engine.Formatting
             base.VisitAccessorDeclaration( node );
         }
 
-        public override void VisitEventFieldDeclaration( EventFieldDeclarationSyntax node ) => this.VisitMember( node, base.VisitEventFieldDeclaration );
+        public override void VisitEventFieldDeclaration( EventFieldDeclarationSyntax node )
+        {
+            if ( node.Declaration.Variables.Any( v => v.IsTemplateFromAnnotation() && v.Initializer != null ) )
+            {
+                this._isInTemplate = true;
+
+                foreach ( var variable in node.Declaration.Variables )
+                {
+                    if ( variable.Initializer != null )
+                    {
+                        this.Mark( variable.Initializer, TextSpanClassification.RunTime );
+                    }
+                }
+
+                base.VisitEventFieldDeclaration( node );
+
+                this._isInTemplate = false;
+            }
+            else
+            {
+                this.VisitMember( node, base.VisitEventFieldDeclaration );
+            }
+        }
 
         public override void VisitToken( SyntaxToken token )
         {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/FieldAndPropertyInitializers.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/FieldAndPropertyInitializers.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Collections.Generic;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Formatting.FieldAndPropertyInitializers
+{
+    internal class Aspect : TypeAspect
+    {
+        [Introduce]
+        public string IntroducedField = meta.Target.Type.Name;
+
+        [Introduce]
+        public string IntroducedProperty { get; set; } = meta.Target.Type.Name;
+    }
+
+    [CompileTime]
+    internal class CompileTimeClass
+    {
+        public int Field = 42;
+
+        public string Property { get; set; } = "hello";
+
+        public List<int> ListField = new List<int>();
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/FieldAndPropertyInitializers.cs.html
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/FieldAndPropertyInitializers.cs.html
@@ -1,0 +1,99 @@
+
+<html>
+    <head>
+        <style>
+            .cr-CompileTime,
+            .cr-Conflict,
+            .cr-TemplateKeyword,
+            .cr-Dynamic,
+            .cr-CompileTimeVariable,
+            .cr-GeneratedCode
+            {
+                background-color: rgba(50,50,90,0.1);
+            }
+
+            .cr-NeutralTrivia
+            {
+                background-color: rgba(0,255,0,0.1);
+            }
+
+            .cr-TemplateKeyword
+            {
+                color: rgb(250, 0, 250) !important;
+                font-weight: bold;
+            }
+
+            .cr-Dynamic
+            {
+                text-decoration: underline;
+            }
+
+            .cr-CompileTimeVariable
+            {
+                font-style: italic;
+            }
+
+            .diag-Warning
+            {
+                text-decoration: underline 1px wavy orange;
+            }
+
+            .diag-Error
+            {
+                text-decoration: underline 1px wavy red;
+            }
+
+         .diff-Imaginary {
+                display: block;
+                background-image: repeating-linear-gradient( -45deg, gray, gray 2px, transparent 2px, transparent 8px );
+            }
+
+
+            .legend
+            {
+                margin-top: 100px;
+            }
+        </style>
+    </head>
+    <body><pre><code class="nohighlight"><span class='line-number'>1</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">System</span><span class="cs-operator">.</span><span class="cs-namespace-name">Collections</span><span class="cs-operator">.</span><span class="cs-namespace-name">Generic</span><span class="cs-punctuation">;</span>
+<span class='line-number'>2</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Aspects</span><span class="cs-punctuation">;</span>
+<span class='line-number'>3</span>
+<span class='line-number'>4</span><span class="cs-keyword">namespace</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">AspectTests</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">Formatting</span><span class="cs-operator">.</span><span class="cs-namespace-name">FieldAndPropertyInitializers</span>
+<span class='line-number'>5</span><span class="cs-punctuation">{</span>
+<span class='line-number' data-member='Aspect'>6</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">internal</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">class</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">Aspect</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">:</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">TypeAspect</span>
+<span class='line-number' data-member='Aspect'>7</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">{</span>
+<span class='line-number' data-member='Aspect.IntroducedField'>8</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-punctuation">[</span><span class="cr-CompileTime cs-class-name">Introduce</span><span class="cr-CompileTime cs-punctuation">]</span>
+<span class='line-number' data-member='Aspect.IntroducedField'>9</span><span class="cr-NeutralTrivia">        </span><span class="cs-keyword">public</span> <span class="cs-keyword">string</span> <span class="cs-field-name">IntroducedField</span> <span class="cr-CompileTime cs-operator">=</span><span class="cr-CompileTime"> </span><span class="cr-TemplateKeyword cs-class-name cs-static-symbol">meta</span><span class="cr-TemplateKeyword cs-operator">.</span><span class="cr-TemplateKeyword cs-property-name cs-static-symbol">Target</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-CompileTime cs-property-name">Type</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-CompileTime cs-property-name">Name</span><span class="cs-punctuation">;</span>
+<span class='line-number' data-member='Aspect.IntroducedField'>10</span>
+<span class='line-number' data-member='Aspect.IntroducedProperty'>11</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-punctuation">[</span><span class="cr-CompileTime cs-class-name">Introduce</span><span class="cr-CompileTime cs-punctuation">]</span>
+<span class='line-number' data-member='Aspect.IntroducedProperty'>12</span><span class="cr-NeutralTrivia">        </span><span class="cs-keyword">public</span> <span class="cs-keyword">string</span> <span class="cs-property-name">IntroducedProperty</span> <span class="cs-punctuation">{</span> <span class="cs-keyword">get</span><span class="cs-punctuation">;</span> <span class="cs-keyword">set</span><span class="cs-punctuation">;</span> <span class="cs-punctuation">}</span> <span class="cr-CompileTime cs-operator">=</span><span class="cr-CompileTime"> </span><span class="cr-TemplateKeyword cs-class-name cs-static-symbol">meta</span><span class="cr-TemplateKeyword cs-operator">.</span><span class="cr-TemplateKeyword cs-property-name cs-static-symbol">Target</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-CompileTime cs-property-name">Type</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-CompileTime cs-property-name">Name</span><span class="cs-punctuation">;</span>
+<span class='line-number' data-member='Aspect'>13</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">}</span>
+<span class='line-number' data-member='Aspect'>14</span>
+<span class='line-number' data-member='CompileTimeClass'>15</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">[</span><span class="cr-CompileTime cs-class-name">CompileTime</span><span class="cr-CompileTime cs-punctuation">]</span>
+<span class='line-number' data-member='CompileTimeClass'>16</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">internal</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">class</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">CompileTimeClass</span>
+<span class='line-number' data-member='CompileTimeClass'>17</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">{</span>
+<span class='line-number' data-member='CompileTimeClass.Field'>18</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-keyword">public</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">int</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-field-name">Field</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-operator">=</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-number">42</span><span class="cr-CompileTime cs-punctuation">;</span>
+<span class='line-number' data-member='CompileTimeClass.Field'>19</span>
+<span class='line-number' data-member='CompileTimeClass.Property'>20</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-keyword">public</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">string</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-property-name">Property</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">{</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">get</span><span class="cr-CompileTime cs-punctuation">;</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">set</span><span class="cr-CompileTime cs-punctuation">;</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">}</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-operator">=</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-string">"hello"</span><span class="cr-CompileTime cs-punctuation">;</span>
+<span class='line-number' data-member='CompileTimeClass.Property'>21</span>
+<span class='line-number' data-member='CompileTimeClass.ListField'>22</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-keyword">public</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">List</span><span class="cr-CompileTime cs-punctuation">&lt;</span><span class="cr-CompileTime cs-keyword">int</span><span class="cr-CompileTime cs-punctuation">&gt;</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-field-name">ListField</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-operator">=</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">new</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">List</span><span class="cr-CompileTime cs-punctuation">&lt;</span><span class="cr-CompileTime cs-keyword">int</span><span class="cr-CompileTime cs-punctuation">&gt;();</span>
+<span class='line-number' data-member='CompileTimeClass'>23</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">}</span>
+<span class='line-number'>24</span><span class="cs-punctuation">}</span>
+<span class='line-number'>25</span>
+</code></pre>
+       <p class='legend'>Legend:</p>
+       <pre>
+<span class='cr-Default'>Default</span>
+<span class='cr-RunTime'>RunTime</span>
+<span class='cr-CompileTime'>CompileTime</span>
+<span class='cr-Dynamic'>Dynamic</span>
+<span class='cr-CompileTimeVariable'>CompileTimeVariable</span>
+<span class='cr-TemplateKeyword'>TemplateKeyword</span>
+<span class='cr-Conflict'>Conflict</span>
+<span class='cr-Excluded'>Excluded</span>
+<span class='cr-GeneratedCode'>GeneratedCode</span>
+<span class='cr-SourceCode'>SourceCode</span>
+<span class='cr-NeutralTrivia'>NeutralTrivia</span>
+       </pre>
+   </body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #663: Syntax highlighting was not executed on field and property initializers in template contexts.

### Changes

- **`TextSpanClassifier.VisitFieldDeclaration`**: Now checks if any variable declarator has a template annotation with an initializer, and if so, enters template mode and marks the initializer as RunTime (allowing fine-grained compile-time/run-time classification within the initializer).
- **`TextSpanClassifier.VisitPropertyDeclaration`**: Now also marks the `Initializer` (not just `ExpressionBody`) as RunTime when in template mode, so property initializers in template properties get proper classification.
- **`TextSpanClassifier.VisitEventFieldDeclaration`**: Same fix as field declarations — template event fields with initializers now get proper classification.
- **New test**: `FieldAndPropertyInitializers` formatting test with `[Introduce]` fields and properties using `meta.Target.Type.Name` in initializers, plus a `[CompileTime]` class with initializers. Verifies that `meta.Target` gets `TemplateKeyword` classification and other compile-time expressions get `CompileTime` classification.

## Checklist

- [x] Reproduce the bug (formatting test with field/property initializers)
- [x] Implement the fix
- [x] Add regression test
- [x] All formatting tests pass (34/34)
- [x] Full `Build.ps1 build` for Metalama repo
- [x] Full `Build.ps1 test` for Metalama repo
- [x] Mark PR as ready

— Claude for @gfraiteur