### PR TITLE
Fix dotnet host path detection and DevHub assembly loading (#1461, #1462)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
@@ -4,7 +4,6 @@
 
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
-using Metalama.Backstage.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,9 +17,7 @@ namespace Metalama.Backstage.Infrastructure
         private readonly IEnvironmentVariableProvider _environmentVariableProvider;
         private readonly IFileSystem _fileSystem;
         private readonly IRuntimeInformation _runtimeInformation;
-        private readonly IProcessInfo _processInfo;
         private readonly Lazy<string> _dotNetExePath;
-        private readonly Lazy<bool> _isRunningUnderRider;
 
         public string DotNetExePath => this._dotNetExePath.Value;
 
@@ -30,20 +27,29 @@ namespace Metalama.Backstage.Infrastructure
             this._environmentVariableProvider = serviceProvider.GetRequiredBackstageService<IEnvironmentVariableProvider>();
             this._fileSystem = serviceProvider.GetRequiredBackstageService<IFileSystem>();
             this._runtimeInformation = serviceProvider.GetRequiredBackstageService<IRuntimeInformation>();
-            this._processInfo = serviceProvider.GetRequiredBackstageService<IProcessInfo>();
 
-            this._isRunningUnderRider = new Lazy<bool>( this.DetectRider );
             this._dotNetExePath = new Lazy<string>( this.GetDotNetPath );
         }
 
         /// <summary>
-        /// Detects if the current process is running under JetBrains Rider.
-        /// Rider runs in its own dotnet.exe instance and sets DOTNET_ROOT to point to its limited installation,
-        /// which doesn't have the SDK we need. We need to skip environment variable detection in this case.
+        /// Checks whether a dotnet.exe at the given path has an SDK installation (i.e. a <c>sdk</c> subdirectory
+        /// next to the executable). Some hosts (e.g. Visual Studio, Rider) bundle a runtime-only dotnet.exe
+        /// that has no SDK, which would cause <c>dotnet build</c> to fail.
         /// </summary>
-        private bool DetectRider()
+        private bool HasSdk( string dotnetExePath, ILogger? logger )
         {
-            return this._processInfo.ProcessKind == ProcessKind.Rider;
+            var dotnetDir = Path.GetDirectoryName( dotnetExePath );
+            var sdkDir = dotnetDir != null ? Path.Combine( dotnetDir, "sdk" ) : null;
+
+            if ( sdkDir != null && this._fileSystem.DirectoryExists( sdkDir ) )
+            {
+                return true;
+            }
+
+            logger?.Warning?.Log(
+                $"'{dotnetExePath}' exists but its installation has no SDK directory. Ignoring." );
+
+            return false;
         }
 
         private string GetDotNetPath()
@@ -56,58 +62,44 @@ namespace Metalama.Backstage.Infrastructure
 
             logger?.Trace?.Log( $"Looking for {dotnetFileName} path." );
 
-            // We no longer look for the current process being dotnet because of Rider. Rider runs in dotnet.exe, but this
-            // instance of dotnet.exe does not have an SDK installed. So, it is better to ignore the current process as a hint.
-
-            // Check if we're running under Rider.
-            var isRunningUnderRider = this._isRunningUnderRider.Value;
-
-            if ( isRunningUnderRider )
-            {
-                logger?.Trace?.Log(
-                    "Detected JetBrains Rider environment (based on IProcessInfo.ProcessKind == ProcessKind.Rider). Skipping DOTNET_HOST_PATH and DOTNET_ROOT environment variables to avoid using Rider's limited dotnet installation." );
-            }
-
-            // 1. Check DOTNET_HOST_PATH first (highest priority), unless running under Rider.
+            // 1. Check DOTNET_HOST_PATH first (highest priority).
             // This is the absolute path to the dotnet host executable.
-            if ( !isRunningUnderRider )
             {
                 var dotnetHostPath = this._environmentVariableProvider.GetEnvironmentVariable( "DOTNET_HOST_PATH" );
 
                 if ( !string.IsNullOrEmpty( dotnetHostPath ) )
                 {
-                    if ( this._fileSystem.FileExists( dotnetHostPath ) )
+                    if ( this._fileSystem.FileExists( dotnetHostPath ) && this.HasSdk( dotnetHostPath, logger ) )
                     {
                         logger?.Trace?.Log( $"{dotnetFileName} found via DOTNET_HOST_PATH: '{dotnetHostPath}'." );
 
                         return dotnetHostPath;
                     }
-                    else
+                    else if ( !this._fileSystem.FileExists( dotnetHostPath ) )
                     {
                         logger?.Warning?.Log( $"DOTNET_HOST_PATH is set to '{dotnetHostPath}' but the file was not found." );
                     }
                 }
             }
 
