### PR TITLE
Add verification tests for WithNamespace with dotted names (#615)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedName.C.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedName.C.i.cs
@@ -1,0 +1,7 @@
+namespace Foo.Bar
+{
+  class C
+  {
+    private global::System.Int32 f;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedName.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedName.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.DottedName;
+
+// WithNamespace with a dotted namespace name should create proper nested namespaces.
+[assembly: IntroduceTypeAspect]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.DottedName
+{
+    public class IntroduceTypeAspectAttribute : CompilationAspect
+    {
+        public override void BuildAspect( IAspectBuilder<ICompilation> builder )
+        {
+            var c = builder.WithNamespace( "Foo.Bar" ).IntroduceClass( "C" );
+
+            c.IntroduceField( "f", typeof(int) );
+        }
+    }
+
+    #pragma warning disable CS8618
+
+    // <target>
+    public class TargetType { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedName.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedName.t.cs
@@ -1,0 +1,4 @@
+[assembly: IntroduceTypeAspect]
+public class TargetType
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedNameAdviceFactory.C.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedNameAdviceFactory.C.i.cs
@@ -1,0 +1,7 @@
+namespace Foo.Bar
+{
+  class C
+  {
+    private global::System.Int32 f;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedNameAdviceFactory.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedNameAdviceFactory.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.DottedNameAdviceFactory;
+
+// WithNamespace using IAdviceFactory.WithNamespace(INamespace, string) with a dotted namespace name.
+[assembly: IntroduceTypeAspect]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Namespaces.DottedNameAdviceFactory
+{
+    public class IntroduceTypeAspectAttribute : CompilationAspect
+    {
+        public override void BuildAspect( IAspectBuilder<ICompilation> builder )
+        {
+#pragma warning disable CS0618 // Testing obsolete IAdviceFactory.WithNamespace API
+            var c = builder.Advice.WithNamespace( builder.Target.GlobalNamespace, "Foo.Bar" ).IntroduceClass( "C" );
+
+            c.IntroduceField( "f", typeof(int) );
+        }
+    }
+
+    #pragma warning disable CS8618
+
+    // <target>
+    public class TargetType { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedNameAdviceFactory.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Namespaces/DottedNameAdviceFactory.t.cs
@@ -1,0 +1,4 @@
+[assembly: IntroduceTypeAspect]
+public class TargetType
+{
+}


### PR DESCRIPTION
## Summary
- Adds two aspect tests verifying that `WithNamespace` correctly handles dotted namespace names like `"Foo.Bar"`
- Test **DottedName**: Uses `builder.WithNamespace("Foo.Bar")` extension method
- Test **DottedNameAdviceFactory**: Uses `builder.Advice.WithNamespace(globalNamespace, "Foo.Bar")` (the exact pattern from the issue)
- Both tests confirm the bug is already fixed — the class is correctly placed in nested namespace `Foo.Bar`

Closes #615

## Checklist
- [x] Reproduce bug (verified already fixed)
- [x] Write verification tests
- [x] Build (Build.ps1 build) — zero warnings
- [x] Run full tests (Build.ps1 test) — all pass
- [x] Finalize PR

## Test plan
- [x] Verify DottedName test passes
- [x] Verify DottedNameAdviceFactory test passes
- [x] Full build with zero warnings
- [x] Full test suite passes