### PR TITLE
Complete ServiceLocator NuGet package readme (#651)

### DIFF
--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection.ServiceLocator/README.md
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection.ServiceLocator/README.md
@@ -2,10 +2,19 @@
 
 ## About
 
-The `Metalama.Extensions.DependencyInjection.ServiceLocator` implements an adapter for the _service locator_ dependency injection pattern, in which all services are provided by a global service locator. 
+The `Metalama.Extensions.DependencyInjection.ServiceLocator` implements an adapter for the _service locator_ dependency injection pattern, in which all services are provided by a global service locator.
 
 When you add this package to a project, it automatically configures itself as the default dependency injection framework for Metalama.
 
+## Principal Types
+
+* `ServiceLocatorDependencyInjectionFramework` is the adapter that implements the service locator pattern for use with the `[IntroduceDependency]` advice attribute.
+* `ServiceProviderProvider` is a static class whose `ServiceProvider` property must be set to the application's `IServiceProvider` in order for the service locator to resolve dependencies at run time.
+
+## Documentation
+
+* [Conceptual Documentation](https://doc.metalama.net/conceptual/aspects/dependency-injection)
+* [API Documentation](https://doc.metalama.net/api/metalama_extensions_dependencyinjection_servicelocator)
 
 ## Related Packages
 


### PR DESCRIPTION
## Summary

Fixes #651 — The NuGet package readme for `Metalama.Extensions.DependencyInjection.ServiceLocator` was incomplete.

- Added **Principal Types** section documenting `ServiceLocatorDependencyInjectionFramework` and `ServiceProviderProvider`
- Added **Documentation** section with links to conceptual and API documentation

The readme now follows the same pattern as the parent `Metalama.Extensions.DependencyInjection` package readme.

## Checklist

- [x] Understand the issue
- [x] Implement fix
- [x] Build succeeds
- [x] Finalize PR

## Test plan

- [x] Verify `Build.ps1 build` completes without errors
- [x] Verify the README.md is packed into the NuGet package
- [x] Verify documentation links resolve correctly