### PR TITLE
Add back navigation button to Backstage web UI

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ChooseLicenseKind.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ChooseLicenseKind.cshtml
@@ -49,10 +49,9 @@
         </div>
     </div>
 
-    <div class="navigation-buttons">
+    <div class="navigation-buttons" style="justify-content: flex-start;">
         <div class="back-button">
             <a href="/">&larr; Back</a>
         </div>
-        <div></div>
     </div>
 </form>

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ChooseLicenseKind.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ChooseLicenseKind.cshtml
@@ -48,4 +48,11 @@
                 eliminating those licensing notifications.</p>
         </div>
     </div>
+
+    <div class="navigation-buttons">
+        <div class="back-button">
+            <a href="/">&larr; Back</a>
+        </div>
+        <div></div>
+    </div>
 </form>

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/Consents.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/Consents.cshtml
@@ -103,17 +103,22 @@
             </label>
         </div>
     </div>
-    <div class="continue-button">
-        @if (Model.IsDeviceOnline)
-        {
-            <button type="submit" class="g-recaptcha" data-sitekey="@Model.RecaptchaSiteKey" data-callback="onSubmit">
-                Continue
-            </button>
-        }
-        else
-        {
-            <button type="submit">Continue</button>
-        }
+    <div class="navigation-buttons">
+        <div class="back-button">
+            <a href="@Model.BackUrl">&larr; Back</a>
+        </div>
+        <div class="continue-button">
+            @if (Model.IsDeviceOnline)
+            {
+                <button type="submit" class="g-recaptcha" data-sitekey="@Model.RecaptchaSiteKey" data-callback="onSubmit">
+                    Continue
+                </button>
+            }
+            else
+            {
+                <button type="submit">Continue</button>
+            }
+        </div>
     </div>
 
 </form>

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/Consents.cshtml.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/Consents.cshtml.cs
@@ -76,6 +76,10 @@ internal class ConsentsPageModel : PageModel
 
     public bool IsDeviceOnline { get; set; }
 
+#pragma warning disable CA1822 // Accessed as Model.BackUrl in Razor
+    public string BackUrl => GlobalState.SelectedAction == SelectedAction.Register ? "/LicenseKey" : "/ChooseLicenseKind";
+#pragma warning restore CA1822
+
     private async Task PrepareCaptchaAsync()
     {
         var recaptchaSiteKey = await this._recaptcha.GetRecaptchaSiteKeyAsync();

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/Consents.cshtml.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/Consents.cshtml.cs
@@ -76,9 +76,7 @@ internal class ConsentsPageModel : PageModel
 
     public bool IsDeviceOnline { get; set; }
 
-#pragma warning disable CA1822 // Accessed as Model.BackUrl in Razor
-    public string BackUrl => GlobalState.SelectedAction == SelectedAction.Register ? "/LicenseKey" : "/ChooseLicenseKind";
-#pragma warning restore CA1822
+    public string BackUrl { get; private set; } = "/ChooseLicenseKind";
 
     private async Task PrepareCaptchaAsync()
     {
@@ -93,6 +91,8 @@ internal class ConsentsPageModel : PageModel
 
     public async Task<IActionResult> OnGetAsync()
     {
+        this.BackUrl = GlobalState.SelectedAction == SelectedAction.Register ? "/LicenseKey" : "/ChooseLicenseKind";
+
         await this.PrepareCaptchaAsync();
 
         // If newsletter is not available, we keep the email address empty, so the field validation is not triggered.
@@ -106,6 +106,8 @@ internal class ConsentsPageModel : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
+        this.BackUrl = GlobalState.SelectedAction == SelectedAction.Register ? "/LicenseKey" : "/ChooseLicenseKind";
+
         await this.PrepareCaptchaAsync();
 
         if ( !this.ModelState.IsValid )

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/LicenseKey.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/LicenseKey.cshtml
@@ -10,8 +10,13 @@
         <textarea asp-for="LicenseKey"></textarea>
     </p>
 
-    <div class="continue-button" rows="4">
-        <button type="submit">Continue</button>
+    <div class="navigation-buttons">
+        <div class="back-button">
+            <a href="/ChooseLicenseKind">&larr; Back</a>
+        </div>
+        <div class="continue-button">
+            <button type="submit">Continue</button>
+        </div>
     </div>
 </form>
 

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/RssOptions.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/RssOptions.cshtml
@@ -48,6 +48,13 @@
         </div>
 
     </div>
+
+    <div class="navigation-buttons">
+        <div class="back-button">
+            <a href="/">&larr; Back</a>
+        </div>
+        <div></div>
+    </div>
 </form>
 
 

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/RssOptions.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/RssOptions.cshtml
@@ -49,11 +49,10 @@
 
     </div>
 
-    <div class="navigation-buttons">
+    <div class="navigation-buttons" style="justify-content: flex-start;">
         <div class="back-button">
             <a href="/">&larr; Back</a>
         </div>
-        <div></div>
     </div>
 </form>
 

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/wwwroot/css/site.css
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/wwwroot/css/site.css
@@ -171,3 +171,22 @@ input[type="text"]:focus, input[type="email"]:focus, input[type="password"]:focu
 .continue-button {
   text-align: right;
 }
+
+.navigation-buttons {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.back-button a {
+  color: #b1b0b2;
+  text-decoration: none;
+  cursor: pointer;
+  padding: 10px 20px;
+  transition: color 0.3s ease;
+}
+
+.back-button a:hover {
+  color: #fff;
+}


### PR DESCRIPTION
Closes #696

## Summary

- Adds a back navigation button to the Backstage web UI wizard pages
- **ChooseLicenseKind** → Back to Index (home)
- **LicenseKey** → Back to ChooseLicenseKind
- **Consents** → Back to LicenseKey (if RegisterKey action) or ChooseLicenseKind (if Trial/Skip)
- **RssOptions** → Back to Index (home)
- Done/DoneOpenSource/InstallVsx pages have no back button (terminal or post-registration pages)

## Changes

- Added `.navigation-buttons` and `.back-button` CSS classes for consistent back/forward button layout
- Added back links to ChooseLicenseKind, LicenseKey, Consents, and RssOptions pages
- Added `BackUrl` property to `ConsentsPageModel` to determine context-dependent back URL

## Checklist

- [x] Implement back navigation button
- [x] Build succeeds with zero warnings
- [x] Existing tests pass
- [x] Full `Build.ps1 build` verification
- [x] `dotnet test` verification (all Backstage tests pass)
- [x] Mark PR as ready

— Claude for @gfraiteur