### PR TITLE
Fix missing UserCodeExecutionContext during transitive aspect deserialization (#1430)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectsManifest.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectsManifest.cs
@@ -105,11 +105,15 @@ public sealed class TransitiveAspectsManifest : ITransitiveAspectsManifest
         CompilationContext compilationContext,
         string? assemblyName )
     {
-        using var deflate = new DeflateStream( stream, CompressionMode.Decompress );
+        using ( UserCodeExecutionContext.WithContext(
+                   UserCodeExecutionContext.CreateInstance( serviceProvider, UserCodeDescription.Create( "Deserializing" ), compilationContext ) ) )
+        {
+            using var deflate = new DeflateStream( stream, CompressionMode.Decompress );
 
-        var formatter = CompileTimeSerializer.CreateInstance( serviceProvider, compilationContext );
+            var formatter = CompileTimeSerializer.CreateInstance( serviceProvider, compilationContext );
 
-        return (TransitiveAspectsManifest) formatter.Deserialize( deflate, assemblyName ).AssertNotNull();
+            return (TransitiveAspectsManifest) formatter.Deserialize( deflate, assemblyName ).AssertNotNull();
+        }
     }
 
     public IEnumerable<string> InheritableAspectTypes => this.InheritableAspects.Keys;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectsManifest.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectsManifest.cs
@@ -106,7 +106,7 @@ public sealed class TransitiveAspectsManifest : ITransitiveAspectsManifest
         string? assemblyName )
     {
         using ( UserCodeExecutionContext.WithContext(
-                   UserCodeExecutionContext.CreateInstance( serviceProvider, UserCodeDescription.Create( "Deserializing" ), compilationContext ) ) )
+                   UserCodeExecutionContext.CreateInstance( serviceProvider, UserCodeDescription.Create( $"Deserializing transitive aspects [from {assemblyName}]" ), compilationContext ) ) )
         {
             using var deflate = new DeflateStream( stream, CompressionMode.Decompress );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectsManifest.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectsManifest.cs
@@ -105,8 +105,12 @@ public sealed class TransitiveAspectsManifest : ITransitiveAspectsManifest
         CompilationContext compilationContext,
         string? assemblyName )
     {
+        var description = assemblyName != null
+            ? $"Deserializing transitive aspects from '{assemblyName}'."
+            : "Deserializing transitive aspects from a referenced assembly.";
+
         using ( UserCodeExecutionContext.WithContext(
-                   UserCodeExecutionContext.CreateInstance( serviceProvider, UserCodeDescription.Create( $"Deserializing transitive aspects [from {assemblyName}]" ), compilationContext ) ) )
+                   UserCodeExecutionContext.CreateInstance( serviceProvider, UserCodeDescription.Create( description ), compilationContext ) ) )
         {
             using var deflate = new DeflateStream( stream, CompressionMode.Decompress );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Inheritance/CrossAssembly_TypeOf.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Inheritance/CrossAssembly_TypeOf.Dependency.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Inheritance.CrossAssembly_TypeOf
+{
+    // A run-time attribute type. typeof() on this type in compile-time code
+    // will be rewritten to TypeOfResolver.Resolve().
+    public class MarkerAttribute : Attribute { }
+
+    // This [Inheritable] aspect has a static field initialized with typeof(MarkerAttribute).
+    // Since MarkerAttribute is a run-time type, the typeof() gets rewritten to
+    // TypeOfResolver.Resolve() in compile-time code. When this aspect is deserialized
+    // transitively in a consuming project, the static initializer runs and requires
+    // UserCodeExecutionContext to be set up.
+    [Inheritable]
+    public class TypeOfAspect : TypeAspect
+    {
+        private static readonly Type _markerAttributeType = typeof(MarkerAttribute);
+
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            base.BuildAspect( builder );
+
+            // Use the static field in BuildAspect to ensure it's not optimized away.
+            if ( _markerAttributeType != null )
+            {
+                builder.IntroduceMethod( nameof(GetMarkerTypeName), whenExists: OverrideStrategy.Ignore );
+            }
+        }
+
+        [Template]
+        public string GetMarkerTypeName() => _markerAttributeType.Name;
+    }
+
+    [TypeOfAspect]
+    public class BaseClass { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Inheritance/CrossAssembly_TypeOf.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Inheritance/CrossAssembly_TypeOf.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+// Tests that transitive deserialization of an [Inheritable] aspect with a static typeof()
+// field initializer works correctly (requires UserCodeExecutionContext during deserialization).
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Inheritance.CrossAssembly_TypeOf
+{
+    // Inherits TypeOfAspect from BaseClass transitively across assemblies.
+    // This triggers deserialization of TransitiveAspectsManifest.
+    public class DerivedClass : BaseClass { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Inheritance/CrossAssembly_TypeOf.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Inheritance/CrossAssembly_TypeOf.t.cs
@@ -1,0 +1,8 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Inheritance.CrossAssembly_TypeOf
+{
+  // Inherits TypeOfAspect from BaseClass transitively across assemblies.
+  // This triggers deserialization of TransitiveAspectsManifest.
+  public class DerivedClass : BaseClass
+  {
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1430

`TransitiveAspectsManifest.Deserialize()` did not wrap deserialization in a `UserCodeExecutionContext`, unlike `Serialize()` which correctly does. When a consuming project deserializes inherited aspects transitively from a PE reference, any static field initializer in the aspect class that calls `TypeOfResolver.Resolve()` (rewritten from compile-time `typeof()`) triggers `InvalidOperationException: "The MetalamaExecutionContext is not available"`.

The fix wraps the deserialization call in `UserCodeExecutionContext.WithContext()`, matching the existing pattern used by `Serialize()`.

## Changes

- **`TransitiveAspectsManifest.cs`**: Wrapped `Deserialize()` body in `UserCodeExecutionContext.WithContext()`.
- **`CrossAssembly_TypeOf` test**: Added a cross-assembly inheritance aspect test with a `typeof()` reference to a run-time type. Note: the aspect test framework uses `CompilationReference` (not `PortableExecutableReference`), so it exercises the `ITransitiveAspectManifestProvider` path rather than `Deserialize()`. The actual bug only manifests with PE references.

## Checklist

- [x] Implement fix
- [x] Add cross-assembly inheritance test
- [x] Build and verify tests pass
- [ ] Full `Build.ps1 build`
- [ ] Full `Build.ps1 test`
- [ ] Finalize

--- Claude