-            // 2. Search in installation locations.
+            // 2. Search in installation locations (DOTNET_ROOT env vars, then default locations).
             foreach ( var directory in this.GetDotNetDirectories() )
             {
                 var dotnetPath = Path.Combine( directory, dotnetFileName );
 
-                if ( this._fileSystem.FileExists( dotnetPath ) )
+                if ( this._fileSystem.FileExists( dotnetPath ) && this.HasSdk( dotnetPath, logger ) )
                 {
-                    logger?.Trace?.Log( $"{dotnetFileName} found in default location '{dotnetPath}'." );
+                    logger?.Trace?.Log( $"{dotnetFileName} found in '{dotnetPath}'." );
 
                     return dotnetPath;
                 }
-                else
+                else if ( !this._fileSystem.FileExists( dotnetPath ) )
                 {
-                    logger?.Trace?.Log( $"Looked for {dotnetFileName} in default location '{dotnetPath}' but it did not exist." );
+                    logger?.Trace?.Log( $"Looked for {dotnetFileName} in '{dotnetPath}' but it did not exist." );
                 }
             }
 
-            // Explicitly resolve PATH, because in the Rider process, "dotnet" alone would resolve to Rider's limited dotnet.
-            // While doing so, ignore Rider's ReSharperHost paths, which contain that dotnet.
+            // 3. Explicitly resolve PATH.
             var path = this._environmentVariableProvider.GetEnvironmentVariable( "PATH" );
 
             if ( path != null )
