### PR TITLE
Remove CS8424/CS8425 warning suppressions

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/metalamaTests.json
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/metalamaTests.json
@@ -13,8 +13,6 @@
     "CS0626",  // Method, operator, or accessor is marked external and has no attributes on it
     "CS0649",  // Field is never assigned to (will always have default value)
     "CS0659",  // Class overrides Object.Equals but does not override Object.GetHashCode
-    "CS8424",  // Iterator specifying non-nullable return type but code block returns null values
-    "CS8425",  // Async-iterator does not have the proper return type
     "CS8600",  // Converting null literal or possible null value to non-nullable type
     "CS8602",  // Dereference of a possibly null reference
     "CS8603",  // Possible null reference return

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/metalamaTests.json
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/metalamaTests.json
@@ -3,7 +3,7 @@
   "ReportErrorMessage": true,
   "FormatOutput": false,
   "ReportOutputWarnings": true,
-  "IgnoredDiagnostics" : [ "CS8603", "CS0219", "CS0067", "CS8602", "CS8600", "CS8604", "CS0649", "CS8767", "CS0169", "CS8765", "CS8625", "CS8424", "CS8425" ],
+  "IgnoredDiagnostics" : [ "CS8603", "CS0219", "CS0067", "CS8602", "CS8600", "CS8604", "CS0649", "CS8767", "CS0169", "CS8765", "CS8625" ],
   "CheckMemoryLeaks": true,
   "IgnoreUserProfileLicenses": true
 }


### PR DESCRIPTION
Closes #844

## Summary
- Removed CS8424 and CS8425 from the `IgnoredDiagnostics` in both `metalamaTests.json` files (AspectTests and TemplateTests)
- The linker already correctly handles `[EnumeratorCancellation]` attributes in async iterators, so these suppressions are no longer needed

## Investigation
- CS8424 (EnumeratorCancellationAttribute on wrong parameter type) and CS8425 (missing EnumeratorCancellation on CancellationToken in async-iterator) were suppressed globally in test configurations
- All async iterator test outputs (`.t.cs` files) show correct `[EnumeratorCancellation]` placement on `CancellationToken` parameters of `IAsyncEnumerable<T>`-returning methods
- Removing the suppressions causes zero test failures across all 2138 aspect tests and 314 template tests

## Checklist
- [x] Remove CS8424/CS8425 suppressions from metalamaTests.json
- [x] Run all async iterator tests (16/16 passed)
- [x] Run all async tests (55/55 passed)
- [x] Run full aspect test suite (2138 passed)
- [x] Run full template test suite (314 passed, 1 skipped)
- [x] Build.ps1 build (zero warnings)
- [x] Build.ps1 test (passed)