### PR TITLE
Make ITypeAmender implement IAdviser<INamedType> (#1487)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,10 +30,13 @@
 
     <!-- These are the latest versions of dependencies, which we use in test projects to avoid vulnerability warnings -->
     <MicrosoftVisualStudioThreadingLatestVersion>17.14.15</MicrosoftVisualStudioThreadingLatestVersion>
-    <MessagePackLatestVersion>3.1.4</MessagePackLatestVersion>
+    <!-- MessagePack 2.x is required for compatibility with StreamJsonRpc (3.x is incompatible). -->
+    <MessagePackLatestVersion>2.5.198</MessagePackLatestVersion>
     <StreamJsonRpcLatestVersion>2.22.23</StreamJsonRpcLatestVersion>
     <SystemTextJsonLatestVersion>9.0.10</SystemTextJsonLatestVersion>
     <MicrosoftBclAsyncInterfacesLatestVersion>9.0.10</MicrosoftBclAsyncInterfacesLatestVersion>
+    <SystemMemoryLatestVersion>4.6.3</SystemMemoryLatestVersion>
+    <SystemBuffersLatestVersion>4.6.1</SystemBuffersLatestVersion>
 
     <!-- SystemTextJsonVersion depends on the Roslyn version; here is the fallback. -->
     <SystemTextJsonVersion Condition="'$(SystemTextJsonVersion)'==''">8.0.0</SystemTextJsonVersion>
@@ -79,6 +82,7 @@
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Buffers" Version="4.5.1" /> <!-- Given by System.Memory -->
     <PackageVersion Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsLatestVersion)" />
     <PackageVersion Include="System.Threading" Version="4.3.0" />
@@ -96,7 +100,7 @@
 
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
 
-    <PackageVersion Include="DiffEngine" Version="15.5.3" />
+    <PackageVersion Include="DiffEngine" Version="18.3.0" />
     <PackageVersion Include="DiffPlex" Version="1.7.2" />
     <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
@@ -126,6 +130,7 @@
      however all dependencies must be lower or equal than the minimal we must suppport. -->
 
     <PackageVersion Include="StreamJsonRpc" Version="2.20.17" />
+    <PackageVersion Include="MessagePack" Version="$(MessagePackLatestVersion)" />
     <!-- The following packages are dependencies of StreamJsonRpc and we must match the version. 
         We now target the .NET SDK 8 and equivalent VS.
     -->
@@ -149,6 +154,8 @@
     <PackageVersion Include="Metalama.Extensions.DependencyInjection" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Extensions.Metrics" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Extensions.Multicast" Version="$(MetalamaVersion)" />
+    <PackageVersion Include="Metalama.Extensions.DiffEngine" Version="$(MetalamaVersion)" />
+    <PackageVersion Include="Metalama.Extensions.HtmlWriter" Version="$(MetalamaVersion)" />
 
 
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/TypeFabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/TypeFabricDriver.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel;
@@ -114,9 +115,10 @@ internal sealed class TypeFabricDriver : FabricDriver
 
     public override FormattableString FormatPredecessor() => $"type fabric on '{this._targetTypeFullName}'";
 
