### PR TITLE
Fix: skip OnChildPropertyChanged for sealed types (#644)

### DIFF
--- a/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/ClassicDesignTimeObservabilityStrategyImpl.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/ClassicDesignTimeObservabilityStrategyImpl.cs
@@ -83,6 +83,12 @@ internal sealed class ClassicDesignTimeObservabilityStrategyImpl : DesignTimeObs
     {
         var isOverride = this._baseOnChildPropertyChangedMethod != null;
 
+        if ( this.Builder.Target.IsSealed && !isOverride )
+        {
+            // For sealed types, OnChildPropertyChanged is unnecessary because no derived type can override it.
+            return;
+        }
+
         this.Builder
             .WithTemplateProvider( this )
             .IntroduceMethod(

--- a/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/ClassicObservabilityStrategyImpl.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/ClassicObservabilityStrategyImpl.cs
@@ -304,6 +304,8 @@ internal sealed class ClassicObservabilityStrategyImpl : IObservabilityStrategy
                     } )
                 .ToList();
 
+        var isOverride = this._baseOnChildPropertyChangedMethod != null;
+
         if ( this._propertyPathsForOnChildPropertyChangedMethod.Count == 0 && nodesForOnChildPropertyChanged.Count == 0 )
         {
             // This method is not necessary.
@@ -312,7 +314,13 @@ internal sealed class ClassicObservabilityStrategyImpl : IObservabilityStrategy
             return true;
         }
 
-        var isOverride = this._baseOnChildPropertyChangedMethod != null;
+        if ( this.CurrentType.IsSealed && !isOverride )
+        {
+            // For sealed types, OnChildPropertyChanged is unnecessary because no derived type can override it.
+            this._onChildPropertyChangedMethod.Value = null;
+
+            return true;
+        }
 
         var result = this.AspectBuilder
             .With( this.CurrentType )

--- a/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/Templates.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/Templates.cs
@@ -237,9 +237,9 @@ internal sealed class Templates : ITemplateProvider
             if ( parentNode.ReferencedFieldOrProperty.Accessibility != Accessibility.Private )
             {
                 // Don't notify if we're joining on to existing NotifyChildPropertyChanged support from a base type, or we'll be stuck in a loop.
-                if ( parentNode.InpcBaseHandling != InpcBaseHandling.OnChildPropertyChanged )
+                if ( parentNode.InpcBaseHandling != InpcBaseHandling.OnChildPropertyChanged && templateArgs.OnChildPropertyChangedMethod != null )
                 {
-                    templateArgs.OnChildPropertyChangedMethod!.WithOptions( InvokerOptions.Final ).Invoke( parentNode.DottedPropertyPath, node.Name );
+                    templateArgs.OnChildPropertyChangedMethod.WithOptions( InvokerOptions.Final ).Invoke( parentNode.DottedPropertyPath, node.Name );
                 }
                 else if ( templateArgs.CommonOptions.DiagnosticCommentVerbosity! > 0 )
                 {
@@ -834,7 +834,7 @@ internal sealed class Templates : ITemplateProvider
             }
         }
 
-        if ( nodeIsAccessible )
+        if ( nodeIsAccessible && templateArgs.OnChildPropertyChangedMethod != null )
         {
             switchBuilder.AddDefault(
                 StatementFactory.FromTemplate(
@@ -877,9 +877,9 @@ internal sealed class Templates : ITemplateProvider
                 templateArgs.OnPropertyChangedInvocableMethod.WithOptions( InvokerOptions.Final ).Invoke( r.Name );
             }
 
-            if ( nodeIsAccessible )
+            if ( nodeIsAccessible && templateArgs.OnChildPropertyChangedMethod != null )
             {
-                templateArgs.OnChildPropertyChangedMethod!.WithOptions( InvokerOptions.Final ).Invoke( node.DottedPropertyPath, childNode.Name );
+                templateArgs.OnChildPropertyChangedMethod.WithOptions( InvokerOptions.Final ).Invoke( node.DottedPropertyPath, childNode.Name );
             }
         }
     }

--- a/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/Templates.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Observability/Implementation/ClassicStrategy/Templates.cs
@@ -243,8 +243,16 @@ internal sealed class Templates : ITemplateProvider
                 }
                 else if ( templateArgs.CommonOptions.DiagnosticCommentVerbosity! > 0 )
                 {
-                    meta.InsertComment(
-                        $"Not calling OnChildPropertyChanged('{parentNode.DottedPropertyPath}','{node.Name}') because a base type already provides OnChildPropertyChanged support for the parent property." );
+                    if ( templateArgs.OnChildPropertyChangedMethod == null )
+                    {
+                        meta.InsertComment(
+                            $"Not calling OnChildPropertyChanged('{parentNode.DottedPropertyPath}','{node.Name}') because the type is sealed and OnChildPropertyChanged is not available." );
+                    }
+                    else
+                    {
+                        meta.InsertComment(
+                            $"Not calling OnChildPropertyChanged('{parentNode.DottedPropertyPath}','{node.Name}') because a base type already provides OnChildPropertyChanged support for the parent property." );
+                    }
                 }
             }
             else

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObject.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObject.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Patterns.Observability.AspectTests.Include;
+
+#if TEST_OPTIONS
+// @Include(Include/SimpleInpcByHand.cs)
+#endif
+
+namespace Metalama.Patterns.Observability.AspectTests.Sealed_ChildObject;
+
+// <target>
+[Observable]
+public sealed class SealedWithChildObject
+{
+    public SimpleInpcByHand Child { get; set; }
+
+    public int DerivedFromChild => this.Child.A;
+
+    public int LocalProperty { get; set; }
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObject.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObject.t.cs
@@ -1,0 +1,70 @@
+[Observable]
+public sealed class SealedWithChildObject : INotifyPropertyChanged
+{
+  private SimpleInpcByHand _child = default !;
+  public SimpleInpcByHand Child
+  {
+    get
+    {
+      return _child;
+    }
+    set
+    {
+      if (!object.ReferenceEquals(value, _child))
+      {
+        var oldValue = _child;
+        if (oldValue != null)
+        {
+          oldValue.PropertyChanged -= _handleChildPropertyChanged;
+        }
+        _child = value;
+        OnPropertyChanged("DerivedFromChild");
+        OnPropertyChanged("Child");
+        SubscribeToChild(value);
+      }
+    }
+  }
+  public int DerivedFromChild => this.Child.A;
+  private int _localProperty;
+  public int LocalProperty
+  {
+    get
+    {
+      return _localProperty;
+    }
+    set
+    {
+      if (_localProperty != value)
+      {
+        _localProperty = value;
+        OnPropertyChanged("LocalProperty");
+      }
+    }
+  }
+  private PropertyChangedEventHandler? _handleChildPropertyChanged;
+  private void OnPropertyChanged(string propertyName)
+  {
+    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+  }
+  private void SubscribeToChild(SimpleInpcByHand value)
+  {
+    if (value != null)
+    {
+      _handleChildPropertyChanged ??= HandlePropertyChanged;
+      value.PropertyChanged += _handleChildPropertyChanged;
+    }
+    void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+      {
+        var propertyName = e.PropertyName;
+        switch (propertyName)
+        {
+          case "A":
+            OnPropertyChanged("DerivedFromChild");
+            break;
+        }
+      }
+    }
+  }
+  public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObjectDiagnosticComments.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObjectDiagnosticComments.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Fabrics;
+using Metalama.Patterns.Observability.Configuration;
+
+#if TEST_OPTIONS
+// @RequiredConstant(DEBUG)
+#endif
+
+#if DEBUG
+
+namespace Metalama.Patterns.Observability.AspectTests.Sealed_ChildObjectDiagnosticComments;
+
+public class Fabric : NamespaceFabric
+{
+    public override void AmendNamespace( INamespaceAmender amender )
+    {
+        amender.ConfigureObservability( b => b.DiagnosticCommentVerbosity = 1 );
+    }
+}
+
+[Observable]
+public partial class Inner
+{
+    public int Value { get; set; }
+
+    public Leaf Leaf { get; set; }
+}
+
+[Observable]
+public partial class Leaf
+{
+    public int DeepValue { get; set; }
+}
+
+// <target>
+[Observable]
+public sealed partial class SealedWithDeepChild
+{
+    public Inner Child { get; set; }
+
+    public int Derived => this.Child.Leaf.DeepValue;
+}
+
+#endif

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObjectDiagnosticComments.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_ChildObjectDiagnosticComments.t.cs
@@ -1,0 +1,91 @@
+[Observable]
+public sealed partial class SealedWithDeepChild : INotifyPropertyChanged
+{
+  private Inner _child = default !;
+  public Inner Child
+  {
+    get
+    {
+      return _child;
+    }
+    set
+    {
+      // Template: OverrideInpcRefTypePropertySetter
+      if (!object.ReferenceEquals(value, _child))
+      {
+        var oldValue = _child;
+        if (oldValue != null)
+        {
+          oldValue.PropertyChanged -= _handleChildPropertyChanged;
+        }
+        _child = value;
+        UpdateChildLeaf();
+        OnPropertyChanged("Child");
+        SubscribeToChild(value);
+      }
+    }
+  }
+  public int Derived => this.Child.Leaf.DeepValue;
+  private PropertyChangedEventHandler? _handleChildLeafPropertyChanged;
+  private PropertyChangedEventHandler? _handleChildPropertyChanged;
+  private Leaf? _lastChildLeaf;
+  private void OnPropertyChanged(string propertyName)
+  { // Template: OnPropertyChanged
+    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+  }
+  private void SubscribeToChild(Inner value)
+  {
+    if (value != null)
+    {
+      _handleChildPropertyChanged ??= HandlePropertyChanged;
+      value.PropertyChanged += _handleChildPropertyChanged;
+    }
+    void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+      {
+        // Template: HandleChildPropertyChangedDelegateBody
+        var propertyName = e.PropertyName;
+        switch (propertyName)
+        {
+          case "Leaf":
+            UpdateChildLeaf();
+            break;
+        }
+      }
+    }
+  }
+  private void UpdateChildLeaf()
+  {
+    // Template: UpdateChildInpcProperty
+    var newValue = Child?.Leaf;
+    if (!object.ReferenceEquals(newValue, _lastChildLeaf))
+    {
+      if (!object.ReferenceEquals(_lastChildLeaf, null))
+      {
+        _lastChildLeaf.PropertyChanged -= _handleChildLeafPropertyChanged;
+      }
+      if (newValue != null)
+      {
+        _handleChildLeafPropertyChanged ??= HandleChildPropertyChanged;
+        newValue.PropertyChanged += _handleChildLeafPropertyChanged;
+        void HandleChildPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+          {
+            // Template: HandleChildPropertyChangedDelegateBody
+            var propertyName = e.PropertyName;
+            switch (propertyName)
+            {
+              case "DeepValue":
+                OnPropertyChanged("Derived");
+                break;
+            }
+          }
+        }
+      }
+      _lastChildLeaf = newValue;
+      OnPropertyChanged("Derived");
+    // Not calling OnChildPropertyChanged('Child','Leaf') because the type is sealed and OnChildPropertyChanged is not available.
+    }
+  }
+  public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_InpcAutoPropertyWithRef.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Observability.AspectTests/Sealed_InpcAutoPropertyWithRef.t.cs
@@ -26,10 +26,6 @@ public sealed class SealedInpcAutoPropertyWithRef : INotifyPropertyChanged
   }
   public int Y => this.X.A;
   private PropertyChangedEventHandler? _handleXPropertyChanged;
-  [ObservedExpressions("X")]
-  private void OnChildPropertyChanged(string parentPropertyPath, string propertyName)
-  {
-  }
   private void OnPropertyChanged(string propertyName)
   {
     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -49,10 +45,6 @@ public sealed class SealedInpcAutoPropertyWithRef : INotifyPropertyChanged
         {
           case "A":
             OnPropertyChanged("Y");
-            OnChildPropertyChanged("X", "A");
-            break;
-          default:
-            OnChildPropertyChanged("X", propertyName);
             break;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #644

- Skip generating `OnChildPropertyChanged` method for sealed types (no derived type can override it)
- Guard template calls to `OnChildPropertyChangedMethod` with null checks for when the method is not introduced
- Applied the same fix in the design-time implementation
- `OnObservablePropertyChanged` was already correctly handled for sealed types

## Checklist

- [x] Regression test with sealed class + child object dependency
- [x] Implement fix in Observable aspect
- [x] Build (`Build.ps1 build`) — zero warnings
- [x] Run all tests — 132 observability tests pass
- [x] Finalize

— Claude for @gfraiteur