### PR TITLE
Add HideFromAspectExplorer to EditorExperienceAttribute

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
@@ -115,7 +115,7 @@ internal sealed class AspectDatabase : IGlobalService
 
         var aspectClassesIds = aspectClasses
             .OfType<AspectClass>()
-            .Where( aspectClass => !aspectClass.IsAbstract && !aspectClass.EditorExperienceOptions.HideFromAspectExplorer.GetValueOrDefault() )
+            .Where( aspectClass => !aspectClass.IsAbstract && aspectClass.EditorExperienceOptions.HideFromAspectExplorer != true )
             .Select( aspectClass => aspectClass.TypeId.Id );
 
         var fabrics = pipeline.Fabrics ?? ImmutableArray<string>.Empty;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/AspectExplorer/AspectDatabase.cs
@@ -115,7 +115,7 @@ internal sealed class AspectDatabase : IGlobalService
 
         var aspectClassesIds = aspectClasses
             .OfType<AspectClass>()
-            .Where( aspectClass => !aspectClass.IsAbstract )
+            .Where( aspectClass => !aspectClass.IsAbstract && !aspectClass.EditorExperienceOptions.HideFromAspectExplorer.GetValueOrDefault() )
             .Select( aspectClass => aspectClass.TypeId.Id );
 
         var fabrics = pipeline.Fabrics ?? ImmutableArray<string>.Empty;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/AspectClass.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/AspectClass.cs
@@ -137,7 +137,8 @@ public sealed class AspectClass : TemplateClass, IBoundAspectClass
             this.EditorExperienceOptions = new EditorExperienceOptions
             {
                 SuggestAsAddAttribute = baseClass.EditorExperienceOptions.SuggestAsAddAttribute,
-                SuggestAsLiveTemplate = baseClass.EditorExperienceOptions.SuggestAsLiveTemplate
+                SuggestAsLiveTemplate = baseClass.EditorExperienceOptions.SuggestAsLiveTemplate,
+                HideFromAspectExplorer = baseClass.EditorExperienceOptions.HideFromAspectExplorer
             };
         }
         else

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/EditorExperienceAttribute.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/EditorExperienceAttribute.cs
@@ -92,4 +92,14 @@ public sealed class EditorExperienceAttribute : Attribute
         get => this.Options.AddAttributeSuggestionTitle;
         set => this.Options = this.Options with { AddAttributeSuggestionTitle = value };
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the aspect should be hidden from the Aspect Explorer tool window in the IDE.
+    /// This property is <c>false</c> by default, meaning the aspect is visible in the Aspect Explorer.
+    /// </summary>
+    public bool HideFromAspectExplorer
+    {
+        get => this.Options.HideFromAspectExplorer.GetValueOrDefault();
+        set => this.Options = this.Options with { HideFromAspectExplorer = value };
+    }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/EditorExperienceOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/EditorExperienceOptions.cs
@@ -38,14 +38,16 @@ public sealed record EditorExperienceOptions(
     bool? SuggestAsAddAttribute = null,
     string? AddAttributeSuggestionTitle = null,
     bool? SuggestAsLiveTemplate = null,
-    string? LiveTemplateSuggestionTitle = null )
+    string? LiveTemplateSuggestionTitle = null,
+    bool? HideFromAspectExplorer = null )
 {
     internal EditorExperienceOptions Override( EditorExperienceOptions overriding )
         => new(
             AddAttributeSuggestionTitle: overriding.AddAttributeSuggestionTitle ?? this.AddAttributeSuggestionTitle,
             LiveTemplateSuggestionTitle: overriding.LiveTemplateSuggestionTitle ?? this.LiveTemplateSuggestionTitle,
             SuggestAsAddAttribute: overriding.SuggestAsAddAttribute ?? this.SuggestAsAddAttribute,
-            SuggestAsLiveTemplate: overriding.SuggestAsLiveTemplate ?? this.SuggestAsLiveTemplate );
+            SuggestAsLiveTemplate: overriding.SuggestAsLiveTemplate ?? this.SuggestAsLiveTemplate,
+            HideFromAspectExplorer: overriding.HideFromAspectExplorer ?? this.HideFromAspectExplorer );
 
     public static EditorExperienceOptions Default { get; } = new();
 }

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/EditorExperienceOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/EditorExperienceOptions.cs
@@ -29,6 +29,9 @@ namespace Metalama.Framework.Aspects;
 /// the IDE will offer to apply the aspect directly to the source code, transforming it in place.</param>
 /// <param name="LiveTemplateSuggestionTitle">The title for the live template menu item. Use the vertical pipe (<c>|</c>)
 /// to create nested sub-menus.</param>
