### PR TITLE
Fix relative NuGet fallbackPackageFolders paths (#1414)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
@@ -109,7 +109,7 @@ internal static class NuGetHelper
 
         if ( value == null
              || Uri.IsWellFormedUriString( value, UriKind.Absolute )
-             || value.IndexOf( '%' ) >= 0 )
+             || value.IndexOf( "%", StringComparison.Ordinal ) >= 0 )
         {
             // Skip null values, absolute URIs (https://...), and values containing
             // environment variable references (%VAR%) since the actual path depends

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
@@ -69,32 +69,63 @@ internal static class NuGetHelper
 
     private static void ResolveRelativePaths( XDocument document, string configFileDirectory )
     {
-        var packageSources = document.Root?.Element( "packageSources" );
+        // Sections where each <add> element's "value" attribute can be a local path.
+        ResolveRelativePathsInSection( document.Root?.Element( "packageSources" ), configFileDirectory );
+        ResolveRelativePathsInSection( document.Root?.Element( "fallbackPackageFolders" ), configFileDirectory );
 
-        if ( packageSources == null )
+        // In the <config> section, specific keys can contain paths.
+        var configSection = document.Root?.Element( "config" );
+
+        if ( configSection != null )
+        {
+            foreach ( var add in configSection.Elements( "add" ) )
+            {
+                var key = add.Attribute( "key" )?.Value;
+
+                if ( key is "repositoryPath" or "globalPackagesFolder" )
+                {
+                    ResolveRelativePathInAttribute( add, configFileDirectory );
+                }
+            }
+        }
+    }
+
+    private static void ResolveRelativePathsInSection( XElement? section, string configFileDirectory )
+    {
+        if ( section == null )
         {
             return;
         }
 
-        foreach ( var add in packageSources.Elements( "add" ) )
+        foreach ( var add in section.Elements( "add" ) )
         {
-            var value = add.Attribute( "value" )?.Value;
+            ResolveRelativePathInAttribute( add, configFileDirectory );
+        }
+    }
 
-            if ( value == null || Uri.IsWellFormedUriString( value, UriKind.Absolute ) )
-            {
-                continue;
-            }
+    private static void ResolveRelativePathInAttribute( XElement element, string configFileDirectory )
+    {
+        var value = element.Attribute( "value" )?.Value;
 
-            if ( Path.IsPathRooted( value ) )
-            {
-                // Already absolute — just normalize separators.
-                add.SetAttributeValue( "value", Path.GetFullPath( value ) );
-            }
-            else
-            {
-                // Relative — resolve against the config file's directory.
-                add.SetAttributeValue( "value", Path.GetFullPath( Path.Combine( configFileDirectory, value ) ) );
-            }
+        if ( value == null
+             || Uri.IsWellFormedUriString( value, UriKind.Absolute )
+             || value.Contains( '%', StringComparison.Ordinal ) )
+        {
+            // Skip null values, absolute URIs (https://...), and values containing
+            // environment variable references (%VAR%) since the actual path depends
+            // on variable expansion at runtime.
+            return;
+        }
+
+        if ( Path.IsPathRooted( value ) )
+        {
+            // Already absolute — just normalize separators.
+            element.SetAttributeValue( "value", Path.GetFullPath( value ) );
+        }
+        else
+        {
+            // Relative — resolve against the config file's directory.
+            element.SetAttributeValue( "value", Path.GetFullPath( Path.Combine( configFileDirectory, value ) ) );
         }
     }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/NuGetHelper.cs
@@ -109,7 +109,7 @@ internal static class NuGetHelper
 
         if ( value == null
              || Uri.IsWellFormedUriString( value, UriKind.Absolute )
-             || value.Contains( '%', StringComparison.Ordinal ) )
+             || value.IndexOf( '%' ) >= 0 )
         {
             // Skip null values, absolute URIs (https://...), and values containing
             // environment variable references (%VAR%) since the actual path depends

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
@@ -295,6 +295,86 @@ public class NuGetHelperTests : UnitTestClass
     }
 
     [Fact]
