### PR TITLE
Fix NotEmptyAttribute eligibility check (#796)

### DIFF
--- a/Metalama.Patterns/src/Metalama.Patterns.Contracts/NotEmptyAttribute.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Contracts/NotEmptyAttribute.cs
@@ -36,8 +36,47 @@ public sealed class NotEmptyAttribute : ContractBaseAttribute
         base.BuildEligibility( builder );
 
         builder.MustSatisfy(
-            f => f.Type is INamedType t && (t.Equals( SpecialType.String ) || TryGetCompatibleTargetInterface( t, out _, out _ )),
-            f => $"the type of {f} must string or implement ICollection, ICollection<T> or IReadOnlyCollection<T>" );
+            f => IsEligibleType( f.Type ),
+            f => $"the type of {f} must be a string, array, or collection type" );
+    }
+
+    /// <inheritdoc/>
+    public override void BuildEligibility( IEligibilityBuilder<IParameter> builder )
+    {
+        base.BuildEligibility( builder );
+
+        builder.MustSatisfy(
+            p => IsEligibleType( p.Type ),
+            p => $"the type of {p} must be a string, array, or collection type" );
+    }
+
+    [CompileTime]
+    private static bool IsEligibleType( IType type )
+        => type is IArrayType
+           || type.Equals( SpecialType.String )
+           || (type is INamedType namedType
+               && (namedType.IsConvertibleTo( typeof(ICollection) )
+                   || namedType.Definition.IsConvertibleTo( typeof(ImmutableArray<>) )
+                   || ImplementsGenericCollectionInterface( namedType )));
+
+    [CompileTime]
+    private static bool ImplementsGenericCollectionInterface( INamedType namedType )
+    {
+        foreach ( var t in namedType.GetSelfAndAllImplementedInterfaces() )
+        {
+            if ( t.IsGeneric )
+            {
+                var definition = t.Definition;
+
+                if ( definition.ContainingNamespace.FullName == "System.Collections.Generic"
+                     && definition.Name is "IReadOnlyCollection" or "ICollection" )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <inheritdoc/>

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Int.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Int.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Metalama.Patterns.Contracts.AspectTests.Diagnostics;
+
+public class NotEmpty_Ineligible_Int
+{
+    [NotEmpty]
+    private int field;
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Int.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Int.t.cs
@@ -1,0 +1,1 @@
+// Error LAMA0037 on `NotEmpty`: `The aspect 'NotEmpty' cannot be applied to the field 'NotEmpty_Ineligible_Int.field' because the type of 'NotEmpty_Ineligible_Int.field' must be a string, array, or collection type.`

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Parameter.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Parameter.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Metalama.Patterns.Contracts.AspectTests.Diagnostics;
+
+public class NotEmpty_Ineligible_Parameter
+{
+    public void Method( [NotEmpty] int value ) { }
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Parameter.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Parameter.t.cs
@@ -1,0 +1,1 @@
+// Error LAMA0037 on `NotEmpty`: `The aspect 'NotEmpty' cannot be applied to the parameter 'NotEmpty_Ineligible_Parameter.Method(int)/value' because the type of 'NotEmpty_Ineligible_Parameter.Method(int)/value' must be a string, array, or collection type.`

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Struct.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Struct.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+
+namespace Metalama.Patterns.Contracts.AspectTests.Diagnostics;
+
+public class NotEmpty_Ineligible_Struct
+{
+    [NotEmpty]
+    private DateTime field;
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Struct.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Diagnostics/NotEmpty_Ineligible_Struct.t.cs
@@ -1,0 +1,1 @@
+// Error LAMA0037 on `NotEmpty`: `The aspect 'NotEmpty' cannot be applied to the field 'NotEmpty_Ineligible_Struct.field' because the type of 'NotEmpty_Ineligible_Struct.field' must be a string, array, or collection type.`


### PR DESCRIPTION
## Summary

Fixes #796 — `NotEmptyAttribute` does not check for eligibility.

When `[NotEmpty]` was applied to a type that is not a string, array, or collection (e.g., `int`, `DateTime`), the `BuildEligibility` method crashed with a `NullReferenceException` in `TypeFactory.GetType()` instead of properly reporting ineligibility.

### Root Cause
`BuildEligibility` called `TryGetCompatibleTargetInterface`, which internally uses `TypeFactory.GetType()` — an API not available during eligibility evaluation (eligibility runs on an uninitialized object instance).

### Fix
- Replaced the `TryGetCompatibleTargetInterface` call in `BuildEligibility` with a new `IsEligibleType` method that checks type compatibility using `IsConvertibleTo`, `IArrayType` checks, and interface name matching (avoiding `TypeFactory`).
- Added the missing `BuildEligibility(IEligibilityBuilder<IParameter>)` overload.

### Tests Added
- `NotEmpty_Ineligible_Int` — `[NotEmpty]` on `int` field
- `NotEmpty_Ineligible_Struct` — `[NotEmpty]` on `DateTime` field  
- `NotEmpty_Ineligible_Parameter` — `[NotEmpty]` on `int` parameter

## Checklist

- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build (zero warnings)
- [x] Test (all pass)
- [x] Finalize

— Claude for @gfraiteur