### PR TITLE
Fix relative paths in nuget.config (#1414)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
@@ -125,7 +125,7 @@ internal static class NuGetHelper
             }
 
             // Skip values containing environment variables (e.g. %PACKAGEHOME%).
-            if ( value.Contains( '%', StringComparison.Ordinal ) )
+            if ( value.IndexOf( "%", StringComparison.Ordinal ) >= 0 )
             {
                 continue;
             }
@@ -144,7 +144,7 @@ internal static class NuGetHelper
         {
             if ( childIncrement.Name == "clear" )
             {
-                foreach ( var targetElement in target.Elements() )
+                foreach ( var targetElement in target.Elements().ToList() )
                 {
                     targetElement.Remove();
                 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,14 @@ namespace Metalama.Framework.Engine.Utilities;
 
 internal static class NuGetHelper
 {
+    // Sections in nuget.config where the "value" attribute of <add> elements is a local path.
+    private static readonly HashSet<string> _pathSections =
+        new( StringComparer.OrdinalIgnoreCase ) { "fallbackPackageFolders" };
+
+    // Sections where the "value" attribute may be either a URL or a local path.
+    private static readonly HashSet<string> _mixedPathSections =
+        new( StringComparer.OrdinalIgnoreCase ) { "packageSources" };
+
     public static List<string> GetConfigFiles( string projectPath )
     {
         List<string> configFiles = new();
@@ -57,10 +66,73 @@ internal static class NuGetHelper
                 continue;
             }
 
+            var configDirectory = Path.GetDirectoryName( Path.GetFullPath( configFile ) ).AssertNotNull();
+
+            ResolveRelativePaths( document.Root, configDirectory );
+
             MergeChildrenNodes( mergedDocument.Root!, document.Root );
         }
 
         return mergedDocument;
+    }
+
+    private static void ResolveRelativePaths( XElement root, string configDirectory )
+    {
+        foreach ( var section in root.Elements() )
+        {
+            var sectionName = section.Name.LocalName;
+
+            if ( _pathSections.Contains( sectionName ) )
+            {
+                ResolvePathsInSection( section, configDirectory, urlsAllowed: false );
+            }
+            else if ( _mixedPathSections.Contains( sectionName ) )
+            {
+                ResolvePathsInSection( section, configDirectory, urlsAllowed: true );
+            }
+        }
+    }
+
+    private static void ResolvePathsInSection( XElement section, string configDirectory, bool urlsAllowed )
+    {
+        foreach ( var element in section.Elements( "add" ) )
+        {
+            var valueAttribute = element.Attribute( "value" );
+
+            if ( valueAttribute == null )
+            {
+                continue;
+            }
+
+            var value = valueAttribute.Value;
+
+            if ( string.IsNullOrEmpty( value ) )
+            {
+                continue;
+            }
+
+            // Skip URLs.
+            if ( urlsAllowed && Uri.TryCreate( value, UriKind.Absolute, out var uri ) &&
+                 (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps) )
+            {
+                continue;
+            }
+
+            // Skip absolute paths.
+            if ( Path.IsPathRooted( value ) )
+            {
+                continue;
+            }
+
+            // Skip values containing environment variables (e.g. %PACKAGEHOME%).
+            if ( value.Contains( '%', StringComparison.Ordinal ) )
+            {
+                continue;
+            }
+
+            // Resolve the relative path against the config file's directory.
+            valueAttribute.Value = Path.GetFullPath( Path.Combine( configDirectory, value ) );
+        }
     }
 
     private static void MergeChildrenNodes( XElement target, XElement increment )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
@@ -20,6 +20,10 @@ internal static class NuGetHelper
     private static readonly HashSet<string> _mixedPathSections =
         new( StringComparer.OrdinalIgnoreCase ) { "packageSources" };
 
+    // Keys in the <config> section whose values are local paths.
+    private static readonly HashSet<string> _configPathKeys =
+        new( StringComparer.OrdinalIgnoreCase ) { "repositoryPath", "globalPackagesFolder" };
+
     public static List<string> GetConfigFiles( string projectPath )
     {
         List<string> configFiles = new();
@@ -82,18 +86,74 @@ internal static class NuGetHelper
         {
             var sectionName = section.Name.LocalName;
 
-            if ( _pathSections.Contains( sectionName ) )
+            if ( _pathSections.Contains( sectionName ) || _mixedPathSections.Contains( sectionName ) )
             {
-                ResolvePathsInSection( section, configDirectory, urlsAllowed: false );
+                ResolvePathsInSection( section, configDirectory );
             }
-            else if ( _mixedPathSections.Contains( sectionName ) )
+            else if ( string.Equals( sectionName, "config", StringComparison.OrdinalIgnoreCase ) )
             {
-                ResolvePathsInSection( section, configDirectory, urlsAllowed: true );
+                ResolvePathsInConfigSection( section, configDirectory );
             }
         }
     }
 
-    private static void ResolvePathsInSection( XElement section, string configDirectory, bool urlsAllowed )
+    private static bool TryResolveRelativePath( string value, string configDirectory, out string resolvedPath )
+    {
+        resolvedPath = value;
+
+        if ( string.IsNullOrEmpty( value ) )
+        {
+            return false;
+        }
+
+        // Skip absolute URIs (http, https, file, ftp, etc.).
+        // On Windows, Uri.TryCreate parses "C:\foo" with scheme="c" (drive letter), so we
+        // exclude single-letter schemes to avoid treating drive-letter paths as URIs.
+        if ( Uri.TryCreate( value, UriKind.Absolute, out var uri ) && uri.Scheme.Length > 1 )
+        {
+            return false;
+        }
+
+        // Skip absolute paths.
+        if ( Path.IsPathRooted( value ) )
+        {
+            return false;
+        }
+
+        // Handle environment variable references (%VAR%).
+        // Expand to check whether the result is absolute. If the variable is undefined,
+        // ExpandEnvironmentVariables leaves the %VAR% token as-is — we must not resolve it.
+        var expandedValue = Environment.ExpandEnvironmentVariables( value );
+
+        if ( expandedValue.IndexOf( "%", StringComparison.Ordinal ) >= 0 )
+        {
+            // The expanded value still contains '%', meaning at least one env var is undefined.
+            // NuGet will use the literal value, so we should not resolve it.
+            return false;
+        }
+
+        if ( !string.Equals( expandedValue, value, StringComparison.Ordinal ) )
+        {
+            // The value contained environment variables that were all resolved.
+            // After expansion, the path may be absolute.
+            if ( Path.IsPathRooted( expandedValue ) )
+            {
+                return false;
+            }
+
+            // Environment variable resolved to a relative path — resolve the expanded value.
+            resolvedPath = Path.GetFullPath( Path.Combine( configDirectory, expandedValue ) );
+
+            return true;
+        }
+
+        // Resolve the relative path against the config file's directory.
+        resolvedPath = Path.GetFullPath( Path.Combine( configDirectory, value ) );
+
+        return true;
+    }
+
+    private static void ResolvePathsInSection( XElement section, string configDirectory )
     {
         foreach ( var element in section.Elements( "add" ) )
         {
@@ -104,34 +164,34 @@ internal static class NuGetHelper
                 continue;
             }
 
-            var value = valueAttribute.Value;
+            if ( TryResolveRelativePath( valueAttribute.Value, configDirectory, out var resolvedPath ) )
+            {
+                valueAttribute.Value = resolvedPath;
+            }
+        }
+    }
 
-            if ( string.IsNullOrEmpty( value ) )
+    private static void ResolvePathsInConfigSection( XElement configSection, string configDirectory )
+    {
+        foreach ( var element in configSection.Elements( "add" ) )
+        {
+            var keyAttribute = element.Attribute( "key" );
+            var valueAttribute = element.Attribute( "value" );
+
+            if ( keyAttribute == null || valueAttribute == null )
             {
                 continue;
             }
 
-            // Skip URLs.
-            if ( urlsAllowed && Uri.TryCreate( value, UriKind.Absolute, out var uri ) &&
-                 (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps) )
+            if ( !_configPathKeys.Contains( keyAttribute.Value ) )
             {
                 continue;
             }
 
-            // Skip absolute paths.
-            if ( Path.IsPathRooted( value ) )
+            if ( TryResolveRelativePath( valueAttribute.Value, configDirectory, out var resolvedPath ) )
             {
-                continue;
+                valueAttribute.Value = resolvedPath;
             }
-
-            // Skip values containing environment variables (e.g. %PACKAGEHOME%).
-            if ( value.IndexOf( "%", StringComparison.Ordinal ) >= 0 )
-            {
-                continue;
-            }
-
-            // Resolve the relative path against the config file's directory.
-            valueAttribute.Value = Path.GetFullPath( Path.Combine( configDirectory, value ) );
         }
     }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
@@ -143,6 +143,163 @@ public class NuGetHelperTests : UnitTestClass
     }
 
     [Fact]