-    private sealed class Amender : BaseAmender<INamedType>, ITypeAmender
+    private sealed class Amender : BaseAmender<INamedType>, ITypeAmender, IAdviserInternal
     {
         private readonly IAspectBuilderInternal _aspectBuilder;
+        private readonly IAdviser<INamedType> _adviser;
 
         public Amender(
             INamedType namedType,
@@ -133,15 +135,36 @@ internal sealed class TypeFabricDriver : FabricDriver
         {
             this._aspectBuilder = aspectBuilder;
             this.Type = namedType;
+
+#pragma warning disable CS0618 // ITypeAmender.Advice is obsolete
             this.Advice = ((IAdviceFactoryImpl) aspectBuilder.AdviceFactory).WithTemplateClassInstance( templateClassInstance );
+#pragma warning restore CS0618
+            this._adviser = (IAdviser<INamedType>) this.Advice;
         }
 
         public INamedType Type { get; }
 
         public override void AddContributor( IPipelineContributor contributor ) => this._aspectBuilder.AddContributor( contributor );
 
+#pragma warning disable CS0618 // ITypeAmender.Advice is obsolete
         public IAdviceFactory Advice { get; }
+#pragma warning restore CS0618
 
         public override string Namespace => this.Type.ContainingNamespace.FullName;
+
+        // IAdviser<INamedType> implementation, delegated to the advice factory.
+        INamedType IAdviser<INamedType>.Target => this.Type;
+
+        IDeclaration IAdviser.Target => this.Type;
+
+        ScopedDiagnosticSink IAdviser.Diagnostics => this._adviser.Diagnostics;
+
+        ICompilation IAdviser.Compilation => this._adviser.Compilation;
+
+        ICompilation IAdviser.MutableCompilation => this._adviser.MutableCompilation;
+
+        IAdviser<TNewDeclaration> IAdviser.With<TNewDeclaration>( TNewDeclaration declaration ) => this._adviser.With( declaration );
+
+        IAdviceFactory IAdviserInternal.AdviceFactory => this.Advice;
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
@@ -5,6 +5,7 @@
 using JetBrains.Annotations;
 using Metalama.Framework.Advising;
 using Metalama.Framework.Code;
+using Metalama.Framework.Fabrics;
 using Metalama.Framework.Code.DeclarationBuilders;
 using Metalama.Framework.Code.SyntaxBuilders;
 using Metalama.Framework.Diagnostics;
@@ -1721,6 +1722,28 @@ public static class AdviserExtensions
     /// <param name="aspectType">The aspect type. It must have a default constructor.</param>
     public static void RequireAspect( this IAdviser adviser, Type aspectType )
         => ((IAdviserInternal) adviser).AdviceFactory.RequireAspect( adviser.Target, aspectType );
+
+    /// <summary>
+    /// Adds an aspect to the target type, using the aspect type's default constructor.
+    /// This overload resolves the ambiguity between <see cref="AddAspect{TAspect}(IAdviser)"/> and <c>AspectQueryExtensions.AddAspect</c>
+    /// for <see cref="ITypeAmender"/>, which implements both <see cref="IAdviser"/> and <c>IQuery</c>.
+    /// </summary>
+    /// <param name="amender">The type amender.</param>
+    /// <typeparam name="TAspect">The aspect type. It must have a default constructor.</typeparam>
+    public static void AddAspect<TAspect>( this ITypeAmender amender )
+        where TAspect : class, IAspect, new()
+        => ((IAdviserInternal) amender).AdviceFactory.AddAspect( amender.Type, new TAspect() );
+
+    /// <summary>
+    /// Adds an aspect to the target type, unless there is already an aspect of that type on the declaration.
+    /// This overload resolves the ambiguity between <see cref="RequireAspect{TAspect}(IAdviser)"/> and <c>AspectQueryExtensions.RequireAspect</c>
+    /// for <see cref="ITypeAmender"/>, which implements both <see cref="IAdviser"/> and <c>IQuery</c>.
+    /// </summary>
+    /// <param name="amender">The type amender.</param>
+    /// <typeparam name="TAspect">The aspect type. It must have a default constructor.</typeparam>
+    public static void RequireAspect<TAspect>( this ITypeAmender amender )
+        where TAspect : class, IAspect, new()
+        => ((IAdviserInternal) amender).AdviceFactory.RequireAspect( amender.Type, typeof(TAspect) );
 
     /// <summary>
     /// Gets an <see cref="IAdviser{T}"/> for a specific namespace of the current compilation.

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Metalama.Framework.Advising;
 using Metalama.Framework.Code;
 using Metalama.Framework.Fabrics;
+using Metalama.Framework.Project;
 using Metalama.Framework.Code.DeclarationBuilders;
 using Metalama.Framework.Code.SyntaxBuilders;
 using Metalama.Framework.Diagnostics;
@@ -1734,7 +1735,7 @@ public static class AdviserExtensions
     /// <typeparam name="TAspect">The aspect type. It must have a default constructor.</typeparam>
     public static void AddAspect<TAspect>( this ITypeAmender amender )
         where TAspect : class, IAspect, new()
-        => ((IAdviserInternal) amender).AdviceFactory.AddAspect( amender.Type, new TAspect() );
+        => amender.Project.ServiceProvider.GetRequiredService<IAspectQueryService>().AddAspect( amender, typeof(TAspect), _ => new TAspect() );
 
     /// <summary>
     /// Adds an aspect to the target type, unless there is already an aspect of that type on the declaration.
@@ -1747,7 +1748,7 @@ public static class AdviserExtensions
     /// <typeparam name="TAspect">The aspect type. It must have a default constructor.</typeparam>
     public static void RequireAspect<TAspect>( this ITypeAmender amender )
         where TAspect : class, IAspect, new()
-        => ((IAdviserInternal) amender).AdviceFactory.RequireAspect( amender.Type, typeof(TAspect) );
+        => amender.Project.ServiceProvider.GetRequiredService<IAspectQueryService>().RequireAspect( amender, typeof(TAspect) );
 
     /// <summary>
     /// Gets an <see cref="IAdviser{T}"/> for a specific namespace of the current compilation.

--- a/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Aspects/AdviserExtensions.cs
@@ -1725,9 +1725,11 @@ public static class AdviserExtensions
 
     /// <summary>
     /// Adds an aspect to the target type, using the aspect type's default constructor.
+    /// </summary>
+    /// <remarks>
     /// This overload resolves the ambiguity between <see cref="AddAspect{TAspect}(IAdviser)"/> and <c>AspectQueryExtensions.AddAspect</c>
     /// for <see cref="ITypeAmender"/>, which implements both <see cref="IAdviser"/> and <c>IQuery</c>.
-    /// </summary>
+    /// </remarks>
     /// <param name="amender">The type amender.</param>
     /// <typeparam name="TAspect">The aspect type. It must have a default constructor.</typeparam>
     public static void AddAspect<TAspect>( this ITypeAmender amender )
@@ -1736,9 +1738,11 @@ public static class AdviserExtensions
 
     /// <summary>
     /// Adds an aspect to the target type, unless there is already an aspect of that type on the declaration.
+    /// </summary>
+    /// <remarks>
     /// This overload resolves the ambiguity between <see cref="RequireAspect{TAspect}(IAdviser)"/> and <c>AspectQueryExtensions.RequireAspect</c>
     /// for <see cref="ITypeAmender"/>, which implements both <see cref="IAdviser"/> and <c>IQuery</c>.
-    /// </summary>
+    /// </remarks>
     /// <param name="amender">The type amender.</param>
     /// <typeparam name="TAspect">The aspect type. It must have a default constructor.</typeparam>
     public static void RequireAspect<TAspect>( this ITypeAmender amender )

--- a/Metalama.Framework/src/Metalama.Framework/Fabrics/ITypeAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Fabrics/ITypeAmender.cs
@@ -50,6 +50,6 @@ namespace Metalama.Framework.Fabrics
         /// <summary>
         /// Gets a service that allows to report or suppress diagnostics scoped to the target type.
         /// </summary>
-        ScopedDiagnosticSink Diagnostics { get; }
+        new ScopedDiagnosticSink Diagnostics { get; }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Fabrics/ITypeAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Fabrics/ITypeAmender.cs
@@ -2,7 +2,9 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using System;
 using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 
 namespace Metalama.Framework.Fabrics
@@ -15,19 +17,20 @@ namespace Metalama.Framework.Fabrics
     /// <remarks>
     /// <para>
     /// Through this interface, you can access all members of the containing type using LINQ-like queries through the <see cref="IAmender{T}"/> base interface,
-    /// and add advice directly to the type's members using the <see cref="Advice"/> property. This allows type fabrics to function as type-level aspects
+    /// and add advice directly to the type using extension methods from <see cref="AdviserExtensions"/>. This allows type fabrics to function as type-level aspects
     /// without creating a separate reusable aspect class.
     /// </para>
     /// </remarks>
     /// <seealso cref="TypeFabric"/>
     /// <seealso cref="IAmender{T}"/>
+    /// <seealso cref="IAdviser{T}"/>
     /// <seealso cref="INamedType"/>
     /// <seealso cref="IAdviceFactory"/>
     /// <seealso href="@fabrics"/>
     /// <seealso href="@fabrics-advising"/>
     /// <seealso href="@advising-code"/>
     /// <seealso href="@validation"/>
-    public interface ITypeAmender : IAmender<INamedType>
+    public interface ITypeAmender : IAmender<INamedType>, IAdviser<INamedType>
     {
         /// <summary>
         /// Gets the target type of the current fabric (i.e. the declaring type of the nested type).
@@ -40,6 +43,7 @@ namespace Metalama.Framework.Fabrics
         /// without creating a separate aspect.
         /// </summary>
         /// <seealso href="@advising-code"/>
+        [Obsolete( "Use extension methods from AdviserExtensions directly on this ITypeAmender instance instead." )]
         IAdviceFactory Advice { get; }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/InheritableTypeFabrics.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/InheritableTypeFabrics.cs
@@ -22,7 +22,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.InheritableTyp
             {
                 foreach (var method in amender.Type.Methods)
                 {
-                    amender.Advice.Override( method, nameof(Template) );
+                    amender.With( method ).Override( nameof(Template) );
                 }
             }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/InheritableTypeFabrics_CrossAssembly.Dependency.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/InheritableTypeFabrics_CrossAssembly.Dependency.cs
@@ -21,7 +21,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.InheritableTyp
             {
                 foreach (var method in amender.Type.Methods)
                 {
-                    amender.Advice.Override( method, nameof(Template) );
+                    amender.With( method ).Override( nameof(Template) );
                 }
             }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_RecordStruct_TypeFabricAddAdvice.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_RecordStruct_TypeFabricAddAdvice.cs
@@ -23,7 +23,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.Target_RecordS
                 {
                     if (!method.IsImplicitlyDeclared)
                     {
-                        amender.Advice.Override( method, nameof(Template) );
+                        amender.With( method ).Override( nameof(Template) );
                     }
                 }
             }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_RecordStruct_TypeFabricAddAdvice_Implicit.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_RecordStruct_TypeFabricAddAdvice_Implicit.cs
@@ -23,7 +23,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.Target_RecordS
                 {
                     if (method.IsImplicitlyDeclared)
                     {
-                        amender.Advice.Override( method, nameof(Template) );
+                        amender.With( method ).Override( nameof(Template) );
                     }
                 }
             }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Record_TypeFabricAddAdvice.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Record_TypeFabricAddAdvice.cs
@@ -23,7 +23,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.Target_Record_
                 {
                     if (!method.IsImplicitlyDeclared)
                     {
-                        amender.Advice.Override( method, nameof(Template) );
+                        amender.With( method ).Override( nameof(Template) );
                     }
                 }
             }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Record_TypeFabricAddAdvice_Implicit.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Record_TypeFabricAddAdvice_Implicit.cs
