### PR TITLE
Add regression tests for contract on const field and enum member (#693)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/EnumMember.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/EnumMember.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Contracts.EnumMember;
+
+internal class NotNullAttribute : ContractAspect
+{
+    public override void Validate( dynamic? value )
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException();
+        }
+    }
+}
+
+// <target>
+internal enum E
+{
+    [NotNull]
+    A
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/EnumMember.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/EnumMember.t.cs
@@ -1,0 +1,2 @@
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0037 on `NotNull`: `The aspect 'NotNull' cannot be applied to the field 'E.A' because 'E.A' must be writable.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Field_Const.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Field_Const.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Contracts.Field_Const;
+
+internal class NotNullAttribute : ContractAspect
+{
+    public override void Validate( dynamic? value )
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException();
+        }
+    }
+}
+
+// <target>
+internal class Target
+{
+    [NotNull]
+    private const string name = "Name";
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Field_Const.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Field_Const.t.cs
@@ -1,0 +1,2 @@
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0037 on `NotNull`: `The aspect 'NotNull' cannot be applied to the field 'Target.name' because 'Target.name' must be writable.`


### PR DESCRIPTION
## Summary

- Adds regression tests for applying a `ContractAspect` to a `const` field and an enum member
- Both cases are already handled by existing eligibility checks ("must be writable") in the current codebase
- These tests ensure the fix doesn't regress

Fixes #693

## Checklist

- [x] Reproduce bug (already fixed — eligibility check catches both cases)
- [x] Add regression tests (`Field_Const.cs`, `EnumMember.cs`)
- [x] Tests pass on net8.0 and net48
- [x] Run full Build.ps1 test — all tests pass
- [x] Finalize PR

— Claude for @gfraiteur