### PR TITLE
Clarify LAMA030x diagnostic messages (#737)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/DesignTimeDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/DesignTimeDiagnosticDescriptors.cs
@@ -21,8 +21,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0301",
                     Error,
-                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
-                    + " Please restart your IDE to fix that.",
+                    "{0}: {1} — Diagnostic '{0}' is new and could not be registered in the current session due to an IDE limitation."
+                    + " Please restart your IDE to see it under its correct ID.",
                     "A Metalama user error." );
 
         internal static readonly DiagnosticDefinition<(string Id, string Message)>
@@ -30,8 +30,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0302",
                     Warning,
-                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
-                    + " Please restart your IDE to fix that.",
+                    "{0}: {1} — Diagnostic '{0}' is new and could not be registered in the current session due to an IDE limitation."
+                    + " Please restart your IDE to see it under its correct ID.",
                     "A Metalama user warning.",
                     _category );
 
@@ -40,8 +40,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0303",
                     Info,
-                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
-                    + " Please restart your IDE to fix that.",
+                    "{0}: {1} — Diagnostic '{0}' is new and could not be registered in the current session due to an IDE limitation."
+                    + " Please restart your IDE to see it under its correct ID.",
                     "A Metalama user info.",
                     _category );
 
@@ -50,8 +50,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0304",
                     Hidden,
-                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
-                    + " Please restart your IDE to fix that.",
+                    "{0}: {1} — Diagnostic '{0}' is new and could not be registered in the current session due to an IDE limitation."
+                    + " Please restart your IDE to see it under its correct ID.",
                     "A Metalama user hidden message.",
                     _category );
 
@@ -60,8 +60,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0306",
                     Warning,
-                    "An aspect tried to suppress the diagnostic {0} on '{1}', but this suppression could not be applied due to a Roslyn limitation."
-                    + " Please restart your IDE to fix that.",
+                    "An aspect tried to suppress diagnostic '{0}' on '{1}', but '{0}' was not registered in the current session due to an IDE limitation."
+                    + " Please restart your IDE to apply the suppression.",
                     "An aspect tried to suppress an unregistered diagnostic.",
                     _category );
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/DesignTimeDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/DesignTimeDiagnosticDescriptors.cs
@@ -21,7 +21,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0301",
                     Error,
-                    "{0}: {1} The diagnostic {0} was not defined in the user profile and has been replaced by a generic diagnostic ID.",
+                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
+                    + " Please restart your IDE to fix that.",
                     "A Metalama user error." );
 
         internal static readonly DiagnosticDefinition<(string Id, string Message)>
@@ -29,8 +30,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0302",
                     Warning,
-                    "{0}: {1} The diagnostic {0} was not defined in the user profile and has been replaced by a generic diagnostic ID. "
-                    + "Please restart your IDE.",
+                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
+                    + " Please restart your IDE to fix that.",
                     "A Metalama user warning.",
                     _category );
 
@@ -39,8 +40,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0303",
                     Info,
-                    "{0}: {1} The diagnostic {0} was not defined in the user profile and has been replaced by a generic diagnostic ID. "
-                    + " Please restart your IDE.",
+                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
+                    + " Please restart your IDE to fix that.",
                     "A Metalama user info.",
                     _category );
 
@@ -49,8 +50,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0304",
                     Hidden,
-                    "{0}: {1} The diagnostic {0} was not defined in the user profile and has been replaced by a generic diagnostic ID."
-                    + " Please restart your IDE.",
+                    "{0}: {1} The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation."
+                    + " Please restart your IDE to fix that.",
                     "A Metalama user hidden message.",
                     _category );
 