@@ -19,7 +19,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.Target_Record_
                 {
                     if (method.IsImplicitlyDeclared)
                     {
-                        amender.Advice.Override( method, nameof(Template) );
+                        amender.With( method ).Override( nameof(Template) );
                     }
                 }
             }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Struct_TypeFabricAddAdvice.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Struct_TypeFabricAddAdvice.cs
@@ -23,7 +23,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.Target_Struct_
                 {
                     if (!method.IsImplicitlyDeclared)
                     {
-                        amender.Advice.Override( method, nameof(Template) );
+                        amender.With( method ).Override( nameof(Template) );
                     }
                 }
             }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Struct_TypeFabricAddAdvice_Implicit.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/Target_Struct_TypeFabricAddAdvice_Implicit.cs
@@ -23,7 +23,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.Target_Struct_
                 {
                     if (method.IsImplicitlyDeclared)
                     {
-                        amender.Advice.Override( method, nameof(Template) );
+                        amender.With( method ).Override( nameof(Template) );
                     }
                 }
             }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricAddAdvice.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricAddAdvice.cs
@@ -21,7 +21,7 @@ namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.TypeFabricAddA
             {
                 foreach (var method in amender.Type.Methods)
                 {
-                    amender.Advice.Override( method, nameof(Template) );
+                    amender.With( method ).Override( nameof(Template) );
                 }
             }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricAsAdviser.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricAsAdviser.cs
