### PR TITLE
Fix Enhancements().HasAspect on closed generic types (#753)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework/Code/DeclarationEnhancements.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/DeclarationEnhancements.cs
@@ -45,7 +45,11 @@ public readonly struct DeclarationEnhancements<T>
 
     internal DeclarationEnhancements( T declaration )
     {
-        this._declaration = declaration;
+        // When the declaration is a generic type instance (e.g. Foo<int>) or a member of a generic type instance,
+        // redirect to the definition (e.g. Foo<T>), because enhancements are always applied to the definition.
+        this._declaration = declaration is IMemberOrNamedType memberOrNamedType
+            ? (T) (object) memberOrNamedType.Definition
+            : declaration;
     }
 
     private T Declaration => this._declaration ?? throw new InvalidOperationException( $"The DeclarationEnhancements is not initialized." );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Enhancements/HasAspect_GenericType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Enhancements/HasAspect_GenericType.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Linq;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Enhancements.HasAspect_GenericType;
+
+internal class MyAspect : TypeAspect
+{
+    [Introduce]
+    private void Introduced()
+    {
+        Console.WriteLine( "Introduced" );
+    }
+}
+
+internal class CheckerAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        base.BuildAspect( builder );
+
+        // Find the field of type Foo<int>, which is a closed generic instance.
+        var fooIntField = builder.Target.Fields.Single( f => f.Name == "_fooInt" );
+        var fooIntType = (INamedType) fooIntField.Type;
+
+        // This should return true because MyAspect is applied to Foo<T> (the open generic type).
+        // Bug #753: This currently returns false for the closed generic instance.
+        if ( !fooIntType.Enhancements().HasAspect<MyAspect>() )
+        {
+            throw new InvalidOperationException(
+                $"HasAspect<MyAspect>() returned false for closed generic type '{fooIntType}', but the aspect is applied to the open generic type definition." );
+        }
+
+        // Also verify the non-generic overload.
+        if ( !fooIntType.Enhancements().HasAspect( typeof(MyAspect) ) )
+        {
+            throw new InvalidOperationException(
+                $"HasAspect(typeof(MyAspect)) returned false for closed generic type '{fooIntType}', but the aspect is applied to the open generic type definition." );
+        }
+    }
+}
+
+[MyAspect]
+internal class Foo<T>
+{
+    public T? Value { get; set; }
+}
+
+// <target>
+[CheckerAspect]
+internal partial class TargetCode
+{
+    private Foo<int> _fooInt = new();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Enhancements/HasAspect_GenericType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Enhancements/HasAspect_GenericType.t.cs
@@ -1,0 +1,5 @@
+[CheckerAspect]
+internal partial class TargetCode
+{
+    private Foo<int> _fooInt = new();
+}


### PR DESCRIPTION
Fixes #753

## Summary
- `Enhancements().HasAspect()` on a closed generic type (e.g., `Foo<int>`) did not consider aspects applied to the open generic type definition (`Foo<T>`).
- Per @gfraiteur's guidance, `Enhancements()` now always redirects to the enhancements of the type definition by resolving `IMemberOrNamedType.Definition` in the `DeclarationEnhancements<T>` constructor.

## Changes
- **`DeclarationEnhancements.cs`**: Modified the constructor to redirect to `IMemberOrNamedType.Definition` when the declaration is a member or named type. For non-generic types, `Definition` returns `this`, so there is no behavioral change.
- **`HasAspect_GenericType.cs`**: Added regression test that verifies `HasAspect<MyAspect>()` returns `true` when called on a closed generic type `Foo<int>` where `[MyAspect]` is applied to the open generic type `Foo<T>`.

## Progress
- [x] Reproduce the bug with a failing test
- [x] Implement the fix
- [x] Build and test (zero warnings, all tests pass)
- [x] Finalize

## Test plan
- Regression test `HasAspect_GenericType` verifies both `HasAspect<MyAspect>()` and `HasAspect(typeof(MyAspect))` return `true` on closed generic types.
- All 2069 existing aspect tests continue to pass with zero regressions.