### PR TITLE
Include exception details in diagnostic Description (#1467)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticDescriptorExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticDescriptorExtensions.cs
@@ -33,13 +33,14 @@ public static class DiagnosticDescriptorExtensions
         T arguments,
         IEnumerable<Location>? additionalLocations = null,
         string? deduplicationKey = null,
-        ImmutableDictionary<string, string?>? properties = null )
+        ImmutableDictionary<string, string?>? properties = null,
+        string? description = null )
         where T : notnull
     {
         // ConvertDiagnosticArguments treats an array as multiple arguments, so we need to wrap it in another array.
         var argumentArray = ConvertDiagnosticArguments( typeof(T).IsArray ? new[] { arguments } : arguments );
 
-        return definition.CreateRoslynDiagnosticImpl( location, argumentArray, null, additionalLocations, deduplicationKey, properties );
+        return definition.CreateRoslynDiagnosticImpl( location, argumentArray, null, additionalLocations, deduplicationKey, properties, description );
     }
 
     /// <summary>
@@ -52,13 +53,14 @@ public static class DiagnosticDescriptorExtensions
         IDiagnosticSource? diagnosticSource,
         IEnumerable<Location>? additionalLocations = null,
         string? deduplicationKey = null,
-        ImmutableDictionary<string, string?>? properties = null )
+        ImmutableDictionary<string, string?>? properties = null,
+        string? description = null )
         where T : notnull
     {
         // ConvertDiagnosticArguments treats an array as multiple arguments, so we need to wrap it in another array.
         var argumentArray = ConvertDiagnosticArguments( typeof(T).IsArray ? new[] { arguments } : arguments );
 
-        return definition.CreateRoslynDiagnosticImpl( location, argumentArray, diagnosticSource, additionalLocations, deduplicationKey, properties );
+        return definition.CreateRoslynDiagnosticImpl( location, argumentArray, diagnosticSource, additionalLocations, deduplicationKey, properties, description );
     }
 
     // If this was named CreateRoslynDiagnostic, type safety of the generic versions would be lost.
@@ -69,11 +71,12 @@ public static class DiagnosticDescriptorExtensions
         IDiagnosticSource? diagnosticSource = null,
         IEnumerable<Location>? additionalLocations = null,
         string? deduplicationKey = null,
-        ImmutableDictionary<string, string?>? properties = null )
+        ImmutableDictionary<string, string?>? properties = null,
+        string? description = null )
     {
         var argumentArray = ConvertDiagnosticArguments( arguments );
 
-        return definition.CreateRoslynDiagnosticImpl( location, argumentArray, diagnosticSource, additionalLocations, deduplicationKey, properties );
+        return definition.CreateRoslynDiagnosticImpl( location, argumentArray, diagnosticSource, additionalLocations, deduplicationKey, properties, description );
     }
 
     private static object?[] ConvertDiagnosticArguments( object? arguments )
@@ -108,7 +111,8 @@ public static class DiagnosticDescriptorExtensions
         IDiagnosticSource? diagnosticSource,
         IEnumerable<Location>? additionalLocations,
         string? deduplicationKey,
-        ImmutableDictionary<string, string?>? properties )
+        ImmutableDictionary<string, string?>? properties,
+        string? description = null )
     {
         var propertiesWithAdditions = properties;
 
@@ -116,6 +120,9 @@ public static class DiagnosticDescriptorExtensions
         {
             ImmutableDictionaryExtensions.AddOrCreate( ref propertiesWithAdditions, UserDiagnosticSink.DeduplicationPropertyKey, deduplicationKey );
         }
+
+        var diagnosticSourceDescription = diagnosticSource == null ? null : $"Reported by {diagnosticSource.DiagnosticSourceDescription}.";
+        var effectiveDescription = description ?? diagnosticSourceDescription;
 
         return Diagnostic.Create(
             definition.Id,
@@ -129,6 +136,6 @@ public static class DiagnosticDescriptorExtensions
             location: location,
             additionalLocations: additionalLocations,
             properties: propertiesWithAdditions,
-            description: diagnosticSource == null ? null : $"Reported by {diagnosticSource.DiagnosticSourceDescription}." );
+            description: effectiveDescription );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
@@ -76,7 +76,11 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
             var diagnosticDefinition =
                 canIgnoreException ? GeneralDiagnosticDescriptors.IgnorableUnhandledException : GeneralDiagnosticDescriptors.UnhandledException;
 
-            reportDiagnostic( diagnosticDefinition.CreateRoslynDiagnostic( node?.GetLocation(), (exception.Message, reportFile) ) );
+            reportDiagnostic(
+                diagnosticDefinition.CreateRoslynDiagnostic(
+                    node?.GetLocation(),
+                    (exception.Message, reportFile),
+                    description: exceptionText.ToString() ) );
 
             this._exceptionReporter?.ReportException( exception, localReportPath: reportFile );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/UserCode/UserCodeInvoker.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/UserCode/UserCodeInvoker.cs
@@ -134,7 +134,8 @@ public sealed class UserCodeInvoker : IProjectService, IGlobalService
                     (context.Description,
                      exceptionType,
                      exceptionMessage,
-                     reportFile) ) );
+                     reportFile),
+                    description: userException.ToString() ) );
         }
 
         return true;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Diagnostics/DiagnosticDescriptionTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Diagnostics/DiagnosticDescriptionTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Compiler;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Pipeline.CompileTime;