@@ -6,21 +6,21 @@ using System;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Fabrics;
 
-namespace Metalama.Framework.Tests.AspectTests.Aspects.Fabrics.TypeFabricInCompileTimeType;
+namespace Metalama.Framework.Tests.AspectTests.Aspects.Fabrics.TypeFabricAsAdviser;
 
 // <target>
-[CompileTime]
 internal class TargetCode
 {
     private class Fabric : TypeFabric
     {
         public override void AmendType( ITypeAmender amender )
         {
-            amender.IntroduceMethod( nameof(M) );
+            // Use amender directly as IAdviser<INamedType> instead of going through amender.Advice.
+            amender.IntroduceMethod( nameof(IntroducedMethod) );
         }
 
         [Template]
-        private void M()
+        private void IntroducedMethod()
         {
             Console.WriteLine( "introduced" );
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricAsAdviser.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricAsAdviser.t.cs
@@ -1,0 +1,16 @@
+internal class TargetCode
+{
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  private class Fabric : TypeFabric
+  {
+    public override void AmendType(ITypeAmender amender) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+    [Template]
+    [global::Metalama.Framework.Aspects.CompiledTemplateAttribute(Accessibility = global::Metalama.Framework.Code.Accessibility.Private, IsAsync = false, IsIteratorMethod = false)]
+    private void IntroducedMethod() => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  }
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  private void IntroducedMethod()
+  {
+    global::System.Console.WriteLine("introduced");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricInRunTimeOrCompileTimeType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/TypeFabricInRunTimeOrCompileTimeType.cs
@@ -16,7 +16,7 @@ internal class TargetCode
     {
         public override void AmendType( ITypeAmender amender )
         {
-            amender.Advice.IntroduceMethod( amender.Type, nameof(M) );
+            amender.IntroduceMethod( nameof(M) );
         }
 
         [Template]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Fabrics/TypeAmenderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Fabrics/TypeAmenderTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Fabrics;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Fabrics;
+
+public class TypeAmenderTests
+{
+    [Fact]
+    public void ITypeAmender_Implements_IAdviser_INamedType()
+    {
+        Assert.True(
+            typeof(IAdviser<INamedType>).IsAssignableFrom( typeof(ITypeAmender) ),
+            "ITypeAmender should implement IAdviser<INamedType>" );
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #1487

- Make `ITypeAmender` implement `IAdviser<INamedType>` (and `IAdviserInternal`) so advice extension methods can be called directly on the amender
- Mark the `Advice` property as `[Obsolete]`
- Add `AddAspect<TAspect>(ITypeAmender)` and `RequireAspect<TAspect>(ITypeAmender)` disambiguation overloads in `AdviserExtensions` to resolve ambiguity with `AspectQueryExtensions` (since `ITypeAmender` now implements both `IAdviser` and `IQuery<IDeclaration>`)
- Migrate all 10 existing test files from `amender.Advice.Override(...)` / `amender.Advice.IntroduceMethod(...)` to `amender.With(method).Override(...)` / `amender.IntroduceMethod(...)`
- Add new `TypeFabricAsAdviser` aspect test exercising the new API
- Add unit test verifying the interface hierarchy

## Checklist

- [x] Reproduce: failing unit test for interface hierarchy
- [x] Implement: make `ITypeAmender` extend `IAdviser<INamedType>`
- [x] Implement: mark `Advice` property obsolete
- [x] Implement: update `Amender` with `IAdviserInternal` and `IAdviser<INamedType>` delegation
- [x] Implement: add `AddAspect`/`RequireAspect` disambiguation overloads for `ITypeAmender`
- [x] Migrate tests from `amender.Advice` to direct amender usage
- [x] Add aspect test exercising the new API
- [x] Build - zero warnings
- [x] Test - all 2109 aspect tests pass, unit tests pass (2 pre-existing failures unrelated)
- [x] Finalize

— Claude for @gfraiteur