@@ -59,8 +60,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 = new(
                     "LAMA0306",
                     Warning,
-                    "An aspect tried to suppress the diagnostic {0} on '{1}', but this diagnostic ID has not been configured for "
-                    + "suppression in the user profile. Please restart your IDE.",
+                    "An aspect tried to suppress the diagnostic {0} on '{1}', but this suppression could not be applied due to a Roslyn limitation."
+                    + " Please restart your IDE to fix that.",
                     "An aspect tried to suppress an unregistered diagnostic.",
                     _category );
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/DiagnosticAnalyzerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/DiagnosticAnalyzerTests.cs
@@ -238,8 +238,8 @@ public sealed class DiagnosticAnalyzerTests( ITestOutputHelper logger ) : Diagno
     [InlineData( "LAMA0304" )]
     public void DiagnosticMessageIsClear( string diagnosticId )
     {
-        // Regression test for #737: The diagnostic messages should not contain the confusing "user profile" wording,
-        // and all severities should tell the user to restart their IDE.
+        // Regression test for #737: The diagnostic messages should mention "IDE limitation" (not "Roslyn limitation"
+        // or "user profile"), and all severities should tell the user to restart their IDE.
         var descriptor = diagnosticId switch
         {
             "LAMA0301" => DesignTimeDiagnosticDescriptors.UserError,
@@ -252,7 +252,9 @@ public sealed class DiagnosticAnalyzerTests( ITestOutputHelper logger ) : Diagno
         var message = string.Format( CultureInfo.InvariantCulture, descriptor.MessageFormat, "TEST01", "Some message." );
 
         Assert.Contains( "restart your IDE", message, StringComparison.OrdinalIgnoreCase );
+        Assert.Contains( "IDE limitation", message, StringComparison.OrdinalIgnoreCase );
         Assert.DoesNotContain( "user profile", message, StringComparison.OrdinalIgnoreCase );
+        Assert.DoesNotContain( "Roslyn limitation", message, StringComparison.OrdinalIgnoreCase );
     }
 
     [Fact]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/DiagnosticAnalyzerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/EndToEnd/DiagnosticAnalyzerTests.cs
@@ -231,6 +231,30 @@ public sealed class DiagnosticAnalyzerTests( ITestOutputHelper logger ) : Diagno
         Assert.Contains( diagnostics, d => d.Id == "LAMA0306" );
     }
 
+    [Theory]
+    [InlineData( "LAMA0301" )]
+    [InlineData( "LAMA0302" )]
+    [InlineData( "LAMA0303" )]
+    [InlineData( "LAMA0304" )]
+    public void DiagnosticMessageIsClear( string diagnosticId )
+    {
+        // Regression test for #737: The diagnostic messages should not contain the confusing "user profile" wording,
+        // and all severities should tell the user to restart their IDE.
+        var descriptor = diagnosticId switch
+        {
+            "LAMA0301" => DesignTimeDiagnosticDescriptors.UserError,
+            "LAMA0302" => DesignTimeDiagnosticDescriptors.UserWarning,
+            "LAMA0303" => DesignTimeDiagnosticDescriptors.UserInfo,
+            "LAMA0304" => DesignTimeDiagnosticDescriptors.UserHidden,
+            _ => throw new ArgumentOutOfRangeException( nameof(diagnosticId) )
+        };
+
+        var message = string.Format( CultureInfo.InvariantCulture, descriptor.MessageFormat, "TEST01", "Some message." );
+
+        Assert.Contains( "restart your IDE", message, StringComparison.OrdinalIgnoreCase );
+        Assert.DoesNotContain( "user profile", message, StringComparison.OrdinalIgnoreCase );
+    }
+
     [Fact]
     public async Task UserWarningIsWrappedWhenNotRegistered()
     {


### PR DESCRIPTION
## Summary
Fixes #737

- Updated LAMA0301-LAMA0304 diagnostic messages to replace confusing "was not defined in the user profile" wording with clearer text: "The diagnostic ID {0} was changed to a generic diagnostic ID due to a Roslyn limitation. Please restart your IDE to fix that."
- Added "Please restart your IDE to fix that." to LAMA0301 (UserError), which previously lacked this guidance.
- Updated LAMA0306 message for consistency: "this suppression could not be applied due to a Roslyn limitation."

## Checklist
- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build (Build.ps1 build) — zero warnings
- [x] Run tests — 1611 passed, 0 failed
- [x] Finalize

## Test plan
- [x] DiagnosticMessageIsClear parameterized test verifies all four LAMA030x messages contain "restart your IDE" and do not contain "user profile"
- [x] Existing UserError and UserWarningIsWrappedWhenNotRegistered tests pass with updated messages
- [x] Full unit test suite passes (1611 passed, 6 skipped, 0 failed)