@@ -116,22 +108,15 @@ namespace Metalama.Backstage.Infrastructure
 
                 foreach ( var directory in path.Split( splitCharacter ) )
                 {
-                    if ( directory.ContainsOrdinal( "ReSharperHost" ) )
-                    {
-                        logger?.Trace?.Log( $"Rider directory '{directory}' excluded." );
-
-                        continue;
-                    }
-
                     var dotnetPath = Path.Combine( directory, dotnetFileName );
 
-                    if ( this._fileSystem.FileExists( dotnetPath ) )
+                    if ( this._fileSystem.FileExists( dotnetPath ) && this.HasSdk( dotnetPath, logger ) )
                     {
                         logger?.Trace?.Log( $"{dotnetFileName} found in '{dotnetPath}'." );
 
                         return dotnetPath;
                     }
-                    else
+                    else if ( !this._fileSystem.FileExists( dotnetPath ) )
                     {
                         logger?.Trace?.Log( $"Looked for {dotnetFileName} in '{dotnetPath}', but it did not exist." );
                     }
@@ -146,26 +131,20 @@ namespace Metalama.Backstage.Infrastructure
 
         /// <summary>
         /// Gets the .NET installation directories for the current platform.
-        /// Returns directories in priority order: first based on DOTNET_ROOT environment variables (unless running under Rider), then on default locations.
-        /// Note: DOTNET_HOST_PATH is checked separately before this method, as it specifies the full path to the executable (also skipped when running under Rider).
+        /// Returns directories in priority order: first based on DOTNET_ROOT environment variables, then on default locations.
+        /// Note: DOTNET_HOST_PATH is checked separately before this method, as it specifies the full path to the executable.
         /// Reference: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
         /// </summary>
         /// <returns>A list of directory paths to check for .NET installations.</returns>
         private IEnumerable<string> GetDotNetDirectories()
         {
-            // Skip DOTNET_ROOT environment variables when running under Rider, as Rider overrides them
-            // to point to its own limited dotnet installation which doesn't have the SDK we need.
-            // (DOTNET_HOST_PATH is also skipped when running under Rider - see GetDotNetPath method.)
-            if ( !this._isRunningUnderRider.Value )
+            foreach ( var environmentVariableName in this.GetDotNetRootEnvironmentVariables() )
             {
-                foreach ( var environmentVariableName in this.GetDotNetRootEnvironmentVariables() )
-                {
-                    var environmentVariableValue = this._environmentVariableProvider.GetEnvironmentVariable( environmentVariableName );
+                var environmentVariableValue = this._environmentVariableProvider.GetEnvironmentVariable( environmentVariableName );
 
-                    if ( !string.IsNullOrWhiteSpace( environmentVariableValue ) )
-                    {
-                        yield return environmentVariableValue!;
-                    }
+                if ( !string.IsNullOrWhiteSpace( environmentVariableValue ) )
+                {
+                    yield return environmentVariableValue!;
                 }
             }
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/ProcessUtilities.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/ProcessUtilities.cs
@@ -44,6 +44,7 @@ public static class ProcessUtilities
 
             case "servicehub.roslyncodeanalysisservice":
             case "servicehub.roslyncodeanalysisservices":
+            case "devhub":
                 return ProcessKind.RoslynCodeAnalysisService;
 
             case "servicehub.host":

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoTests.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Infrastructure;
 using Metalama.Backstage.Testing;
@@ -22,6 +21,25 @@ public sealed class PlatformInfoTests : TestsBase
         this._platformInfo = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>();
     }
 
+    /// <summary>
+    /// Creates a dotnet.exe file at the given path with an SDK directory, so it passes the SDK check.
+    /// </summary>
+    private void CreateDotNetWithSdk( string dotnetExePath )
+    {
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.FileSystem.CreateDirectory( Path.Combine( Path.GetDirectoryName( dotnetExePath )!, "sdk" ) );
+    }
+
+    /// <summary>
+    /// Creates a dotnet.exe file at the given path without an SDK directory (runtime-only installation).
+    /// </summary>
+    private void CreateDotNetWithoutSdk( string dotnetExePath )
+    {
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+    }
+
     [Fact]
     public void DOTNET_HOST_PATH_HasHighestPrecedence()
     {
@@ -36,14 +54,69 @@ public sealed class PlatformInfoTests : TestsBase
         this.EnvironmentVariableProvider.Environment["DOTNET_HOST_PATH"] = dotnetHostPath;
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = dotnetRootX64;
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetHostPath )! );
-        this.FileSystem.WriteAllText( dotnetHostPath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetHostPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
 
         // Assert
         Assert.Equal( dotnetHostPath, result );
+    }
+
+    [Fact]
+    public void DOTNET_HOST_PATH_Ignored_WhenNoSdkDirectory()
+    {
+        // Arrange: Visual Studio sets DOTNET_HOST_PATH to its bundled runtime-only dotnet.exe,
+        // which has no SDK. We should skip it and fall back to the default location.
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+
+        const string vsRuntimeDotnet = "C:\\Program Files\\Microsoft Visual Studio\\18\\Professional\\dotnet\\net8.0\\runtime\\dotnet.exe";
+        const string programFiles = "C:\\Program Files";
+        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_HOST_PATH"] = vsRuntimeDotnet;
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
+
+        // Create the VS-bundled dotnet.exe (no sdk directory).
+        this.CreateDotNetWithoutSdk( vsRuntimeDotnet );
+
+        // Create the system dotnet.exe (with SDK).
+        this.CreateDotNetWithSdk( defaultDotnetPath );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert: Should skip VS-bundled dotnet and use system installation.
+        Assert.Equal( defaultDotnetPath, result );
+    }
+
+    [Fact]
+    public void DOTNET_ROOT_Ignored_WhenNoSdkDirectory()
+    {
+        // Arrange: Rider sets DOTNET_ROOT to its own limited dotnet installation without an SDK.
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+
+        const string riderDotnetRoot = "C:\\RiderDotNet";
+        const string programFiles = "C:\\Program Files";
+        var riderDotnetPath = Path.Combine( riderDotnetRoot, "dotnet.exe" );
+        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
+
+        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = riderDotnetRoot;
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
+
+        // Rider's dotnet has no SDK.
+        this.CreateDotNetWithoutSdk( riderDotnetPath );
+
+        // System dotnet has SDK.
+        this.CreateDotNetWithSdk( defaultDotnetPath );
+
+        // Act
+        var result = this._platformInfo.DotNetExePath;
+
+        // Assert: Should skip Rider's DOTNET_ROOT and use system installation.
+        Assert.Equal( defaultDotnetPath, result );
     }
 
     [Fact]
@@ -59,8 +132,7 @@ public sealed class PlatformInfoTests : TestsBase
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = dotnetRootX64;
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -82,8 +154,7 @@ public sealed class PlatformInfoTests : TestsBase
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X86"] = dotnetRootX86;
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -103,8 +174,7 @@ public sealed class PlatformInfoTests : TestsBase
         var dotnetExePath = Path.Combine( dotnetRootX86Paren, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT(x86)"] = dotnetRootX86Paren;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -126,8 +196,7 @@ public sealed class PlatformInfoTests : TestsBase
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_ARM64"] = dotnetRootArm64;
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -147,8 +216,7 @@ public sealed class PlatformInfoTests : TestsBase
         var dotnetExePath = Path.Combine( dotnetRoot, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -168,8 +236,7 @@ public sealed class PlatformInfoTests : TestsBase
         var dotnetExePath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -191,10 +258,8 @@ public sealed class PlatformInfoTests : TestsBase
         var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64DotnetPath )! );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
-        this.FileSystem.WriteAllText( x64DotnetPath, string.Empty );
-        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
+        this.CreateDotNetWithSdk( x64DotnetPath );
+        this.CreateDotNetWithSdk( defaultDotnetPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -211,8 +276,7 @@ public sealed class PlatformInfoTests : TestsBase
         this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
         var dotnetPath = Path.Combine( "/usr/local/share/dotnet", "dotnet" );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetPath )! );