+/// <param name="HideFromAspectExplorer">Whether the aspect should be hidden from the Aspect Explorer tool window in the IDE.
+/// When <c>true</c>, the aspect will not appear in the Aspect Explorer, which is useful for internal or infrastructure aspects
+/// that are not relevant to end users.</param>
 /// <seealso cref="EditorExperienceAttribute"/>
 /// <seealso cref="IAspectClass.EditorExperienceOptions"/>
 /// <seealso href="@live-template"/>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
@@ -699,4 +699,39 @@ public sealed class AspectDatabaseTests( ITestOutputHelper testOutputHelper ) : 
         // HiddenAspect should NOT appear in the aspect classes list.
         AssertAspectClasses( ["Y:global::VisibleAspect"], aspectClasses );
     }
+
+    [Fact]
+    public async Task HideFromAspectExplorerIsInheritedTest()
+    {
+        const string code =
+            """
+            using Metalama.Framework.Aspects;
+
+            [EditorExperience( HideFromAspectExplorer = true )]
+            class HiddenBaseAspect : TypeAspect { }
+
+            class DerivedAspect : HiddenBaseAspect { }
+
+            class VisibleAspect : TypeAspect { }
+
+            [DerivedAspect]
+            class Target1;
+
+            [VisibleAspect]
+            class Target2;
+            """;
+
+        using var testContext = this.CreateTestContext();
+        using TestDesignTimeAspectPipelineFactory factory = new( testContext );
+
+        var workspaceProvider = factory.ServiceProvider.GetRequiredService<TestWorkspaceProvider>();
+        var projectKey = workspaceProvider.AddOrUpdateProject( testContext, "project", new Dictionary<string, string> { ["code.cs"] = code } );
+
+        var aspectDatabase = new AspectDatabase( factory.ServiceProvider );
+
+        var aspectClasses = await aspectDatabase.GetAspectClassesAsync( projectKey, testContext.CancellationToken );
+
+        // DerivedAspect should inherit HideFromAspectExplorer from HiddenBaseAspect and NOT appear.
+        AssertAspectClasses( ["Y:global::VisibleAspect"], aspectClasses );
+    }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
@@ -666,4 +666,37 @@ public sealed class AspectDatabaseTests( ITestOutputHelper testOutputHelper ) : 
         // The original compilation should no longer be referenced anywhere.
         Assert.False( compilationReference.IsAlive );
     }
+
+    [Fact]
+    public async Task HideFromAspectExplorerTest()
+    {
+        const string code =
+            """
+            using Metalama.Framework.Aspects;
+
+            class VisibleAspect : TypeAspect { }
+
+            [EditorExperience( HideFromAspectExplorer = true )]
+            class HiddenAspect : TypeAspect { }
+
+            [VisibleAspect]
+            class Target1;
+
+            [HiddenAspect]
+            class Target2;
+            """;
+
+        using var testContext = this.CreateTestContext();
+        using TestDesignTimeAspectPipelineFactory factory = new( testContext );
+
+        var workspaceProvider = factory.ServiceProvider.GetRequiredService<TestWorkspaceProvider>();
+        var projectKey = workspaceProvider.AddOrUpdateProject( testContext, "project", new Dictionary<string, string> { ["code.cs"] = code } );
+
+        var aspectDatabase = new AspectDatabase( factory.ServiceProvider );
+
+        var aspectClasses = await aspectDatabase.GetAspectClassesAsync( projectKey, testContext.CancellationToken );
+
+        // HiddenAspect should NOT appear in the aspect classes list.
+        AssertAspectClasses( ["Y:global::VisibleAspect"], aspectClasses );
+    }
 }


### PR DESCRIPTION
Fixes #697

## Summary
- Add `HideFromAspectExplorer` bool property to `EditorExperienceAttribute` to allow aspect authors to hide aspects from the Aspect Explorer
- Add corresponding `HideFromAspectExplorer` parameter to `EditorExperienceOptions` record (with `Override` support for inheritance)
- Filter hidden aspects in `AspectDatabase.GetAspectClassesAsync` so they don't appear in the IDE's Aspect Explorer
- Add `HideFromAspectExplorerTest` unit test

## Checklist
- [x] Reproduce bug (failing test)
- [x] Implement fix
- [x] Build (zero warnings)
- [x] Test (all tests pass)
- [x] Finalize

— Claude for @gfraiteur