### PR TITLE
Fix stale compile-time cache when renaming files (#730)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
@@ -148,9 +148,13 @@ internal sealed partial class CompileTimeCompilationBuilder
             h.Append( symbol );
         }
 
-        // Hash syntax trees.
+        // Hash syntax trees, including their file paths.
+        // Including file paths ensures that renaming a file invalidates the cache,
+        // even if the content is unchanged. (fix for #730)
         foreach ( var syntaxTree in compileTimeTrees.OrderBy( t => t.FilePath ) )
         {
+            h.Append( syntaxTree.FilePath );
+
             // SourceText.Checksum does not seem to return the same thing at compile time than at run time, so we take use our own algorithm.
             var text = syntaxTree.GetText().ToString();
             h.Append( text );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeCompilationBuilderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeCompilationBuilderTests.cs
@@ -1678,6 +1678,154 @@ public class ReferencedClass
             }
         }
 
+        [Fact]
+        public void CacheInvalidatedAfterRenamingCompileTimeClass()
+        {
+            // Regression test for https://github.com/metalama/Metalama/issues/730
+            // When a user renames a compile-time class (e.g., an aspect) and rebuilds,
+            // the cache should return a miss because the source code has changed.
+            // The old cached compile-time project should NOT be reused.
+
+            const string assemblyName = "TestProject";
+
+            const string codeBeforeRename = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+[assembly: CompileTime]
+public class OldClassName
+{
+    public string GetName() => ""OldClassName"";
+}
+";
+
+            const string codeAfterRename = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+[assembly: CompileTime]
+public class NewClassName
+{
+    public string GetName() => ""NewClassName"";
+}
+";
+
+            using var testContext = this.CreateTestContext();
+            var domain = testContext.Domain;
+
+            DiagnosticBag diagnosticBag = new();
+
+            // Step 1: Build the compile-time project with the old class name.
+            var compilation1 = testContext.CreateCSharpCompilation( codeBeforeRename, assemblyName: assemblyName );
+            var builder1 = new CompileTimeProjectRepository.Builder( domain, testContext.ServiceProvider );
+
+            Assert.True(
+                builder1.TryGetCompileTimeProjectFromCompilation(
+                    compilation1,
+                    null,
+                    diagnosticBag,
+                    false,
+                    testContext.CancellationToken,
+                    out var project1 ) );
+
+            Assert.NotNull( project1 );
+
+            // Read the generated code to verify it contains the old class name.
+            var generatedCode1 = File.ReadAllText( Path.Combine( project1.Directory!, project1.CodeFiles[0].TransformedPath ) );
+            Assert.Contains( "OldClassName", generatedCode1 );
+
+            // Step 2: Build a new compilation with the renamed class but the same assembly name.
+            // Use a new builder to clear the in-memory cache (simulating a new build/IDE session).
+            var compilation2 = testContext.CreateCSharpCompilation( codeAfterRename, assemblyName: assemblyName );
+            var builder2 = new CompileTimeProjectRepository.Builder( domain, testContext.ServiceProvider );
+
+            // Step 3: Build the new compile-time project.
+            Assert.True(
+                builder2.TryGetCompileTimeProjectFromCompilation(
+                    compilation2,
+                    null,
+                    diagnosticBag,
+                    false,
+                    testContext.CancellationToken,
+                    out var project2 ) );
+
+            Assert.NotNull( project2 );
+
+            // Verify that the generated code contains the NEW class name, not the old one.
+            // If the cache incorrectly returns stale data, this will contain OldClassName.
+            var generatedCode2 = File.ReadAllText( Path.Combine( project2.Directory!, project2.CodeFiles[0].TransformedPath ) );
+            Assert.Contains( "NewClassName", generatedCode2 );
+            Assert.DoesNotContain( "OldClassName", generatedCode2 );
+        }
+
+        [Fact]
+        public void CacheInvalidatedAfterRenamingCompileTimeFile()
+        {
+            // Regression test for https://github.com/metalama/Metalama/issues/730
+            // When a user renames a file containing compile-time code (without changing its content),
+            // the cached compile-time project should reference the correct file paths.
+
+            const string assemblyName = "TestProject";
+
+            const string code = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+[assembly: CompileTime]
+public class MyAspect
+{
+    public string GetName() => ""MyAspect"";
+}
+";
+
+            using var testContext = this.CreateTestContext();
+            var domain = testContext.Domain;
+
+            DiagnosticBag diagnosticBag = new();
+
+            // Step 1: Build the compile-time project with the old file name.
+            var compilation1 = testContext.CreateCSharpCompilation(
+                new Dictionary<string, string> { { "OldFileName.cs", code } },
+                assemblyName: assemblyName );
+
+            var builder1 = new CompileTimeProjectRepository.Builder( domain, testContext.ServiceProvider );
+
+            Assert.True(
+                builder1.TryGetCompileTimeProjectFromCompilation(
+                    compilation1,
+                    null,
+                    diagnosticBag,
+                    false,
+                    testContext.CancellationToken,
+                    out var project1 ) );
+
+            Assert.NotNull( project1 );
+
+            // Step 2: Build a new compilation with the same code but a different file name.
+            // Use a new builder to clear the in-memory cache.
+            var compilation2 = testContext.CreateCSharpCompilation(
+                new Dictionary<string, string> { { "NewFileName.cs", code } },
+                assemblyName: assemblyName );
+
+            var builder2 = new CompileTimeProjectRepository.Builder( domain, testContext.ServiceProvider );
+
+            // Step 3: Build the compile-time project with the new file name.
+            Assert.True(
+                builder2.TryGetCompileTimeProjectFromCompilation(
+                    compilation2,
+                    null,
+                    diagnosticBag,
+                    false,
+                    testContext.CancellationToken,
+                    out var project2 ) );
+
+            Assert.NotNull( project2 );
+
+            // Verify the file paths in the compile-time project reference the new file name,
+            // not the old one. If the cache returns stale data, this will reference OldFileName.cs.
+            var allSourcePaths = project2.CodeFiles.SelectAsReadOnlyList( f => f.SourcePath );
+
+            Assert.DoesNotContain( allSourcePaths, path => path.Contains( "OldFileName" ) );
+            Assert.Contains( allSourcePaths, path => path.Contains( "NewFileName" ) );
+        }
+
 #if ROSLYN_4_12_0_OR_GREATER
         [Fact]
         public void TemplateLanguageVersion()

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeCompilationBuilderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeCompilationBuilderTests.cs
@@ -1730,7 +1730,7 @@ public class NewClassName
 
             // Read the generated code to verify it contains the old class name.
             var generatedCode1 = File.ReadAllText( Path.Combine( project1.Directory!, project1.CodeFiles[0].TransformedPath ) );
