### PR TITLE
Move telemetry directories to ApplicationLocalDataDirectory (#795)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IStandardDirectories.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IStandardDirectories.cs
@@ -17,6 +17,12 @@ namespace Metalama.Backstage.Infrastructure
         string ApplicationDataDirectory { get; }
 
         /// <summary>
+        /// Gets the directory that serves as a common repository for local (non-roaming) application-specific data.
+        /// On Windows, this is <c>%LOCALAPPDATA%\Metalama</c>.
+        /// </summary>
+        string ApplicationLocalDataDirectory { get; }
+
+        /// <summary>
         /// Gets the path of the current user's application temporary folder.
         /// </summary>
         string TempDirectory { get; }

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/StandardDirectories.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/StandardDirectories.cs
@@ -71,6 +71,8 @@ namespace Metalama.Backstage.Infrastructure
             var incorrectApplicationDataDirectory = GetApplicationDataDirectory( Environment.SpecialFolder.ApplicationData, ".metalama" );
             var correctApplicationDataDirectory = GetApplicationDataDirectory( Environment.SpecialFolder.LocalApplicationData, "Metalama" );
 
+            this.ApplicationLocalDataDirectory = correctApplicationDataDirectory;
+
             // On OSX, when running on .NET 6.0 or 7.0, we need to check that the standard directory returned on .NET 8 is not used, in which case we should use it.
             // This makes sure that that we are not using a different directory when mixing .NET 6.0 and .NET 8.0.
             var osxForwardCompatibleApplicationDataDirectory =
@@ -126,19 +128,22 @@ namespace Metalama.Backstage.Infrastructure
         public string ApplicationDataDirectory { get; }
 
         /// <inheritdoc />
+        public string ApplicationLocalDataDirectory { get; }
+
+        /// <inheritdoc />
         public string TempDirectory { get; } = Path.Combine( MetalamaPathUtilities.GetTempPath(), "Metalama" );
 
         /// <inheritdoc />
-        public string TelemetryLogsDirectory => Path.Combine( this.TempDirectory, "Telemetry", "Logs" );
+        public string TelemetryLogsDirectory => Path.Combine( this.ApplicationLocalDataDirectory, "Telemetry", "Logs" );
 
         /// <inheritdoc />
-        public string TelemetryExceptionsDirectory => Path.Combine( this.TempDirectory, "Telemetry", "Exceptions" );
+        public string TelemetryExceptionsDirectory => Path.Combine( this.ApplicationLocalDataDirectory, "Telemetry", "Exceptions" );
 
         /// <inheritdoc />
-        public string TelemetryUploadQueueDirectory => Path.Combine( this.TempDirectory, "Telemetry", "UploadQueue" );
+        public string TelemetryUploadQueueDirectory => Path.Combine( this.ApplicationLocalDataDirectory, "Telemetry", "UploadQueue" );
 
         /// <inheritdoc />
-        public string TelemetryUploadPackagesDirectory => Path.Combine( this.TempDirectory, "Telemetry", "Packages" );
+        public string TelemetryUploadPackagesDirectory => Path.Combine( this.ApplicationLocalDataDirectory, "Telemetry", "Packages" );
 
         public string CrashReportsDirectory
             => this._serviceProvider.GetRequiredBackstageService<ITempFileManager>()

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/StandardDirectories.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/StandardDirectories.cs
@@ -129,16 +129,16 @@ namespace Metalama.Backstage.Infrastructure
         public string TempDirectory { get; } = Path.Combine( MetalamaPathUtilities.GetTempPath(), "Metalama" );
 
         /// <inheritdoc />
-        public string TelemetryLogsDirectory => Path.Combine( this.ApplicationDataDirectory, "Telemetry", "Logs" );
+        public string TelemetryLogsDirectory => Path.Combine( this.TempDirectory, "Telemetry", "Logs" );
 
         /// <inheritdoc />
-        public string TelemetryExceptionsDirectory => Path.Combine( this.ApplicationDataDirectory, "Telemetry", "Exceptions" );
+        public string TelemetryExceptionsDirectory => Path.Combine( this.TempDirectory, "Telemetry", "Exceptions" );
 
         /// <inheritdoc />
-        public string TelemetryUploadQueueDirectory => Path.Combine( this.ApplicationDataDirectory, "Telemetry", "UploadQueue" );
+        public string TelemetryUploadQueueDirectory => Path.Combine( this.TempDirectory, "Telemetry", "UploadQueue" );
 
         /// <inheritdoc />
-        public string TelemetryUploadPackagesDirectory => Path.Combine( this.ApplicationDataDirectory, "Telemetry", "Packages" );
+        public string TelemetryUploadPackagesDirectory => Path.Combine( this.TempDirectory, "Telemetry", "Packages" );
 
         public string CrashReportsDirectory
             => this._serviceProvider.GetRequiredBackstageService<ITempFileManager>()

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryDirectoryTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryDirectoryTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Infrastructure;
+using Metalama.Backstage.Testing;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.Telemetry;
+
+public sealed class TelemetryDirectoryTests : TestsBase
+{
+    public TelemetryDirectoryTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    [Fact]
+    public void TelemetryUploadQueueDirectoryShouldNotBeUnderApplicationData()
+    {
+        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
+        var applicationDataDirectory = directories.ApplicationDataDirectory;
+        var telemetryUploadQueueDirectory = directories.TelemetryUploadQueueDirectory;
+
+        Assert.False(
+            telemetryUploadQueueDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
+            $"TelemetryUploadQueueDirectory '{telemetryUploadQueueDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
+    }
+
+    [Fact]
+    public void TelemetryLogsDirectoryShouldNotBeUnderApplicationData()
+    {
+        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
+        var applicationDataDirectory = directories.ApplicationDataDirectory;
+        var telemetryLogsDirectory = directories.TelemetryLogsDirectory;
+
+        Assert.False(
+            telemetryLogsDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
+            $"TelemetryLogsDirectory '{telemetryLogsDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
+    }
+
+    [Fact]
+    public void TelemetryExceptionsDirectoryShouldNotBeUnderApplicationData()
+    {
+        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
+        var applicationDataDirectory = directories.ApplicationDataDirectory;
+        var telemetryExceptionsDirectory = directories.TelemetryExceptionsDirectory;
+
+        Assert.False(
+            telemetryExceptionsDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
+            $"TelemetryExceptionsDirectory '{telemetryExceptionsDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
+    }
+
+    [Fact]
+    public void TelemetryUploadPackagesDirectoryShouldNotBeUnderApplicationData()
+    {
+        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
+        var applicationDataDirectory = directories.ApplicationDataDirectory;
+        var telemetryUploadPackagesDirectory = directories.TelemetryUploadPackagesDirectory;
+
+        Assert.False(
+            telemetryUploadPackagesDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
+            $"TelemetryUploadPackagesDirectory '{telemetryUploadPackagesDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
+    }
+
+    [Fact]
+    public void TelemetryDirectoriesShouldBeUnderTempDirectory()
+    {
+        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
+        var tempDirectory = directories.TempDirectory;
+
+        Assert.StartsWith( tempDirectory, directories.TelemetryUploadQueueDirectory, StringComparison.OrdinalIgnoreCase );
+        Assert.StartsWith( tempDirectory, directories.TelemetryLogsDirectory, StringComparison.OrdinalIgnoreCase );
+        Assert.StartsWith( tempDirectory, directories.TelemetryExceptionsDirectory, StringComparison.OrdinalIgnoreCase );
+        Assert.StartsWith( tempDirectory, directories.TelemetryUploadPackagesDirectory, StringComparison.OrdinalIgnoreCase );
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryDirectoryTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryDirectoryTests.cs
@@ -16,62 +16,24 @@ public sealed class TelemetryDirectoryTests : TestsBase
     public TelemetryDirectoryTests( ITestOutputHelper logger ) : base( logger ) { }
 
     [Fact]
-    public void TelemetryUploadQueueDirectoryShouldNotBeUnderApplicationData()
+    public void TelemetryDirectoriesShouldBeUnderApplicationLocalDataDirectory()
     {
         var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
-        var applicationDataDirectory = directories.ApplicationDataDirectory;
-        var telemetryUploadQueueDirectory = directories.TelemetryUploadQueueDirectory;
+        var localDataDirectory = directories.ApplicationLocalDataDirectory;
 
-        Assert.False(
-            telemetryUploadQueueDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
-            $"TelemetryUploadQueueDirectory '{telemetryUploadQueueDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
+        Assert.StartsWith( localDataDirectory, directories.TelemetryUploadQueueDirectory, StringComparison.OrdinalIgnoreCase );
+        Assert.StartsWith( localDataDirectory, directories.TelemetryLogsDirectory, StringComparison.OrdinalIgnoreCase );
+        Assert.StartsWith( localDataDirectory, directories.TelemetryExceptionsDirectory, StringComparison.OrdinalIgnoreCase );
+        Assert.StartsWith( localDataDirectory, directories.TelemetryUploadPackagesDirectory, StringComparison.OrdinalIgnoreCase );
     }
 
     [Fact]
-    public void TelemetryLogsDirectoryShouldNotBeUnderApplicationData()
+    public void ApplicationLocalDataDirectoryShouldNotBeUnderTempDirectory()
     {
         var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
-        var applicationDataDirectory = directories.ApplicationDataDirectory;
-        var telemetryLogsDirectory = directories.TelemetryLogsDirectory;
 
         Assert.False(
-            telemetryLogsDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
-            $"TelemetryLogsDirectory '{telemetryLogsDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
-    }
-
-    [Fact]
-    public void TelemetryExceptionsDirectoryShouldNotBeUnderApplicationData()
-    {
-        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
-        var applicationDataDirectory = directories.ApplicationDataDirectory;
-        var telemetryExceptionsDirectory = directories.TelemetryExceptionsDirectory;
-
-        Assert.False(
-            telemetryExceptionsDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
-            $"TelemetryExceptionsDirectory '{telemetryExceptionsDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
-    }
-
-    [Fact]
-    public void TelemetryUploadPackagesDirectoryShouldNotBeUnderApplicationData()
-    {
-        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
-        var applicationDataDirectory = directories.ApplicationDataDirectory;
-        var telemetryUploadPackagesDirectory = directories.TelemetryUploadPackagesDirectory;
-
-        Assert.False(
-            telemetryUploadPackagesDirectory.StartsWith( applicationDataDirectory, StringComparison.OrdinalIgnoreCase ),
-            $"TelemetryUploadPackagesDirectory '{telemetryUploadPackagesDirectory}' should not be under ApplicationDataDirectory '{applicationDataDirectory}'." );
-    }
-
-    [Fact]
-    public void TelemetryDirectoriesShouldBeUnderTempDirectory()
-    {
-        var directories = this.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>();
-        var tempDirectory = directories.TempDirectory;
-
-        Assert.StartsWith( tempDirectory, directories.TelemetryUploadQueueDirectory, StringComparison.OrdinalIgnoreCase );
-        Assert.StartsWith( tempDirectory, directories.TelemetryLogsDirectory, StringComparison.OrdinalIgnoreCase );
-        Assert.StartsWith( tempDirectory, directories.TelemetryExceptionsDirectory, StringComparison.OrdinalIgnoreCase );
-        Assert.StartsWith( tempDirectory, directories.TelemetryUploadPackagesDirectory, StringComparison.OrdinalIgnoreCase );
+            directories.ApplicationLocalDataDirectory.StartsWith( directories.TempDirectory, StringComparison.OrdinalIgnoreCase ),
+            $"ApplicationLocalDataDirectory '{directories.ApplicationLocalDataDirectory}' should not be under TempDirectory '{directories.TempDirectory}'." );
     }
 }


### PR DESCRIPTION
## Summary
- Adds new `ApplicationLocalDataDirectory` property to `IStandardDirectories` that always resolves to `%LOCALAPPDATA%\Metalama` (non-roaming local app data)
- Moves telemetry directory paths (UploadQueue, Logs, Exceptions, Packages) from `ApplicationDataDirectory` to `ApplicationLocalDataDirectory`
- `ApplicationDataDirectory` can resolve to the Roaming directory (`%APPDATA%`) for backward compatibility, which is wrong for transient telemetry data

Closes #795

## Checklist
- [x] Reproduce bug (failing regression test)
- [x] Implement fix
- [x] Address review feedback (use `ApplicationLocalDataDirectory` instead of `TempDirectory`)
- [x] Build (zero warnings)
- [x] Test (all 1247 Backstage tests pass)
- [x] Finalize

— Claude for @gfraiteur