### PR TITLE
Sort projects by name in LinqPad driver (#778)

### DIFF
--- a/Metalama.LinqPad/src/Metalama.LinqPad/SchemaFactory.cs
+++ b/Metalama.LinqPad/src/Metalama.LinqPad/SchemaFactory.cs
@@ -47,7 +47,9 @@ internal sealed class SchemaFactory
 
             rootSchema.Add( projectsItem );
 
-            foreach ( var project in workspace.Projects.OrderBy( p => p.Name ) )
+            foreach ( var project in workspace.Projects
+                         .OrderBy( p => p.Name, StringComparer.OrdinalIgnoreCase )
+                         .ThenBy( p => p.TargetFramework, StringComparer.OrdinalIgnoreCase ) )
             {
                 var nameLiteral = SyntaxFactory.Literal( project.Name ).Text;
                 var frameworkLiteral = SyntaxFactory.Literal( project.TargetFramework ).Text;

--- a/Metalama.LinqPad/src/Metalama.LinqPad/SchemaFactory.cs
+++ b/Metalama.LinqPad/src/Metalama.LinqPad/SchemaFactory.cs
@@ -47,7 +47,7 @@ internal sealed class SchemaFactory
 
             rootSchema.Add( projectsItem );
 
-            foreach ( var project in workspace.Projects )
+            foreach ( var project in workspace.Projects.OrderBy( p => p.Name ) )
             {
                 var nameLiteral = SyntaxFactory.Literal( project.Name ).Text;
                 var frameworkLiteral = SyntaxFactory.Literal( project.TargetFramework ).Text;

--- a/Metalama.LinqPad/src/tests/Metalama.LinqPad.Tests/SchemaTests.cs
+++ b/Metalama.LinqPad/src/tests/Metalama.LinqPad.Tests/SchemaTests.cs
@@ -5,6 +5,7 @@
 using LINQPad.Extensibility.DataContext;
 using Metalama.Framework.Workspaces;
 using Metalama.Testing.UnitTesting;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -75,6 +76,39 @@ public sealed class SchemaTests : UnitTestClass
         xml.Add( new XElement( "schema", schema.Select( item => (object) ConvertToXml( item ) ) ) );
         var xmlString = xml.ToString();
         this._logger.WriteLine( xmlString );
+    }
+
+    [Fact]
+    public async Task ProjectsShouldBeSortedByName()
+    {
+        var solutionPath = Path.GetFullPath(
+            Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "..", "..", "..", "..", "MultiProjectSolution", "MultiProjectSolution.sln" ) );
+
+        Assert.True( File.Exists( solutionPath ), $"Solution file not found at: {solutionPath}" );
+
+        var workspaceCollection = new WorkspaceCollection();
+
+        using var workspace = await workspaceCollection.LoadAsync( solutionPath );
+
+        var factory = new SchemaFactory( ( type, _ ) => type.ToString() );
+
+        var schema = factory.GetSchema( "workspace", workspace );
+
+        // Find the "Projects" node which contains individual project items.
+        var projectsItem = schema.FirstOrDefault( item => item.Text == "Projects" );
+        Assert.NotNull( projectsItem );
+        Assert.NotNull( projectsItem.Children );
+        Assert.True( projectsItem.Children.Count >= 3, $"Expected at least 3 projects, found {projectsItem.Children.Count}" );
+
+        var projectNames = projectsItem.Children.Select( c => c.Text ).ToList();
+
+        this._logger.WriteLine( "Project order: " + string.Join( ", ", projectNames ) );
+
+        // Verify projects are sorted alphabetically by name.
+        var sortedNames = projectNames.OrderBy( n => n, StringComparer.OrdinalIgnoreCase ).ToList();
+        Assert.Equal( sortedNames, projectNames );
     }
 
     private static XElement ConvertToXml( ExplorerItem item )

--- a/Metalama.LinqPad/src/tests/Metalama.LinqPad.Tests/SchemaTests.cs
+++ b/Metalama.LinqPad/src/tests/Metalama.LinqPad.Tests/SchemaTests.cs
@@ -6,6 +6,7 @@ using LINQPad.Extensibility.DataContext;
 using Metalama.Framework.Workspaces;
 using Metalama.Testing.UnitTesting;
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -90,7 +91,7 @@ public sealed class SchemaTests : UnitTestClass
 
         var workspaceCollection = new WorkspaceCollection();
 
-        using var workspace = await workspaceCollection.LoadAsync( solutionPath );
+        using var workspace = await workspaceCollection.LoadAsync( ImmutableArray.Create( solutionPath ), restore: false );
 
         var factory = new SchemaFactory( ( type, _ ) => type.ToString() );
 

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/Apple/Apple.csproj
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/Apple/Apple.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/Apple/Class1.cs
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/Apple/Class1.cs
@@ -1,0 +1,3 @@
+namespace Apple;
+
+public class Class1 { }

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/Mango/Class1.cs
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/Mango/Class1.cs
@@ -1,0 +1,3 @@
+namespace Mango;
+
+public class Class1 { }

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/Mango/Mango.csproj
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/Mango/Mango.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/MultiProjectSolution.sln
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/MultiProjectSolution.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zebra", "Zebra\Zebra.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mango", "Mango\Mango.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apple", "Apple\Apple.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/Zebra/Class1.cs
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/Zebra/Class1.cs
@@ -1,0 +1,3 @@
+namespace Zebra;
+
+public class Class1 { }

--- a/Metalama.LinqPad/src/tests/MultiProjectSolution/Zebra/Zebra.csproj
+++ b/Metalama.LinqPad/src/tests/MultiProjectSolution/Zebra/Zebra.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #778

## Summary
- Sort projects alphabetically by name in the LinqPad driver's schema view by adding `.OrderBy(p => p.Name)` to the project iteration in `SchemaFactory.GetSchema`.
- Added a multi-project test solution and a regression test that verifies project sorting order.

## Checklist
- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build (`Build.ps1 build`) - zero warnings
- [x] Test (`dotnet test`) - all tests pass
- [x] Finalize

-- Claude for @PostSharpAgent