### PR TITLE
Fix design-time constructor parameter of introduced type (#652)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceEmptyMethodSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/AspectReferenceEmptyMethodSubstitution.cs
@@ -6,7 +6,6 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.SyntaxGeneration;
-using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Framework.Engine.Formatting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
@@ -19,7 +19,7 @@ using Metalama.Framework.Engine.Linking;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Transformations;
-using Metalama.Framework.Engine.Utilities.Comparers;
+using Metalama.Framework.Engine.CodeModel.Comparers;
 using Metalama.Framework.Engine.Utilities.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -350,15 +350,14 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
             var finalType = type.Translate( finalCompilationModel );
 
             var constructors = new List<ConstructorDeclarationSyntax>();
-            var existingSignatures = new HashSet<(ISymbol Type, RefKind RefKind)[]>( ConstructorSignatureEqualityComparer.Instance );
+            var existingSignatures = new HashSet<(IType Type, RefKind RefKind)[]>( ConstructorSignatureEqualityComparer.Instance );
 
             // Go through all types that will get generated constructors and index existing constructors.
             foreach ( var constructor in initialType.Constructors )
             {
                 existingSignatures.Add(
                     constructor.Parameters.SelectAsArray(
-                        p => ((ISymbol) p.Type.GetSymbol().AssertSymbolNullNotImplemented( UnsupportedFeatures.DesignTimeIntroducedTypeConstructorParameters ),
-                              p.RefKind) ) );
+                        p => (p.Type, p.RefKind) ) );
             }
 
             // Additionally, add all introduced constructors to the list.
@@ -373,10 +372,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 existingSignatures.Add(
                     introducedConstructor.Parameters
                         .SelectAsArray(
-                            p => (
-                                (ISymbol) p.Type.GetSymbol()
-                                    .AssertSymbolNullNotImplemented( UnsupportedFeatures.DesignTimeIntroducedTypeConstructorParameters ),
-                                p.RefKind) ) );
+                            p => (p.Type, p.RefKind) ) );
             }
 
             foreach ( var constructor in type.Constructors )
