### PR TITLE
Highlight static subtemplate calls as TemplateKeyword (#762)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplateAnnotator.cs
@@ -848,6 +848,11 @@ internal sealed partial class TemplateAnnotator : SafeSyntaxRewriter, IDiagnosti
                     {
                         nodeOrToken = nodeOrToken.AddColoringAnnotation( TextSpanClassification.TemplateKeyword );
                     }
+                    else if ( symbol is IMethodSymbol
+                              && this._symbolScopeClassifier.GetTemplateInfo( symbol ).AttributeType == TemplateAttributeType.Template )
+                    {
+                        nodeOrToken = nodeOrToken.AddColoringAnnotation( TextSpanClassification.TemplateKeyword );
+                    }
                     else
                     {
                         var node = nodeOrToken.AsNode() ?? nodeOrToken.Parent;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/StaticSubtemplateCall.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/StaticSubtemplateCall.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.TestInputs.Highlighting.StaticSubtemplateCall
+{
+    internal class Aspect : OverrideMethodAspect
+    {
+        public override dynamic? OverrideMethod()
+        {
+            Console.WriteLine( "before" );
+            StaticHelper.LogMessage();
+            AnotherHelper.AnotherTemplate();
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class StaticHelper : ITemplateProvider
+    {
+        [Template]
+        public static void LogMessage()
+        {
+            Console.WriteLine( "from static subtemplate" );
+        }
+    }
+
+    internal class AnotherHelper : ITemplateProvider
+    {
+        [Template]
+        public static void AnotherTemplate()
+        {
+            Console.WriteLine( "from another static subtemplate" );
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/StaticSubtemplateCall.cs.html
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Formatting/StaticSubtemplateCall.cs.html
@@ -1,0 +1,110 @@
+
+<html>
+    <head>
+        <style>
+            .cr-CompileTime,
+            .cr-Conflict,
+            .cr-TemplateKeyword,
+            .cr-Dynamic,
+            .cr-CompileTimeVariable,
+            .cr-GeneratedCode
+            {
+                background-color: rgba(50,50,90,0.1);
+            }
+
+            .cr-NeutralTrivia
+            {
+                background-color: rgba(0,255,0,0.1);
+            }
+
+            .cr-TemplateKeyword
+            {
+                color: rgb(250, 0, 250) !important;
+                font-weight: bold;
+            }
+
+            .cr-Dynamic
+            {
+                text-decoration: underline;
+            }
+
+            .cr-CompileTimeVariable
+            {
+                font-style: italic;
+            }
+
+            .diag-Warning
+            {
+                text-decoration: underline 1px wavy orange;
+            }
+
+            .diag-Error
+            {
+                text-decoration: underline 1px wavy red;
+            }
+
+         .diff-Imaginary {
+                display: block;
+                background-image: repeating-linear-gradient( -45deg, gray, gray 2px, transparent 2px, transparent 8px );
+            }
+
+
+            .legend
+            {
+                margin-top: 100px;
+            }
+        </style>
+    </head>
+    <body><pre><code class="nohighlight"><span class='line-number'>1</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">System</span><span class="cs-punctuation">;</span>
+<span class='line-number'>2</span><span class="cs-keyword">using</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Aspects</span><span class="cs-punctuation">;</span>
+<span class='line-number'>3</span>
+<span class='line-number'>4</span><span class="cs-keyword">namespace</span> <span class="cs-namespace-name">Metalama</span><span class="cs-operator">.</span><span class="cs-namespace-name">Framework</span><span class="cs-operator">.</span><span class="cs-namespace-name">Tests</span><span class="cs-operator">.</span><span class="cs-namespace-name">AspectTests</span><span class="cs-operator">.</span><span class="cs-namespace-name">TestInputs</span><span class="cs-operator">.</span><span class="cs-namespace-name">Highlighting</span><span class="cs-operator">.</span><span class="cs-namespace-name">StaticSubtemplateCall</span>
+<span class='line-number'>5</span><span class="cs-punctuation">{</span>
+<span class='line-number' data-member='Aspect'>6</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">internal</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">class</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">Aspect</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">:</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">OverrideMethodAspect</span>
+<span class='line-number' data-member='Aspect'>7</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">{</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>8</span><span class="cr-NeutralTrivia">        </span><span class="cs-keyword">public</span> <span class="cs-keyword">override</span> <span class="cs-keyword">dynamic</span><span class="cs-operator">?</span> <span class="cs-method-name">OverrideMethod</span><span class="cs-punctuation">()</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>9</span><span class="cr-NeutralTrivia">        </span><span class="cr-RunTime cs-punctuation">{</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>10</span><span class="cr-NeutralTrivia">            </span><span class="cr-RunTime cs-class-name cs-static-symbol">Console</span><span class="cr-RunTime cs-operator">.</span><span class="cr-RunTime cs-method-name cs-static-symbol">WriteLine</span><span class="cr-RunTime cs-punctuation">(</span><span class="cr-RunTime"> </span><span class="cr-RunTime cs-string">"before"</span><span class="cr-RunTime"> </span><span class="cr-RunTime cs-punctuation">);</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>11</span><span class="cr-NeutralTrivia">            </span><span class="cr-CompileTime cs-class-name">StaticHelper</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-TemplateKeyword cs-method-name cs-static-symbol">LogMessage</span><span class="cr-CompileTime cs-punctuation">();</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>12</span><span class="cr-NeutralTrivia">            </span><span class="cr-CompileTime cs-class-name">AnotherHelper</span><span class="cr-CompileTime cs-operator">.</span><span class="cr-TemplateKeyword cs-method-name cs-static-symbol">AnotherTemplate</span><span class="cr-CompileTime cs-punctuation">();</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>13</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>14</span><span class="cr-NeutralTrivia">            </span><span class="cr-RunTime cs-keyword cs-control">return</span><span class="cr-RunTime"> </span><span class="cr-TemplateKeyword cs-class-name cs-static-symbol">meta</span><span class="cr-TemplateKeyword cs-operator">.</span><span class="cr-TemplateKeyword cs-method-name cs-static-symbol">Proceed</span><span class="cr-CompileTime cs-punctuation">()</span><span class="cr-RunTime cs-punctuation">;</span>
+<span class='line-number' data-member='Aspect.OverrideMethod'>15</span><span class="cr-NeutralTrivia">        </span><span class="cr-RunTime cs-punctuation">}</span>
+<span class='line-number' data-member='Aspect'>16</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">}</span>
+<span class='line-number' data-member='Aspect'>17</span>
+<span class='line-number' data-member='StaticHelper'>18</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">internal</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">class</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">StaticHelper</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">:</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-interface-name">ITemplateProvider</span>
+<span class='line-number' data-member='StaticHelper'>19</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">{</span>
+<span class='line-number' data-member='StaticHelper.LogMessage'>20</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-punctuation">[</span><span class="cr-CompileTime cs-class-name">Template</span><span class="cr-CompileTime cs-punctuation">]</span>
+<span class='line-number' data-member='StaticHelper.LogMessage'>21</span><span class="cr-NeutralTrivia">        </span><span class="cs-keyword">public</span> <span class="cs-keyword">static</span> <span class="cs-keyword">void</span> <span class="cs-method-name cs-static-symbol">LogMessage</span><span class="cs-punctuation">()</span>
+<span class='line-number' data-member='StaticHelper.LogMessage'>22</span><span class="cr-NeutralTrivia">        </span><span class="cr-RunTime cs-punctuation">{</span>
+<span class='line-number' data-member='StaticHelper.LogMessage'>23</span><span class="cr-NeutralTrivia">            </span><span class="cr-RunTime cs-class-name cs-static-symbol">Console</span><span class="cr-RunTime cs-operator">.</span><span class="cr-RunTime cs-method-name cs-static-symbol">WriteLine</span><span class="cr-RunTime cs-punctuation">(</span><span class="cr-RunTime"> </span><span class="cr-RunTime cs-string">"from static subtemplate"</span><span class="cr-RunTime"> </span><span class="cr-RunTime cs-punctuation">);</span>
+<span class='line-number' data-member='StaticHelper.LogMessage'>24</span><span class="cr-NeutralTrivia">        </span><span class="cr-RunTime cs-punctuation">}</span>
+<span class='line-number' data-member='StaticHelper'>25</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">}</span>
+<span class='line-number' data-member='StaticHelper'>26</span>
+<span class='line-number' data-member='AnotherHelper'>27</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-keyword">internal</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-keyword">class</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-class-name">AnotherHelper</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-punctuation">:</span><span class="cr-CompileTime"> </span><span class="cr-CompileTime cs-interface-name">ITemplateProvider</span>
+<span class='line-number' data-member='AnotherHelper'>28</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">{</span>
+<span class='line-number' data-member='AnotherHelper.AnotherTemplate'>29</span><span class="cr-NeutralTrivia">        </span><span class="cr-CompileTime cs-punctuation">[</span><span class="cr-CompileTime cs-class-name">Template</span><span class="cr-CompileTime cs-punctuation">]</span>
+<span class='line-number' data-member='AnotherHelper.AnotherTemplate'>30</span><span class="cr-NeutralTrivia">        </span><span class="cs-keyword">public</span> <span class="cs-keyword">static</span> <span class="cs-keyword">void</span> <span class="cs-method-name cs-static-symbol">AnotherTemplate</span><span class="cs-punctuation">()</span>
+<span class='line-number' data-member='AnotherHelper.AnotherTemplate'>31</span><span class="cr-NeutralTrivia">        </span><span class="cr-RunTime cs-punctuation">{</span>
+<span class='line-number' data-member='AnotherHelper.AnotherTemplate'>32</span><span class="cr-NeutralTrivia">            </span><span class="cr-RunTime cs-class-name cs-static-symbol">Console</span><span class="cr-RunTime cs-operator">.</span><span class="cr-RunTime cs-method-name cs-static-symbol">WriteLine</span><span class="cr-RunTime cs-punctuation">(</span><span class="cr-RunTime"> </span><span class="cr-RunTime cs-string">"from another static subtemplate"</span><span class="cr-RunTime"> </span><span class="cr-RunTime cs-punctuation">);</span>
+<span class='line-number' data-member='AnotherHelper.AnotherTemplate'>33</span><span class="cr-NeutralTrivia">        </span><span class="cr-RunTime cs-punctuation">}</span>
+<span class='line-number' data-member='AnotherHelper'>34</span><span class="cr-NeutralTrivia">    </span><span class="cr-CompileTime cs-punctuation">}</span>
+<span class='line-number'>35</span><span class="cs-punctuation">}</span>
+<span class='line-number'>36</span>
+</code></pre>
+       <p class='legend'>Legend:</p>
+       <pre>
+<span class='cr-Default'>Default</span>
+<span class='cr-RunTime'>RunTime</span>
+<span class='cr-CompileTime'>CompileTime</span>
+<span class='cr-Dynamic'>Dynamic</span>
+<span class='cr-CompileTimeVariable'>CompileTimeVariable</span>
+<span class='cr-TemplateKeyword'>TemplateKeyword</span>
+<span class='cr-Conflict'>Conflict</span>
+<span class='cr-Excluded'>Excluded</span>
+<span class='cr-GeneratedCode'>GeneratedCode</span>
+<span class='cr-SourceCode'>SourceCode</span>
+<span class='cr-NeutralTrivia'>NeutralTrivia</span>
+       </pre>
+   </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds syntax highlighting for static calls to auxiliary templates (subtemplates), classifying the method name with the same `TemplateKeyword` classification used for the `meta` keyword.
- Only the method name is colored, per #762.

Closes #762

## Checklist

- [x] Regression test (failing)
- [x] Implement fix
- [x] Build (zero warnings)
- [x] Test (all pass)
- [x] Finalize

— Claude for @gfraiteur