+using Metalama.Framework.Tests.UnitTests.Aspects;
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Diagnostics;
+
+#pragma warning disable VSTHRD200
+
+public sealed class DiagnosticDescriptionTests : AspectTestBase
+{
+    [Fact]
+    public async Task ExceptionDiagnosticDescriptionContainsExceptionDetails()
+    {
+        // Arrange: an aspect whose template throws a DivideByZeroException.
+        const string code = """
+                            using Metalama.Framework.Aspects;
+
+                            class ThrowingAspect : OverrideMethodAspect
+                            {
+                                public override dynamic? OverrideMethod()
+                                {
+                                    var a = meta.CompileTime( 0 );
+                                    var b = 1 / a;
+                                    return meta.Proceed();
+                                }
+                            }
+
+                            class TargetCode
+                            {
+                                [ThrowingAspect]
+                                int Method( int x ) => x;
+                            }
+                            """;
+
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCSharpCompilation( code );
+
+        var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
+        var diagnostics = new DiagnosticBag();
+
+        await pipeline.ExecuteAsync( diagnostics.Report, null, compilation, ImmutableArray<ManagedResource>.Empty );
+
+        // Find the LAMA0041 diagnostic (ExceptionInUserCode).
+        var exceptionDiagnostic = diagnostics.ToImmutableArray().FirstOrDefault( d => d.Id == "LAMA0041" );
+
+        Assert.NotNull( exceptionDiagnostic );
+
+        // The diagnostic Description should contain the exception details so that
+        // VS users can see them directly in the Error List panel (issue #1467).
+        var description = exceptionDiagnostic.Descriptor.Description.ToString( CultureInfo.InvariantCulture );
+
+        Assert.Contains( "DivideByZeroException", description, StringComparison.Ordinal );
+    }
+
+    [Fact]
+    public async Task UnhandledExceptionDiagnosticDescriptionContainsExceptionDetails()
+    {
+        // Arrange: an aspect whose BuildAspect throws an exception.
+        const string code = """
+                            using Metalama.Framework.Aspects;
+                            using Metalama.Framework.Code;
+                            using Metalama.Framework.Advising;
+
+                            class ThrowingAspect : TypeAspect
+                            {
+                                public override void BuildAspect( IAspectBuilder<INamedType> builder )
+                                {
+                                    throw new System.InvalidOperationException( "Intentional test exception" );
+                                }
+                            }
+
+                            [ThrowingAspect]
+                            class TargetClass { }
+                            """;
+
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCSharpCompilation( code );
+
+        var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
+        var diagnostics = new DiagnosticBag();
+
+        await pipeline.ExecuteAsync( diagnostics.Report, null, compilation, ImmutableArray<ManagedResource>.Empty );
+
+        // Find the LAMA0041 diagnostic (ExceptionInUserCode) — BuildAspect exceptions are also reported as LAMA0041.
+        var exceptionDiagnostic = diagnostics.ToImmutableArray().FirstOrDefault( d => d.Id == "LAMA0041" || d.Id == "LAMA0001" );
+
+        Assert.NotNull( exceptionDiagnostic );
+
+        // The diagnostic Description should contain the exception details so that
+        // VS users can see them directly in the Error List panel (issue #1467).
+        var description = exceptionDiagnostic.Descriptor.Description.ToString( CultureInfo.InvariantCulture );
+
+        Assert.Contains( "InvalidOperationException", description, StringComparison.Ordinal );
+    }
+}


### PR DESCRIPTION
Closes #1467

## Summary
- Populate the Roslyn `Diagnostic.Description` property with full exception details when unhandled exceptions occur (LAMA0001, LAMA0041, LAMA0049)
- VS users will see the exception details directly in the Error List panel, without needing to navigate to a temp file
- The temp file is preserved for `dotnet build`/CI scenarios (MSBuild doesn't transmit Description)

## Changes
- **`DiagnosticDescriptorExtensions.cs`**: Added optional `description` parameter to `CreateRoslynDiagnostic` and `CreateRoslynDiagnosticNonGeneric` methods, threaded through to `Diagnostic.Create()`
- **`CompileTimeExceptionHandler.cs`**: Pass the full exception text (including stack trace, runtime info) as the diagnostic description for LAMA0001/LAMA0049
- **`UserCodeInvoker.cs`**: Pass `userException.ToString()` as the diagnostic description for LAMA0041

## Test plan
- [x] Added `DiagnosticDescriptionTests.ExceptionDiagnosticDescriptionContainsExceptionDetails` - verifies LAMA0041 from template exception includes exception type in Description
- [x] Added `DiagnosticDescriptionTests.UnhandledExceptionDiagnosticDescriptionContainsExceptionDetails` - verifies LAMA0041/LAMA0001 from BuildAspect exception includes exception type in Description
- [x] All 1715 unit tests pass
- [x] `Build.ps1 build` - zero warnings
- [x] `Build.ps1 test` - all tests pass, zero warnings

## Checklist
- [x] Reproduce: failing regression tests added
- [x] Implement fix
- [x] Build (Build.ps1 build)
- [x] Test (Build.ps1 test)
- [x] Finalize