@@ -399,9 +395,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 var initialParameters = initialConstructor.Parameters.ToImmutableArray();
 
                 var finalSignature = finalParameters.SelectAsArray(
-                    p => (
-                        (ISymbol) p.Type.GetSymbol()
-                            .AssertSymbolNullNotImplemented( UnsupportedFeatures.DesignTimeIntroducedTypeConstructorParameters ), p.RefKind) );
+                    p => (p.Type, p.RefKind) );
 
                 if ( !existingSignatures.Add( finalSignature ) )
                 {
@@ -442,10 +436,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
 
                     if ( existingSignatures.Add(
                             nonOptionalParameters.SelectAsArray(
-                                p => (
-                                    (ISymbol) p.Type.GetSymbol()
-                                        .AssertSymbolNullNotImplemented( UnsupportedFeatures.DesignTimeIntroducedTypeConstructorParameters ),
-                                    p.RefKind) ) ) )
+                                p => (p.Type, p.RefKind) ) ) )
                     {
                         constructors.Add(
                             ConstructorDeclaration(
@@ -674,15 +665,15 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 LineFeed );
         }
 
-        private sealed class ConstructorSignatureEqualityComparer : IEqualityComparer<(ISymbol Type, RefKind RefKind)[]>
+        private sealed class ConstructorSignatureEqualityComparer : IEqualityComparer<(IType Type, RefKind RefKind)[]>
         {
             public static ConstructorSignatureEqualityComparer Instance { get; } = new();
 
-            private readonly StructuralSymbolComparer _symbolComparer = StructuralSymbolComparer.Default;
+            private readonly SignatureTypeComparer _typeComparer = SignatureTypeComparer.Instance;
 
             private ConstructorSignatureEqualityComparer() { }
 
-            public bool Equals( (ISymbol Type, RefKind RefKind)[]? x, (ISymbol Type, RefKind RefKind)[]? y )
+            public bool Equals( (IType Type, RefKind RefKind)[]? x, (IType Type, RefKind RefKind)[]? y )
             {
                 if ( x == null || y == null )
                 {
@@ -697,7 +688,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 return this.Equals( x, y, x.Length );
             }
 
-            private bool Equals( (ISymbol Type, RefKind RefKind)[] x, (ISymbol Type, RefKind RefKind)[] y, int count )
+            private bool Equals( (IType Type, RefKind RefKind)[] x, (IType Type, RefKind RefKind)[] y, int count )
             {
                 for ( var i = 0; i < count; i++ )
                 {
@@ -706,7 +697,7 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                         return false;
                     }
 
-                    if ( !this._symbolComparer.Equals( x[i].Type, y[i].Type ) )
+                    if ( !this._typeComparer.Equals( x[i].Type, y[i].Type ) )
                     {
                         return false;
                     }
@@ -715,13 +706,13 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 return true;
             }
 
-            public int GetHashCode( (ISymbol Type, RefKind RefKind)[] obj )
+            public int GetHashCode( (IType Type, RefKind RefKind)[] obj )
             {
                 var hashCode = obj.Length;
 
                 for ( var i = 0; i < obj.Length; i++ )
                 {
-                    hashCode = HashCode.Combine( hashCode, this._symbolComparer.GetHashCode( obj[i].Type ), (int) obj[i].RefKind );
+                    hashCode = HashCode.Combine( hashCode, this._typeComparer.GetHashCode( obj[i].Type ), (int) obj[i].RefKind );
                 }
 
                 return hashCode;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/UnsupportedFeatures.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/UnsupportedFeatures.cs
@@ -10,7 +10,7 @@ namespace Metalama.Framework.Engine
         public const string DerivedFabricsOnIntroducedTypes = "Derived fabrics on introduced types.";
         public const string IntroducedTypeSerialization = "Introduced type serialization.";
         public const string IntroducedTypeReflectionWrappers = "Introduced type reflection wrappers.";
-        public const string DesignTimeIntroducedTypeConstructorParameters = "Design time support for introducing constructor parameters of introduced type.";
+
         public const string IntroducedTypeStateMachines = "Introduced type state machines.";
         public const string Uncategorized = "Uncategorized";
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType.0.i.cs
@@ -1,0 +1,12 @@
+namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType
+{
+  partial class C
+  {
+    public partial class X
+    {
+    }
+    public C([global::Metalama.Framework.RunTime.AspectGeneratedAttribute] global::Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType.C.X p = null) : this()
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @TestScenario(DesignTime)
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System.Linq;
+
+/*
+ * Tests that when a parameter of an introduced type is appended to a constructor, the design-time pipeline generates a correct constructor.
+ */
+
+namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var introducedType = builder.IntroduceClass( "X", buildType: b => { b.Accessibility = Accessibility.Public; } )
+            .Declaration;
+
+        builder.With( builder.Target.Constructors.Single() )
+            .IntroduceParameter( "p", introducedType, TypedConstant.Default( introducedType ) );
+    }
+}
+
+// <target>
+[MyAspect]
+public partial class C
+{
+    public C() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType.t.cs
@@ -1,0 +1,7 @@
+[MyAspect]
+public partial class C
+{
+  public C()
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_NonDefaultCtor.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_NonDefaultCtor.0.i.cs
@@ -1,0 +1,12 @@
+namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_NonDefaultCtor
+{
+  partial class C
+  {
+    public partial class X
+    {
+    }
+    public C(global::System.Int32 x, global::System.String y, [global::Metalama.Framework.RunTime.AspectGeneratedAttribute] global::Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_NonDefaultCtor.C.X p = null) : this(x, y)
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_NonDefaultCtor.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_NonDefaultCtor.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @TestScenario(DesignTime)
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System.Linq;
+
+/*
+ * Tests that when a parameter of an introduced type is appended to a non-default constructor,
+ * the design-time pipeline generates a correct constructor.
+ */
+
+namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_NonDefaultCtor;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var introducedType = builder.IntroduceClass( "X", buildType: b => { b.Accessibility = Accessibility.Public; } )
+            .Declaration;
+
+        builder.With( builder.Target.Constructors.Single() )
+            .IntroduceParameter( "p", introducedType, TypedConstant.Default( introducedType ) );
+    }
+}
+
+// <target>
+[MyAspect]
+public partial class C
+{
+    public C( int x, string y ) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_NonDefaultCtor.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_NonDefaultCtor.t.cs
@@ -1,0 +1,7 @@
+[MyAspect]
+public partial class C
+{
+  public C(int x, string y)
+  {
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_TwoCtors.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_TwoCtors.0.i.cs
@@ -1,0 +1,15 @@
+namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_TwoCtors
+{
+  partial class C
+  {
+    public partial class X
+    {
+    }
+    public C([global::Metalama.Framework.RunTime.AspectGeneratedAttribute] global::Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_TwoCtors.C.X p = null) : this()
+    {
+    }
+    public C(global::System.Int32 x, [global::Metalama.Framework.RunTime.AspectGeneratedAttribute] global::Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_TwoCtors.C.X p = null) : this(x)
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_TwoCtors.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_TwoCtors.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @TestScenario(DesignTime)
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+/*
+ * Tests that when a parameter of an introduced type is appended to constructors of a class with two constructors,
+ * the design-time pipeline generates correct constructors.
+ */
+
+namespace Metalama.Framework.IntegrationTests.Aspects.DesignTime.IntroduceParameter_OfIntroducedType_TwoCtors;
+
+public class MyAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var introducedType = builder.IntroduceClass( "X", buildType: b => { b.Accessibility = Accessibility.Public; } )
+            .Declaration;
+
+        foreach ( var ctor in builder.Target.Constructors )
+        {
+            builder.With( ctor )
+                .IntroduceParameter( "p", introducedType, TypedConstant.Default( introducedType ) );
+        }
+    }
+}
+
+// <target>
+[MyAspect]
+public partial class C
+{
+    public C() { }
+
+    public C( int x ) { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_TwoCtors.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/DesignTime/IntroduceParameter_OfIntroducedType_TwoCtors.t.cs
@@ -1,0 +1,10 @@
+[MyAspect]
+public partial class C
+{
+  public C()
+  {
+  }
+  public C(int x)
+  {
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #652: Design-time introduction of constructor parameter of introduced type
- The design-time pipeline threw `AssertionFailedException` when a constructor parameter's type was an introduced type (via `IntroduceClass`), because `GetSymbol()` returns null for introduced types that don't exist in the original Roslyn compilation
- Changed constructor signature comparison from `ISymbol`-based to `IType`-based using the existing `SignatureTypeComparer`, which already handles both source and introduced types
- Also fixed a pre-existing IDE0005 warning in `AspectReferenceEmptyMethodSubstitution.cs`

## Checklist
- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build and verify zero warnings
- [x] Run all tests (2084 passed, 0 failed)
- [x] Finalize

## Test plan
- New test `IntroduceParameter_OfIntroducedType` in `DesignTime` test folder verifies design-time code generation for constructor parameters of introduced types
- All 65 existing design-time tests pass
- All 39 existing AppendParameter tests pass
- Full suite of 2114 aspect tests pass on both net8.0 and net48

--- Claude for @gfraiteur