+    public void FileUrlsAreNotModified()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string content = """
+                               <configuration>
+                                   <packageSources>
+                                       <clear />
+                                       <add key="local" value="file://C:/local-packages" />
+                                   </packageSources>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var localElement = mergedConfig.Root.AssertNotNull()
+            .Element( "packageSources" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "local" );
+
+        var value = localElement.Attribute( "value" ).AssertNotNull().Value;
+
+        Assert.Equal( "file://C:/local-packages", value );
+    }
+
+    [Fact]
+    public void EnvironmentVariablePathsAreNotResolved()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string content = """
+                               <configuration>
+                                   <packageSources>
+                                       <clear />
+                                       <add key="envSource" value="%MY_NUGET_SOURCE_UNDEFINED_VAR%" />
+                                   </packageSources>
+                                   <fallbackPackageFolders>
+                                       <add key="envFallback" value="%MY_NUGET_FALLBACK_UNDEFINED_VAR%" />
+                                   </fallbackPackageFolders>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var envSourceElement = mergedConfig.Root.AssertNotNull()
+            .Element( "packageSources" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "envSource" );
+
+        var envFallbackElement = mergedConfig.Root.AssertNotNull()
+            .Element( "fallbackPackageFolders" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "envFallback" );
+
+        // Undefined environment variables should not be modified — NuGet handles expansion at runtime.
+        Assert.Equal( "%MY_NUGET_SOURCE_UNDEFINED_VAR%", envSourceElement.Attribute( "value" ).AssertNotNull().Value );
+        Assert.Equal( "%MY_NUGET_FALLBACK_UNDEFINED_VAR%", envFallbackElement.Attribute( "value" ).AssertNotNull().Value );
+    }
+
+    [Fact]
+    public void ConfigRepositoryPathRelativePathIsResolvedToAbsolute()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string content = """
+                               <configuration>
+                                   <config>
+                                       <add key="repositoryPath" value="packages/repo" />
+                                   </config>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var repoPathElement = mergedConfig.Root.AssertNotNull()
+            .Element( "config" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "repositoryPath" );
+
+        var value = repoPathElement.Attribute( "value" ).AssertNotNull().Value;
+        var expectedAbsolutePath = Path.Combine( testContext.BaseDirectory, "packages", "repo" );
+
+        Assert.Equal( expectedAbsolutePath, value );
+    }
+
+    [Fact]
+    public void ConfigGlobalPackagesFolderRelativePathIsResolvedToAbsolute()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string content = """
+                               <configuration>
+                                   <config>
+                                       <add key="globalPackagesFolder" value="my-packages" />
+                                   </config>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var element = mergedConfig.Root.AssertNotNull()
+            .Element( "config" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "globalPackagesFolder" );
+
+        var value = element.Attribute( "value" ).AssertNotNull().Value;
+        var expectedAbsolutePath = Path.Combine( testContext.BaseDirectory, "my-packages" );
+
+        Assert.Equal( expectedAbsolutePath, value );
+    }
+
+    [Fact]
+    public void ConfigNonPathKeysAreNotModified()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string content = """
+                               <configuration>
+                                   <config>
+                                       <add key="defaultPushSource" value="https://MyRepo/ES/api/v2/package" />
+                                       <add key="http_proxy" value="host" />
+                                   </config>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var pushSourceElement = mergedConfig.Root.AssertNotNull()
+            .Element( "config" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "defaultPushSource" );
+
+        var proxyElement = mergedConfig.Root.AssertNotNull()
+            .Element( "config" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "http_proxy" );
+
+        Assert.Equal( "https://MyRepo/ES/api/v2/package", pushSourceElement.Attribute( "value" ).AssertNotNull().Value );
+        Assert.Equal( "host", proxyElement.Attribute( "value" ).AssertNotNull().Value );
+    }
+
+    [Fact]
     public void MergeTest()
     {
         using var testContext = this.CreateTestContext();

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
@@ -6,6 +6,7 @@ using Metalama.Framework.Engine;
 using Metalama.Framework.Engine.Utilities;
 using Metalama.Testing.UnitTesting;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Metalama.Framework.Tests.UnitTests.CompileTime;
@@ -13,7 +14,136 @@ namespace Metalama.Framework.Tests.UnitTests.CompileTime;
 public class NuGetHelperTests : UnitTestClass
 {
     [Fact]
-    public void Test()
+    public void RelativeFallbackPackageFoldersAreResolvedToAbsolutePaths()
+    {
+        using var testContext = this.CreateTestContext();
+
+        // Create a nuget.config with a relative path in fallbackPackageFolders, as in issue #1414.
+        const string content = """
+                               <configuration>
+                                   <packageSources>
+                                       <clear />
+                                       <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                                   </packageSources>
+                                   <fallbackPackageFolders>
+                                       <add key="SomeFallback" value="nuget/fallback" />
+                                   </fallbackPackageFolders>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        // The relative path "nuget/fallback" should be resolved to an absolute path
+        // relative to the directory containing the nuget.config file.
+        var fallbackElement = mergedConfig.Root.AssertNotNull()
+            .Element( "fallbackPackageFolders" ).AssertNotNull()
+            .Element( "add" ).AssertNotNull();
+
+        var value = fallbackElement.Attribute( "value" ).AssertNotNull().Value;
+        var expectedAbsolutePath = Path.Combine( testContext.BaseDirectory, "nuget", "fallback" );
+
+        Assert.Equal( expectedAbsolutePath, value );
+    }
+
+    [Fact]
+    public void RelativePackageSourcePathsAreResolvedToAbsolutePaths()
+    {
+        using var testContext = this.CreateTestContext();
+
+        // A nuget.config with a relative local package source path.
+        const string content = """
+                               <configuration>
+                                   <packageSources>
+                                       <clear />
+                                       <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                                       <add key="LocalPackages" value="packages/local" />
+                                   </packageSources>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var localSourceElement = mergedConfig.Root.AssertNotNull()
+            .Element( "packageSources" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "LocalPackages" );
+
+        var value = localSourceElement.Attribute( "value" ).AssertNotNull().Value;
+        var expectedAbsolutePath = Path.Combine( testContext.BaseDirectory, "packages", "local" );
+
+        Assert.Equal( expectedAbsolutePath, value );
+    }
+
+    [Fact]
+    public void AbsolutePathsAreNotModified()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var absolutePath = Path.Combine( testContext.BaseDirectory, "abs", "fallback" );
+
+        var content = $"""
+                       <configuration>
+                           <packageSources>
+                               <clear />
+                               <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                           </packageSources>
+                           <fallbackPackageFolders>
+                               <add key="SomeFallback" value="{absolutePath}" />
+                           </fallbackPackageFolders>
+                       </configuration>
+                       """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var fallbackElement = mergedConfig.Root.AssertNotNull()
+            .Element( "fallbackPackageFolders" ).AssertNotNull()
+            .Element( "add" ).AssertNotNull();
+
+        var value = fallbackElement.Attribute( "value" ).AssertNotNull().Value;
+
+        Assert.Equal( absolutePath, value );
+    }
+
+    [Fact]
+    public void HttpUrlsAreNotModified()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string content = """
+                               <configuration>
+                                   <packageSources>
+                                       <clear />
+                                       <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                                   </packageSources>
+                               </configuration>
+                               """;
+
+        var configPath = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( configPath, content );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( configPath ) ).AssertNotNull();
+
+        var nugetOrgElement = mergedConfig.Root.AssertNotNull()
+            .Element( "packageSources" ).AssertNotNull()
+            .Elements( "add" )
+            .First( e => e.Attribute( "key" )?.Value == "nuget.org" );
+
+        var value = nugetOrgElement.Attribute( "value" ).AssertNotNull().Value;
+
+        Assert.Equal( "https://api.nuget.org/v3/index.json", value );
+    }
+
+    [Fact]
+    public void MergeTest()
     {
         using var testContext = this.CreateTestContext();
 

--- a/Metalama.Framework/src/tests/Standalone/Issue1414/Class1.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1414/Class1.cs
@@ -1,0 +1,5 @@
+// Standalone repro for issue #1414: Metalama fails when nuget.config
+// contains a relative path in fallbackPackageFolders.
+internal class Class1
+{
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1414/Class1.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1414/Class1.cs
@@ -1,5 +1,20 @@
 // Standalone repro for issue #1414: Metalama fails when nuget.config
 // contains a relative path in fallbackPackageFolders.
+
+using Metalama.Framework.Aspects;
+
 internal class Class1
 {
+    [Log]
+    public void DoWork() { }
+}
+
+internal class LogAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( $"Executing {meta.Target.Method.Name}" );
+
+        return meta.Proceed();
+    }
 }

--- a/Metalama.Framework/src/tests/Standalone/Issue1414/Class1.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1414/Class1.cs
@@ -1,12 +1,18 @@
 // Standalone repro for issue #1414: Metalama fails when nuget.config
 // contains a relative path in fallbackPackageFolders.
 
+using System;
 using Metalama.Framework.Aspects;
 
 internal class Class1
 {
+    private int _counter;
+
     [Log]
-    public void DoWork() { }
+    public void DoWork()
+    {
+        _counter++;
+    }
 }
 
 internal class LogAttribute : OverrideMethodAspect

--- a/Metalama.Framework/src/tests/Standalone/Issue1414/Issue1414.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1414/Issue1414.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <MetalamaEnabled>true</MetalamaEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metalama.Framework" />
+  </ItemGroup>
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1414/nuget.config
+++ b/Metalama.Framework/src/tests/Standalone/Issue1414/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Standalone repro for issue #1414: relative paths in fallbackPackageFolders. -->
+<configuration>
+  <fallbackPackageFolders>
+    <add key="SomeFallback" value="nuget/fallback" />
+  </fallbackPackageFolders>
+</configuration>

--- a/Metalama.Framework/src/tests/Standalone/Issue1414/test.json
+++ b/Metalama.Framework/src/tests/Standalone/Issue1414/test.json
@@ -1,0 +1,3 @@
+{
+    "BuildOnly": true
+}


### PR DESCRIPTION
## Summary

Fixes #1414 — Metalama fails when `nuget.config` contains relative paths in `fallbackPackageFolders`, `packageSources`, or `<config>` section keys.

When `CompileTimeAssemblyLocator` copies the merged `nuget.config` to a temp directory, relative paths are interpreted against the temp directory instead of the original config file's directory.

### Changes

**`NuGetHelper.cs`**: Refactored path resolution into a shared `TryResolveRelativePath` method that handles:
- **Relative paths** → resolved to absolute paths against the config file's directory
- **Absolute paths** → preserved unchanged
- **Absolute URIs** (http, https, file, ftp, etc.) → preserved unchanged (drive-letter paths like `C:\foo` are excluded from URI detection)
- **Environment variables** → expanded with `Environment.ExpandEnvironmentVariables`; if any var is undefined (literal `%VAR%` remains), the value is left unchanged for NuGet to handle at runtime

Supports path resolution in:
- `<packageSources>` — local file paths
- `<fallbackPackageFolders>` — the reported bug
- `<config>` section keys: `repositoryPath`, `globalPackagesFolder` (per [NuGet config spec](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file))

Also preserves the `<clear/>` iteration fix from the initial commit (materializing `Elements()` with `.ToList()`).

## Checklist

- [x] Reproduce bug with failing regression tests
- [x] Implement fix in NuGetHelper
- [x] Address review feedback (file:// URIs, env var expansion, config section, additional tests)
- [x] Build and test (0 warnings, all tests pass)
- [x] Finalize

## Test plan

- [x] `RelativeFallbackPackageFoldersAreResolvedToAbsolutePaths` — reproduces the reported bug
- [x] `RelativePackageSourcePathsAreResolvedToAbsolutePaths` — relative local source paths
- [x] `AbsolutePathsAreNotModified` — absolute paths preserved
- [x] `HttpUrlsAreNotModified` — HTTPS URLs preserved
- [x] `FileUrlsAreNotModified` — file:// URLs preserved
- [x] `EnvironmentVariablePathsAreNotResolved` — undefined %VAR% preserved
- [x] `ConfigRepositoryPathRelativePathIsResolvedToAbsolute` — config section repositoryPath
- [x] `ConfigGlobalPackagesFolderRelativePathIsResolvedToAbsolute` — config section globalPackagesFolder
- [x] `ConfigNonPathKeysAreNotModified` — non-path config keys untouched
- [x] `MergeTest` — existing merge test still passes
- [x] Full build (Build.ps1 build) — 0 warnings
- [x] All 1499 unit tests pass (net8.0)

— Claude for @gfraiteur