### PR TITLE
Fix AllMethods cache invalidation on mutable compilation (#749)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/AllMemberOrNamedTypesCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Collections/AllMemberOrNamedTypesCollection.cs
@@ -8,7 +8,6 @@ using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Services;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace Metalama.Framework.Engine.CodeModel.Collections;
 
@@ -17,6 +16,7 @@ internal abstract class AllMemberOrNamedTypesCollection<TItem, TCollection> : IM
     where TCollection : class, IMemberOrNamedTypeCollection<TItem>
 {
     private volatile HashSet<TItem>? _members;
+    private volatile int _cachedRevision = -1;
 
     protected AllMemberOrNamedTypesCollection( INamedType declaringType )
     {
@@ -63,9 +63,15 @@ internal abstract class AllMemberOrNamedTypesCollection<TItem, TCollection> : IM
 
     private HashSet<TItem> GetItems()
     {
-        if ( this._members == null )
+        var currentRevision = this.DeclaringType.GetCompilationModel().Revision;
+
+        if ( this._members == null || this._cachedRevision != currentRevision )
         {
-            Interlocked.CompareExchange( ref this._members, this.GetItemsCore( null ), null );
+            var members = this.GetItemsCore( null );
+            this._members = members;
+            this._cachedRevision = currentRevision;
+
+            return members;
         }
 
         return this._members;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.Members.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.Members.cs
@@ -45,6 +45,12 @@ public sealed partial class CompilationModel
 
     private bool IsMutable { get; }
 
+    /// <summary>
+    /// Gets the current revision number, which is incremented each time a transformation is added. Used to detect
+    /// cache staleness in collections that cache computed results (e.g. <c>AllMethods</c>).
+    /// </summary>
+    internal int Revision { get; private set; }
+
     private TCollection GetMemberCollection<TOwner, TCollection>(
         ref ImmutableDictionary<IFullRef<TOwner>, TCollection> dictionary,
         bool requestMutableCollection,
@@ -222,6 +228,8 @@ public sealed partial class CompilationModel
         {
             return;
         }
+
+        this.Revision++;
 
         // Replaced declaration should be always removed before adding the replacement.
         // ReSharper disable once ConvertIfStatementToSwitchStatement

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelUpdateTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/CodeModelUpdateTests.cs
@@ -749,6 +749,85 @@ class C
     }
 
     [Fact]
+    public void AddMethodToEmptyType_InitializeBefore_AllMethods_Complete()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string code = @"
+class C
+{
+}";
+
+        var immutableCompilation = testContext.CreateCompilationModel( code );
+        var compilation = immutableCompilation.CreateMutableClone();
+
+        var type = Assert.Single( compilation.Types );
+
+        // Memoize the AllMethods collection before adding a method.
+        var allMethodsBefore = type.AllMethods.Count;
+
+        // Add a method.
+        var methodBuilder = new MethodBuilder( null!, type, "M" );
+        methodBuilder.Freeze();
+        compilation.AddTransformation( methodBuilder.ToTransformation() );
+
+        // Assert that AllMethods reflects the newly added method.
+        Assert.Equal( allMethodsBefore + 1, type.AllMethods.Count );
+        Assert.Single( type.AllMethods.OfName( "M" ) );
+    }
+
+    [Fact]
+    public void AddMethodToEmptyType_DontInitializeBefore_AllMethods_Complete()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string code = @"
+class C
+{
+}";
+
+        var immutableCompilation = testContext.CreateCompilationModel( code );
+        var compilation = immutableCompilation.CreateMutableClone();
+
+        var type = Assert.Single( compilation.Types );
+
+        // Add a method without accessing AllMethods first.
+        var methodBuilder = new MethodBuilder( null!, type, "M" );
+        methodBuilder.Freeze();
+        compilation.AddTransformation( methodBuilder.ToTransformation() );
+
+        // Assert that AllMethods includes the newly added method.
+        Assert.Single( type.AllMethods.OfName( "M" ) );
+    }
+
+    [Fact]
+    public void AddMethodToEmptyType_InitializeBefore_AllMethods_ByName()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string code = @"
+class C
+{
+}";
+
+        var immutableCompilation = testContext.CreateCompilationModel( code );
+        var compilation = immutableCompilation.CreateMutableClone();
+
+        var type = Assert.Single( compilation.Types );
+
+        // Memoize AllMethods.OfName before adding a method.
+        Assert.Empty( type.AllMethods.OfName( "M" ) );
+
+        // Add a method.
+        var methodBuilder = new MethodBuilder( null!, type, "M" );
+        methodBuilder.Freeze();
+        compilation.AddTransformation( methodBuilder.ToTransformation() );
+
+        // Assert that AllMethods.OfName reflects the newly added method.
+        Assert.Single( type.AllMethods.OfName( "M" ) );
+    }
+
+    [Fact]
     public void AddMethodToGenericType_ParameterTypesMappedInDerivedType()
     {
         using var testContext = this.CreateTestContext();


### PR DESCRIPTION
## Summary
- Fixes #749: `AllMethods` returns stale cached results after `IntroduceMethod` is called on a mutable compilation
- Added a `Revision` counter to `CompilationModel` that increments when transformations are added
- `AllMemberOrNamedTypesCollection` now checks this revision before returning cached results, invalidating stale data when the compilation has been modified

## Checklist
- [x] Reproduce bug with failing regression test
- [x] Implement fix
- [x] Build and test (zero warnings, all tests pass)
- [x] Finalize

## Test plan
- [x] Unit test `AddMethodToEmptyType_InitializeBefore_AllMethods_Complete` — confirms the bug is fixed
- [x] Unit test `AddMethodToEmptyType_DontInitializeBefore_AllMethods_Complete` — control test
- [x] Unit test `AddMethodToEmptyType_InitializeBefore_AllMethods_ByName` — tests OfName path
- [x] All 1616 unit tests pass
- [x] `Build.ps1 build` succeeds with zero warnings
- [x] `Build.ps1 test` succeeds with zero warnings