+    public void ConfigRepositoryPathRelativePathIsResolvedToAbsolute()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string config = """
+                              <configuration>
+                                  <config>
+                                      <add key="repositoryPath" value="packages/installed" />
+                                      <add key="globalPackagesFolder" value="cache/global" />
+                                      <add key="defaultPushSource" value="https://MyRepo/api/v2/package" />
+                                  </config>
+                              </configuration>
+                              """;
+
+        var path = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( path, config );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( path ) ).AssertNotNull().ToString();
+
+        var resolvedRepoPath = Path.GetFullPath( Path.Combine( testContext.BaseDirectory, "packages/installed" ) );
+        var resolvedGlobalPath = Path.GetFullPath( Path.Combine( testContext.BaseDirectory, "cache/global" ) );
+
+        var expectedMergedConfig =
+            $"""
+            <configuration>
+              <config>
+                <add key="repositoryPath" value="{resolvedRepoPath}" />
+                <add key="globalPackagesFolder" value="{resolvedGlobalPath}" />
+                <add key="defaultPushSource" value="https://MyRepo/api/v2/package" />
+              </config>
+            </configuration>
+            """;
+
+        AssertEx.WhitespaceInvariantEqual( expectedMergedConfig, mergedConfig );
+    }
+
+    [Fact]
+    public void EnvironmentVariablePathsAreNotResolved()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string config = """
+                              <configuration>
+                                  <config>
+                                      <add key="repositoryPath" value="%PACKAGEHOME%/External" />
+                                  </config>
+                                  <packageSources>
+                                      <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                                  </packageSources>
+                                  <fallbackPackageFolders>
+                                      <add key="EnvFallback" value="%NUGET_FALLBACK%/packages" />
+                                  </fallbackPackageFolders>
+                              </configuration>
+                              """;
+
+        var path = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( path, config );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( path ) ).AssertNotNull().ToString();
+
+        // Values containing environment variables (%VAR%) should NOT be resolved.
+        var expectedMergedConfig =
+            """
+            <configuration>
+              <config>
+                <add key="repositoryPath" value="%PACKAGEHOME%/External" />
+              </config>
+              <packageSources>
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+              <fallbackPackageFolders>
+                <add key="EnvFallback" value="%NUGET_FALLBACK%/packages" />
+              </fallbackPackageFolders>
+            </configuration>
+            """;
+
+        AssertEx.WhitespaceInvariantEqual( expectedMergedConfig, mergedConfig );
+    }
+
+    [Fact]
     public void ConsolidatedPackageSourceMappingClearRemovesAllInheritedMappings()
     {
         // Reproduces the Metalama.Consolidated + Metalama scenario where:

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/NuGetHelperTests.cs
@@ -254,6 +254,47 @@ public class NuGetHelperTests : UnitTestClass
     }
 
     [Fact]
+    public void FallbackPackageFoldersRelativePathsAreResolvedToAbsolute()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string parentConfig = """
+                                    <configuration>
+                                        <packageSources>
+                                            <clear />
+                                            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                                        </packageSources>
+                                        <fallbackPackageFolders>
+                                            <add key="SomeFallback" value="nuget/fallback" />
+                                        </fallbackPackageFolders>
+                                    </configuration>
+                                    """;
+
+        var path1 = Path.Combine( testContext.BaseDirectory, "nuget.config" );
+        File.WriteAllText( path1, parentConfig );
+
+        var mergedConfig = NuGetHelper.MergeConfigFiles( NuGetHelper.GetConfigFiles( path1 ) ).AssertNotNull().ToString();
+
+        // The relative path "nuget/fallback" should be resolved relative to the config file's directory.
+        var resolvedFallbackPath = Path.GetFullPath( Path.Combine( testContext.BaseDirectory, "nuget/fallback" ) );
+
+        var expectedMergedConfig =
+            $"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+              <fallbackPackageFolders>
+                <add key="SomeFallback" value="{resolvedFallbackPath}" />
+              </fallbackPackageFolders>
+            </configuration>
+            """;
+
+        AssertEx.WhitespaceInvariantEqual( expectedMergedConfig, mergedConfig );
+    }
+
+    [Fact]
     public void ConsolidatedPackageSourceMappingClearRemovesAllInheritedMappings()
     {
         // Reproduces the Metalama.Consolidated + Metalama scenario where:


### PR DESCRIPTION
## Summary

Fixes #1414 — Metalama does not handle relative paths in NuGet `fallbackPackageFolders` correctly.

When Metalama's `CompileTimeAssemblyLocator` copies the user's `nuget.config` to a temp directory to run `dotnet build`, relative paths in `fallbackPackageFolders` (and potentially other path-bearing sections) resolve relative to the temp directory instead of the original project directory, causing `NU1301` errors.

### Changes

**`NuGetHelper.cs`**: Extended `ResolveRelativePaths` to handle all path-bearing nuget.config sections:
- `packageSources` (already handled)
- `fallbackPackageFolders` (new — the reported bug)
- `config/repositoryPath` (new)
- `config/globalPackagesFolder` (new)

Also added logic to skip values containing environment variable references (`%VAR%`) since those depend on runtime expansion.

Refactored path resolution into three focused methods: `ResolveRelativePaths`, `ResolveRelativePathsInSection`, `ResolveRelativePathInAttribute`.

**`NuGetHelperTests.cs`**: Added 3 new regression tests:
- `FallbackPackageFoldersRelativePathsAreResolvedToAbsolute`
- `ConfigRepositoryPathRelativePathIsResolvedToAbsolute`
- `EnvironmentVariablePathsAreNotResolved`

## Checklist

- [x] Reproduce bug with regression test
- [x] Implement fix in NuGetHelper
- [x] Add additional test cases
- [x] Build and test (`Build.ps1 build` + `Build.ps1 test` passed with zero warnings, zero failures)
- [x] Finalize

— Claude for @gfraiteur