-            Assert.Contains( "OldClassName", generatedCode1 );
+            Assert.Contains( "OldClassName", generatedCode1, StringComparison.Ordinal );
 
             // Step 2: Build a new compilation with the renamed class but the same assembly name.
             // Use a new builder to clear the in-memory cache (simulating a new build/IDE session).
@@ -1752,8 +1752,8 @@ public class NewClassName
             // Verify that the generated code contains the NEW class name, not the old one.
             // If the cache incorrectly returns stale data, this will contain OldClassName.
             var generatedCode2 = File.ReadAllText( Path.Combine( project2.Directory!, project2.CodeFiles[0].TransformedPath ) );
-            Assert.Contains( "NewClassName", generatedCode2 );
-            Assert.DoesNotContain( "OldClassName", generatedCode2 );
+            Assert.Contains( "NewClassName", generatedCode2, StringComparison.Ordinal );
+            Assert.DoesNotContain( "OldClassName", generatedCode2, StringComparison.Ordinal );
         }
 
         [Fact]
@@ -1820,10 +1820,10 @@ public class MyAspect
 
             // Verify the file paths in the compile-time project reference the new file name,
             // not the old one. If the cache returns stale data, this will reference OldFileName.cs.
-            var allSourcePaths = project2.CodeFiles.SelectAsReadOnlyList( f => f.SourcePath );
+            var allSourcePaths = project2.CodeFiles.SelectAsArray( f => f.SourcePath );
 
-            Assert.DoesNotContain( allSourcePaths, path => path.Contains( "OldFileName" ) );
-            Assert.Contains( allSourcePaths, path => path.Contains( "NewFileName" ) );
+            Assert.DoesNotContain( allSourcePaths, path => path.Contains( "OldFileName", StringComparison.Ordinal ) );
+            Assert.Contains( allSourcePaths, path => path.Contains( "NewFileName", StringComparison.Ordinal ) );
         }
 
 #if ROSLYN_4_12_0_OR_GREATER


### PR DESCRIPTION
## Summary
- Fixes #730: Outdated CompileTime files are used when renaming aspect tests
- The compile-time project cache hash (`ComputeSourceHash`) only hashed the **source text** of syntax trees, not their **file paths**. When a user renamed a file containing compile-time code, the cache returned stale data with old file path references.
- **Fix**: Include `syntaxTree.FilePath` in the source hash computation, so renaming a file invalidates the cache even if the content is unchanged.

## Changes
- `CompileTimeCompilationBuilder.cs`: Added `h.Append( syntaxTree.FilePath )` to `ComputeSourceHash()` to include file paths in the hash
- `CompileTimeCompilationBuilderTests.cs`: Added two regression tests:
  - `CacheInvalidatedAfterRenamingCompileTimeClass` — verifies cache miss when source text changes
  - `CacheInvalidatedAfterRenamingCompileTimeFile` — verifies cache miss when file is renamed (the bug scenario)

## Checklist
- [x] Reproduce the bug with a failing regression test
- [x] Implement the fix (include file paths in source hash computation)
- [x] Run all tests in the solution (1602 passed, 6 skipped, 0 failed)
- [x] Build with `Build.ps1 build` and verify zero warnings
- [x] Run `Build.ps1 test` and verify zero warnings
- [x] Finalize and mark PR as ready

## Test plan
- [x] `CacheInvalidatedAfterRenamingCompileTimeFile` passes (was FAILING before fix)
- [x] `CacheInvalidatedAfterRenamingCompileTimeClass` passes
- [x] All existing cache-related tests pass (33/33 in CompileTimeCompilationBuilderTests)
- [x] Full unit test suite passes (1602/1602)
- [x] Full build produces zero warnings

— Claude for @PostSharpAgent