### PR TITLE
Add reporting call stack to CEIP crash reports (#608)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -279,9 +279,20 @@ internal sealed class ExceptionReporter : IExceptionReporter
             // This is essential for async exceptions where the exception's own StackTrace
             // only shows the throw-to-catch chain, but not the broader context of the entry
             // point that caught the exception (e.g., CodeLens, Preview, AspectExplorer).
-            xmlWriter.WriteElementString(
-                "ReportingCallStack",
-                Environment.NewLine + ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( Environment.StackTrace ) + Environment.NewLine );
+            try
+            {
+                var reportingCallStack =
+                    Environment.NewLine
+                    + ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( Environment.StackTrace )
+                    + Environment.NewLine;
+
+                xmlWriter.WriteElementString( "ReportingCallStack", reportingCallStack );
+            }
+            catch
+            {
+                // Best-effort: ignore failures when capturing or sanitizing the reporting call stack
+                // so that exception reporting remains resilient.
+            }
 
             xmlWriter.WriteStartElement( "Assemblies" );
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -275,6 +275,14 @@ internal sealed class ExceptionReporter : IExceptionReporter
 
             xmlWriter.WriteEndElement();
 
+            // Include the call stack at the point where the exception is being reported.
+            // This is essential for async exceptions where the exception's own StackTrace
+            // only shows the throw-to-catch chain, but not the broader context of the entry
+            // point that caught the exception (e.g., CodeLens, Preview, AspectExplorer).
+            xmlWriter.WriteElementString(
+                "ReportingCallStack",
+                Environment.NewLine + ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( Environment.StackTrace ) + Environment.NewLine );
+
             xmlWriter.WriteStartElement( "Assemblies" );
 
             foreach ( var assembly in AppDomain.CurrentDomain.GetAssemblies() )

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LocalExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LocalExceptionReporter.cs
@@ -102,6 +102,19 @@ internal sealed class LocalExceptionReporter : IBackstageService
 
                 // ReSharper disable once EmptyGeneralCatchClause
                 catch { }
+
+                // Include the call stack at the point where the exception is being reported.
+                // This is essential for async exceptions where the exception's own StackTrace
+                // only shows the throw-to-catch chain, but not the broader context of the entry
+                // point that caught the exception (e.g., CodeLens, Preview, AspectExplorer).
+                try
+                {
+                    exceptionText.AppendLine( "===== Reporting Call Stack =====" );
+                    exceptionText.AppendLine( ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( Environment.StackTrace ) );
+                }
+
+                // ReSharper disable once EmptyGeneralCatchClause
+                catch { }
 #pragma warning restore CA1305
 
                 this._fileSystem.WriteAllText( localReportPath, exceptionText.ToString() );

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/LocalExceptionReporterTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/LocalExceptionReporterTests.cs
@@ -7,6 +7,7 @@ using Metalama.Backstage.Infrastructure;
 using Metalama.Backstage.Telemetry;
 using Metalama.Backstage.Testing;
 using System;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -45,5 +46,19 @@ public sealed class LocalExceptionReporterTests : TestsBase
         var reporter = new LocalExceptionReporter( this.ServiceProvider );
         reporter.ReportException( new InvalidOperationException(), "currentReport.txt" );
         Assert.NotEmpty( this.UserInterface.Notifications );
+    }
+
+    [Fact]
+    public void CrashReportContainsReportingCallStack()
+    {
+        var reporter = new LocalExceptionReporter( this.ServiceProvider );
+        reporter.ReportException( new InvalidOperationException( "Test exception" ), null );
+
+        var files = this.FileSystem.EnumerateFiles( this._crashReportsDirectory, "*.txt" ).ToList();
+        Assert.Single( files );
+
+        var content = this.FileSystem.ReadAllText( files[0] );
+        Assert.Contains( "===== Reporting Call Stack =====", content, StringComparison.Ordinal );
+        Assert.Contains( "ReportException", content, StringComparison.Ordinal );
     }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
@@ -270,4 +270,90 @@ public sealed class ReportExceptionTests : TestsBase
 
         this.AssertFilesCount( 2 );
     }
