### PR TITLE
Add Diagnostics property to ITypeAmender (#724)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/TypeFabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/TypeFabricDriver.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel;
@@ -141,6 +142,8 @@ internal sealed class TypeFabricDriver : FabricDriver
         public override void AddContributor( IPipelineContributor contributor ) => this._aspectBuilder.AddContributor( contributor );
 
         public IAdviceFactory Advice { get; }
+
+        public ScopedDiagnosticSink Diagnostics => this._aspectBuilder.Diagnostics;
 
         public override string Namespace => this.Type.ContainingNamespace.FullName;
     }

--- a/Metalama.Framework/src/Metalama.Framework/Fabrics/ITypeAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Fabrics/ITypeAmender.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.Advising;
 using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
 
 namespace Metalama.Framework.Fabrics
 {
@@ -41,5 +42,10 @@ namespace Metalama.Framework.Fabrics
         /// </summary>
         /// <seealso href="@advising-code"/>
         IAdviceFactory Advice { get; }
+
+        /// <summary>
+        /// Gets a service that allows to report or suppress diagnostics scoped to the target type.
+        /// </summary>
+        ScopedDiagnosticSink Diagnostics { get; }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricDiagnostics.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricDiagnostics.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Diagnostics;
+using Metalama.Framework.Fabrics;
+
+namespace Metalama.Framework.Tests.AspectTests.Fabrics.TypeFabricDiagnostics
+{
+    // <target>
+    internal class TargetCode
+    {
+        public void Method1() { }
+
+        public void Method2() { }
+
+        private class Fabric : TypeFabric
+        {
+            private static readonly DiagnosticDefinition<string> _warning =
+                new( "MY001", Severity.Warning, "Warning on type '{0}'." );
+
+            public override void AmendType( ITypeAmender amender )
+            {
+                amender.Diagnostics.Report( _warning.WithArguments( amender.Type.Name ) );
+            }
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricDiagnostics.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricDiagnostics.t.cs
@@ -1,0 +1,17 @@
+// Warning MY001 on `TargetCode`: `Warning on type 'TargetCode'.`
+internal class TargetCode
+{
+  public void Method1()
+  {
+  }
+  public void Method2()
+  {
+  }
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  private class Fabric : TypeFabric
+  {
+    private static readonly DiagnosticDefinition<string> _warning = new("MY001", Severity.Warning, "Warning on type '{0}'.");
+    public override void AmendType(ITypeAmender amender) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  }
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+}


### PR DESCRIPTION
Closes #724

## Summary
- Add `Diagnostics` property of type `ScopedDiagnosticSink` to `ITypeAmender`, allowing type fabrics to report diagnostics directly via `amender.Diagnostics.Report(...)`.

## Changes
- `ITypeAmender.cs`: Added `ScopedDiagnosticSink Diagnostics { get; }` property to the interface.
- `TypeFabricDriver.cs`: Implemented the property in the `Amender` class, delegating to the underlying `IAspectBuilderInternal.Diagnostics`.
- Added `TypeFabricDiagnostics` aspect test verifying that a `TypeFabric` can report a diagnostic via `amender.Diagnostics.Report(...)`.

## Checklist
- [x] Reproduce: failing test using `amender.Diagnostics`
- [x] Implement: add `Diagnostics` property to `ITypeAmender` and its implementation
- [x] Build: `Build.ps1 build` passes with zero warnings
- [x] Test: all 2109 aspect tests pass
- [x] Finalize: mark PR as ready

--- Claude for @PostSharpAgent