-        this.FileSystem.WriteAllText( dotnetPath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -232,10 +296,8 @@ public sealed class PlatformInfoTests : TestsBase
         var x64DotnetPath = Path.Combine( "/usr/local/share/dotnet", "x64", "dotnet" );
         var defaultDotnetPath = Path.Combine( "/usr/local/share/dotnet", "dotnet" );
 
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64DotnetPath )! );
-        this.FileSystem.WriteAllText( x64DotnetPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
-        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
+        this.CreateDotNetWithSdk( x64DotnetPath );
+        this.CreateDotNetWithSdk( defaultDotnetPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -254,10 +316,8 @@ public sealed class PlatformInfoTests : TestsBase
         var microsoftPath = Path.Combine( "/usr/share/dotnet", "dotnet" );
         var ubuntuPath = Path.Combine( "/usr/lib/dotnet", "dotnet" );
 
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( microsoftPath )! );
-        this.FileSystem.WriteAllText( microsoftPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( ubuntuPath )! );
-        this.FileSystem.WriteAllText( ubuntuPath, string.Empty );
+        this.CreateDotNetWithSdk( microsoftPath );
+        this.CreateDotNetWithSdk( ubuntuPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -274,8 +334,7 @@ public sealed class PlatformInfoTests : TestsBase
         this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
 
         var ubuntuPath = Path.Combine( "/usr/lib/dotnet", "dotnet" );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( ubuntuPath )! );
-        this.FileSystem.WriteAllText( ubuntuPath, string.Empty );
+        this.CreateDotNetWithSdk( ubuntuPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -295,10 +354,8 @@ public sealed class PlatformInfoTests : TestsBase
         var x64Path = Path.Combine( "/usr/share/dotnet", "x64", "dotnet" );
         var defaultPath = Path.Combine( "/usr/share/dotnet", "dotnet" );
 
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64Path )! );
-        this.FileSystem.WriteAllText( x64Path, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultPath )! );
-        this.FileSystem.WriteAllText( defaultPath, string.Empty );
+        this.CreateDotNetWithSdk( x64Path );
+        this.CreateDotNetWithSdk( defaultPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -317,8 +374,7 @@ public sealed class PlatformInfoTests : TestsBase
         var dotnetExePath = Path.Combine( customPath, "dotnet.exe" );
 
         this.EnvironmentVariableProvider.Environment["PATH"] = customPath;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.CreateDotNetWithSdk( dotnetExePath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
@@ -328,24 +384,25 @@ public sealed class PlatformInfoTests : TestsBase
     }
 
     [Fact]
-    public void ReSharperHost_DirectoriesExcluded_FromPATH()
+    public void PATH_SkipsEntriesWithoutSdk()
     {
         // Arrange
         this.RuntimeInformation.Platform = OSPlatform.Windows;
 
-        const string riderPath = "C:\\Users\\test\\AppData\\Local\\JetBrains\\Installations\\ReSharperHost";
+        const string noSdkPath = "C:\\nosdk\\bin";
         const string validPath = "C:\\dotnet\\bin";
-        var dotnetExePath = Path.Combine( validPath, "dotnet.exe" );
+        var noSdkDotnet = Path.Combine( noSdkPath, "dotnet.exe" );
+        var validDotnet = Path.Combine( validPath, "dotnet.exe" );
 
-        this.EnvironmentVariableProvider.Environment["PATH"] = $"{riderPath};{validPath}";
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
-        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+        this.EnvironmentVariableProvider.Environment["PATH"] = $"{noSdkPath};{validPath}";
+        this.CreateDotNetWithoutSdk( noSdkDotnet );
+        this.CreateDotNetWithSdk( validDotnet );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
 
         // Assert
-        Assert.Equal( dotnetExePath, result );
+        Assert.Equal( validDotnet, result );
     }
 
     [Fact]
@@ -375,103 +432,13 @@ public sealed class PlatformInfoTests : TestsBase
 
         this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = dotnetRoot;
         this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( customDotnetPath )! );
