### PR TITLE
Fix potential NRE in compile-time init-only interface properties (#1431)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
@@ -1032,6 +1032,42 @@ namespace Metalama.Framework.Engine.CompileTime
 
                                     // If the property implicitly implements any interface property with init accessor, we need to add explicit implementation because
                                     // changing it to ordinary setter would cause an error.
+                                    var accessors = new List<AccessorDeclarationSyntax>();
+
+                                    if ( interfaceProperty.GetMethod != null )
+                                    {
+                                        accessors.Add(
+                                            AccessorDeclaration(
+                                                SyntaxKind.GetAccessorDeclaration,
+                                                List<AttributeListSyntax>(),
+                                                TokenList(),
+                                                Token( SyntaxKind.GetKeyword ),
+                                                null,
+                                                ArrowExpressionClause(
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        ThisExpression(),
+                                                        SyntaxFactoryEx.SafeIdentifierName( interfaceProperty.Name ) ) ),
+                                                Token( SyntaxKind.SemicolonToken ) ) );
+                                    }
+
+                                    accessors.Add(
+                                        AccessorDeclaration(
+                                            SyntaxKind.InitAccessorDeclaration,
+                                            List<AttributeListSyntax>(),
+                                            TokenList(),
+                                            Token( SyntaxKind.InitKeyword ),
+                                            null,
+                                            ArrowExpressionClause(
+                                                AssignmentExpression(
+                                                    SyntaxKind.SimpleAssignmentExpression,
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        ThisExpression(),
+                                                        SyntaxFactoryEx.SafeIdentifierName( interfaceProperty.Name ) ),
+                                                    SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ),
+                                            Token( SyntaxKind.SemicolonToken ) ) );
+
                                     yield return
                                         PropertyDeclaration(
                                             List<AttributeListSyntax>(),
@@ -1041,39 +1077,7 @@ namespace Metalama.Framework.Engine.CompileTime
                                                 (NameSyntax) this._syntaxGenerationContext.SyntaxGenerator.TypeSyntax( interfaceProperty.ContainingType ) ),
                                             rewrittenProperty.Identifier,
                                             AccessorList(
-                                                List(
-                                                    new[]
-                                                    {
-                                                        interfaceProperty.GetMethod != null
-                                                            ? AccessorDeclaration(
-                                                                SyntaxKind.GetAccessorDeclaration,
-                                                                List<AttributeListSyntax>(),
-                                                                TokenList(),
-                                                                Token( SyntaxKind.GetKeyword ),
-                                                                null,
-                                                                ArrowExpressionClause(
-                                                                    MemberAccessExpression(
-                                                                        SyntaxKind.SimpleMemberAccessExpression,
-                                                                        ThisExpression(),
-                                                                        SyntaxFactoryEx.SafeIdentifierName( interfaceProperty.Name ) ) ),
-                                                                Token( SyntaxKind.SemicolonToken ) )
-                                                            : null,
-                                                        AccessorDeclaration(
-                                                            SyntaxKind.InitAccessorDeclaration,
-                                                            List<AttributeListSyntax>(),
-                                                            TokenList(),
-                                                            Token( SyntaxKind.InitKeyword ),
-                                                            null,
-                                                            ArrowExpressionClause(
-                                                                AssignmentExpression(
-                                                                    SyntaxKind.SimpleAssignmentExpression,
-                                                                    MemberAccessExpression(
-                                                                        SyntaxKind.SimpleMemberAccessExpression,
-                                                                        ThisExpression(),
-                                                                        SyntaxFactoryEx.SafeIdentifierName( interfaceProperty.Name ) ),
-                                                                    SyntaxFactoryEx.WellKnownIdentifierName( "value" ) ) ),
-                                                            Token( SyntaxKind.SemicolonToken ) )
-                                                    }.WhereNotNull() ) ) );
+                                                List( accessors ) ) );
                                 }
                             }
                         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/CompileTimeInterfaceInitOnlyProperty.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/CompileTimeInterfaceInitOnlyProperty.Dependency.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Serialization;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.CompileTimeInterfaceInitOnlyProperty;
+
+[CompileTime]
+public interface IFace
+{
+    // Property with only an init setter and no getter.
+    // Using string (reference type) to trigger Deserialize_MakeMutable path.
+    string? InitOnlyValue { init; }
+}
+
+[RunTimeOrCompileTime]
+public class ReferenceType : IFace, ICompileTimeSerializable
+{
+    // Implicitly implements IFace.InitOnlyValue (interface has no getter, class has both).
+    public string? InitOnlyValue { get; init; }
+
+    public ReferenceType( string? value )
+    {
+        InitOnlyValue = value;
+    }
+}
+
+[Inheritable]
+public class TestAspect : OverrideMethodAspect
+{
+    public ReferenceType SerializedValue;
+
+    public TestAspect( string? x )
+    {
+        SerializedValue = new ReferenceType( x );
+    }
+
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( meta.CompileTime( SerializedValue.InitOnlyValue ) );
+
+        return meta.Proceed();
+    }
+}
+
+public class BaseClass
+{
+    [TestAspect( "hello" )]
+    public virtual void Foo() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/CompileTimeInterfaceInitOnlyProperty.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/CompileTimeInterfaceInitOnlyProperty.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.CompileTimeInterfaceInitOnlyProperty;
+
+/*
+ * Regression test for #1431: NullReferenceException in ProduceCompileTimeCodeRewriter
+ * when a compile-time interface has a property with only an init setter (no getter).
+ */
+
+// <target>
+public class TargetClass : BaseClass
+{
+    public override void Foo()
+    {
+        Console.WriteLine( "Original" );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/CompileTimeInterfaceInitOnlyProperty.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/CompileTimeInterfaceInitOnlyProperty.t.cs
@@ -1,0 +1,9 @@
+public class TargetClass : BaseClass
+{
+  public override void Foo()
+  {
+    global::System.Console.WriteLine("hello");
+    Console.WriteLine("Original");
+    return;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace `array-with-null` + `.WhereNotNull()` pattern with explicit `List<AccessorDeclarationSyntax>` construction in `ProduceCompileTimeCodeRewriter` when generating explicit interface implementations for properties where the interface declares only an init setter (no getter).
- Add regression test for compile-time interface with init-only property (no getter) implemented by a `[RunTimeOrCompileTime]` serializable type.

Fixes #1431

## Checklist

- [x] Understand the issue
- [x] Write regression test
- [x] Implement fix
- [x] Build (`Build.ps1 build`)
- [x] Test (`Build.ps1 test`)
- [ ] Finalize

## Test plan

- [x] New test `CompileTimeInterfaceInitOnlyProperty` passes
- [x] All existing `Serialization` tests pass (30/30)
- [x] Related `ReferenceType_CompileTimeInterfaceImpl` and `ReferenceType_InterfaceImpl` pass
- [x] Full `Build.ps1 build` succeeds
- [x] Full `Build.ps1 test` succeeds

— Claude for @gfraiteur