+
+    [Fact]
+    public async Task AsyncExceptionReportContainsCompleteStackTrace()
+    {
+        // Simulate an exception thrown in a deep async method and propagated through await chain,
+        // as happens in VS Extension entry points (CodeLens, Preview, AspectExplorer).
+        Exception? caughtException = null;
+
+        try
+        {
+            await OuterAsyncMethod();
+        }
+        catch ( Exception e )
+        {
+            caughtException = e;
+        }
+
+        Assert.NotNull( caughtException );
+
+        this.ReportException( caughtException );
+        this.AssertFilesCount( 1 );
+
+        var xml = this.FileSystem.ReadAllText( this.FileSystem.Mock.AllFiles.Single() );
+        this.Logger.WriteLine( "XML report:" );
+        this.Logger.WriteLine( xml );
+
+        var doc = XDocument.Parse( xml );
+        var stackTraceElement = doc.Descendants( "StackTrace" ).First();
+        var stackTrace = stackTraceElement.Value;
+
+        this.Logger.WriteLine( "StackTrace element content:" );
+        this.Logger.WriteLine( stackTrace );
+
+        // The stack trace should contain the original throw site (ThrowingMethod).
+        Assert.Contains( "ThrowingMethod", stackTrace );
+
+        // The stack trace should contain the intermediate async method.
+        Assert.Contains( "InnerAsyncMethod", stackTrace );
+
+        // The stack trace should contain the outer async method.
+        Assert.Contains( "OuterAsyncMethod", stackTrace );
+
+        return;
+
+        static async Task ThrowingMethod()
+        {
+            await Task.Yield();
+
+            throw new InvalidOperationException( "Test async exception" );
+        }
+
+        static async Task InnerAsyncMethod()
+        {
+            await ThrowingMethod();
+        }
+
+        static async Task OuterAsyncMethod()
+        {
+            await InnerAsyncMethod();
+        }
+    }
+
+    [Fact]
+    public void ExceptionReportContainsReportingCallStack()
+    {
+        // The crash report should include the call stack at the point where the exception
+        // was reported, providing context about the entry point that caught the exception.
+        var exception = new TestException( "Test", CreateStackFrame( "DeepMethod", 1 ) );
+
+        this.ReportException( exception );
+        this.AssertFilesCount( 1 );
+
+        var xml = this.FileSystem.ReadAllText( this.FileSystem.Mock.AllFiles.Single() );
+        this.Logger.WriteLine( "XML report:" );
+        this.Logger.WriteLine( xml );
+
+        var doc = XDocument.Parse( xml );
+
+        // The report should contain a ReportingCallStack element that shows where ReportException was called from.
+        var reportingCallStack = doc.Descendants( "ReportingCallStack" ).FirstOrDefault();
+        Assert.NotNull( reportingCallStack );
+        Assert.NotEmpty( reportingCallStack.Value );
+
+        this.Logger.WriteLine( "ReportingCallStack:" );
+        this.Logger.WriteLine( reportingCallStack.Value );
+    }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
@@ -304,13 +304,13 @@ public sealed class ReportExceptionTests : TestsBase
         this.Logger.WriteLine( stackTrace );
 
         // The stack trace should contain the original throw site (ThrowingMethod).
-        Assert.Contains( "ThrowingMethod", stackTrace );
+        Assert.Contains( "ThrowingMethod", stackTrace, StringComparison.Ordinal );
 
         // The stack trace should contain the intermediate async method.
-        Assert.Contains( "InnerAsyncMethod", stackTrace );
+        Assert.Contains( "InnerAsyncMethod", stackTrace, StringComparison.Ordinal );
 
         // The stack trace should contain the outer async method.
-        Assert.Contains( "OuterAsyncMethod", stackTrace );
+        Assert.Contains( "OuterAsyncMethod", stackTrace, StringComparison.Ordinal );
 
         return;
 


### PR DESCRIPTION
Fixes #608

## Summary
- Adds a `ReportingCallStack` element to the XML crash report that captures `Environment.StackTrace` at the point where the exception is reported
- Adds a `===== Reporting Call Stack =====` section to local `.txt` crash reports with the same information
- This provides the full context of which VS Extension entry point (CodeLens, Preview, AspectExplorer) caught and reported the exception
- The exception's own `StackTrace` only shows the throw-to-catch chain; the reporting call stack shows the broader entry point context

## Tests
- `AsyncExceptionReportContainsCompleteStackTrace`: Verifies async exception stack traces are complete in XML report
- `ExceptionReportContainsReportingCallStack`: Verifies the new `ReportingCallStack` element is present in XML report
- `CrashReportContainsReportingCallStack`: Verifies the reporting call stack section is present in local `.txt` report

## Checklist
- [x] Write regression test
- [x] Implement fix (XML reports)
- [x] Implement fix (local .txt reports) - reviewer feedback
- [x] Build.ps1 build (0 warnings)
- [x] Tests pass (net8.0 + net472)
- [x] Finalize

-- Claude for @gfraiteur