-        this.FileSystem.WriteAllText( customDotnetPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
-        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
+        this.CreateDotNetWithSdk( customDotnetPath );
+        this.CreateDotNetWithSdk( defaultDotnetPath );
 
         // Act
         var result = this._platformInfo.DotNetExePath;
 
         // Assert
         Assert.Equal( customDotnetPath, result );
-    }
-
-    [Fact]
-    public void DOTNET_ROOT_Ignored_WhenRiderDetected()
-    {
-        // Arrange
-        this.RuntimeInformation.Platform = OSPlatform.Windows;
-        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
-
-        const string riderDotnetRoot = "C:\\RiderDotNet";
-        const string programFiles = "C:\\Program Files";
-        var riderDotnetPath = Path.Combine( riderDotnetRoot, "dotnet.exe" );
-        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
-
-        // Rider sets DOTNET_ROOT and the process kind is Rider.
-        this.ProcessInfo.ProcessKind = ProcessKind.Rider;
-        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = riderDotnetRoot;
-        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( riderDotnetPath )! );
-        this.FileSystem.WriteAllText( riderDotnetPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
-        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
-
-        // Act
-        var result = this._platformInfo.DotNetExePath;
-
-        // Assert
-        // Should use default location, not Rider's DOTNET_ROOT.
-        Assert.Equal( defaultDotnetPath, result );
-    }
-
-    [Fact]
-    public void DOTNET_ROOT_X64_Ignored_WhenRiderDetected()
-    {
-        // Arrange
-        this.RuntimeInformation.Platform = OSPlatform.Windows;
-        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
-
-        const string riderDotnetRootX64 = "C:\\RiderDotNetX64";
-        const string programFiles = "C:\\Program Files";
-        var riderDotnetPath = Path.Combine( riderDotnetRootX64, "dotnet.exe" );
-        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
-
-        // Rider sets DOTNET_ROOT_X64 and the process kind is Rider.
-        this.ProcessInfo.ProcessKind = ProcessKind.Rider;
-        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT_X64"] = riderDotnetRootX64;
-        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( riderDotnetPath )! );
-        this.FileSystem.WriteAllText( riderDotnetPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
-        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
-
-        // Act
-        var result = this._platformInfo.DotNetExePath;
-
-        // Assert
-        // Should use default location, not Rider's DOTNET_ROOT_X64.
-        Assert.Equal( defaultDotnetPath, result );
-    }
-
-    [Fact]
-    public void DOTNET_HOST_PATH_Ignored_WhenRiderDetected()
-    {
-        // Arrange
-        this.RuntimeInformation.Platform = OSPlatform.Windows;
-        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
-
-        const string dotnetHostPath = "C:\\custom\\host\\dotnet.exe";
-        const string riderDotnetRoot = "C:\\RiderDotNet";
-        const string programFiles = "C:\\Program Files";
-        var defaultDotnetPath = Path.Combine( programFiles, "dotnet", "dotnet.exe" );
-
-        // Rider environment with process kind set to Rider, DOTNET_HOST_PATH and DOTNET_ROOT set.
-        this.ProcessInfo.ProcessKind = ProcessKind.Rider;
-        this.EnvironmentVariableProvider.Environment["DOTNET_HOST_PATH"] = dotnetHostPath;
-        this.EnvironmentVariableProvider.Environment["DOTNET_ROOT"] = riderDotnetRoot;
-        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = programFiles;
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetHostPath )! );
-        this.FileSystem.WriteAllText( dotnetHostPath, string.Empty );
-        this.FileSystem.CreateDirectory( Path.GetDirectoryName( defaultDotnetPath )! );
-        this.FileSystem.WriteAllText( defaultDotnetPath, string.Empty );
-
-        // Act
-        var result = this._platformInfo.DotNetExePath;
-
-        // Assert
-        // DOTNET_HOST_PATH should be ignored when Rider is detected, falling back to default location.
-        Assert.Equal( defaultDotnetPath, result );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ProcessKindHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ProcessKindHelper.cs
@@ -23,6 +23,7 @@ public static class ProcessKindHelper
 
             case "servicehub.roslyncodeanalysisservice":
             case "servicehub.roslyncodeanalysisservices":
+            case "devhub":
                 return ProcessKind.RoslynCodeAnalysisService;
 
             case "csc":

--- a/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ResourceExtractor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ResourceExtractor.cs
@@ -478,10 +478,14 @@ public static class ResourceExtractor
                 log?.AppendLine( $"Loading the embedded assembly '{embeddedAssembly.Path}'." );
 
                 // It seems assemblies loaded into an ALC don't participate in COM type equivalence.
-                // Since we need that for the DesignTime.Contracts assembly, load it without using ALC.
+                // Since we need that for the DesignTime.Contracts assembly in devenv.exe, load it without using ALC.
+                // However, in other processes (DevHub, ServiceHub, compiler), COM type equivalence is not needed
+                // and Assembly.LoadFile causes Microsoft.CodeAnalysis to resolve from the wrong ALC in DevHub,
+                // leading to MissingMethodException/TypeLoadException (#1461).
 
                 // ReSharper disable once StringStartsWithIsCultureSpecific
-                if ( name.StartsWith( $"{_designTimeContractsAssemblyName}," ) )
+                if ( name.StartsWith( $"{_designTimeContractsAssemblyName}," )
+                     && ProcessKindHelper.CurrentProcessKind == ProcessKind.DevEnv )
                 {
                     return Assembly.LoadFile( embeddedAssembly.Path );
                 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/SourceGeneration/AnalysisProcessProjectSourceGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/SourceGeneration/AnalysisProcessProjectSourceGenerator.cs
@@ -6,7 +6,6 @@ using Metalama.Backstage.Utilities;
 using Metalama.Framework.DesignTime.Pipeline;
 using Metalama.Framework.DesignTime.Rpc;
 using Metalama.Framework.DesignTime.Utilities;
-using Metalama.Framework.Engine;
 using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Pipeline.DesignTime;
 using Metalama.Framework.Engine.Services;
@@ -285,7 +284,6 @@ internal class AnalysisProcessProjectSourceGenerator : ProjectSourceGenerator
         if ( string.IsNullOrEmpty( this._sourceGeneratorTouchFile ) )
         {
             this._sourceGeneratorTouchFile = this.ProjectOptions.SourceGeneratorTouchFile;
-            Invariant.AssertNot( string.IsNullOrEmpty( this._sourceGeneratorTouchFile ) );
 
             if ( !string.IsNullOrEmpty( this._sourceGeneratorTouchFile ) )
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
@@ -40,6 +40,7 @@ public sealed class DotNetTool
 
         // We must avoid passing the following environment variables to the child process, otherwise there can be a mismatch
         // between SDK versions and the build will fail.
+        startInfo.Environment.Remove( "DOTNET_HOST_PATH" );
         startInfo.Environment.Remove( "DOTNET_ROOT_X64" );
         startInfo.Environment.Remove( "MSBUILD_EXE_PATH" );
         startInfo.Environment.Remove( "MSBuildSDKsPath" );


### PR DESCRIPTION
## Summary
- Replace Rider-specific process detection in PlatformInfo with a generic HasSdk check that skips any dotnet.exe without an SDK directory — correctly handles VS 2026, Rider, and any future host bundling a runtime-only dotnet
- Add DOTNET_HOST_PATH to cleared environment variables in DotNetTool to prevent child processes from inheriting VS 2026's runtime-only dotnet path (#1462)
- Only use Assembly.LoadFile for DesignTime.Contracts in devenv.exe (where COM type equivalence is needed); in DevHub and other processes, load via the Metalama ALC to avoid Microsoft.CodeAnalysis type identity mismatches (#1461)
- Add devhub to ProcessKindHelper and ProcessUtilities for VS 2026
- Remove debug assertion crash in AnalysisProcessProjectSourceGenerator when SourceGeneratorTouchFile is null

## Issues Fixed
- Fixes #1461 - The process Metalama.DesignTime encountered an unexpected exception: Method not found
- Fixes #1462 - Metalama picks the VS-bundled dotnet.exe instead of the system-wide one
