### PR TITLE
Fix file-local types producing duplicate SerializableDeclarationId (#662)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/DocumentationIdHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/DocumentationIdHelper.cs
@@ -79,6 +79,29 @@ namespace Metalama.Framework.Engine.SerializableIds
             return results.Count == 0 ? null : results[0];
         }
 
+        /// <summary>
+        /// Gets all declarations that match the declaration id string.
+        /// </summary>
+        public static IReadOnlyList<IDeclaration> GetDeclarationsForDeclarationId( string id, CompilationModel compilation )
+        {
+            if ( id == null )
+            {
+                throw new ArgumentNullException( nameof(id) );
+            }
+
+            if ( compilation == null )
+            {
+                throw new ArgumentNullException( nameof(compilation) );
+            }
+
+            var results = new List<IDeclaration>();
+
+            var parser = new Parser( compilation );
+            parser.ParseDeclaredSymbolId( id, results );
+
+            return results;
+        }
+
         private static int GetTotalTypeParameterCount( INamedType? namedType )
         {
             var n = 0;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/DocumentationIdHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/DocumentationIdHelper.cs
@@ -79,29 +79,6 @@ namespace Metalama.Framework.Engine.SerializableIds
             return results.Count == 0 ? null : results[0];
         }
 
-        /// <summary>
-        /// Gets all declarations that match the declaration id string.
-        /// </summary>
-        public static IReadOnlyList<IDeclaration> GetDeclarationsForDeclarationId( string id, CompilationModel compilation )
-        {
-            if ( id == null )
-            {
-                throw new ArgumentNullException( nameof(id) );
-            }
-
-            if ( compilation == null )
-            {
-                throw new ArgumentNullException( nameof(compilation) );
-            }
-
-            var results = new List<IDeclaration>();
-
-            var parser = new Parser( compilation );
-            parser.ParseDeclaredSymbolId( id, results );
-
-            return results;
-        }
-
         private static int GetTotalTypeParameterCount( INamedType? namedType )
         {
             var n = 0;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
@@ -92,10 +92,10 @@ public static partial class SerializableDeclarationIdProvider
                         exception );
                 }
 
-                // For file-local types (or members of file-local types), append the source file path
+                // For file-local types (or members of file-local types), append a hash of the source file path
                 // to disambiguate types with the same name in different files.
-                var fileLocalPath = GetFileLocalFilePath( declaration );
-                var idString = AppendFileLocalSuffix( documentationId, fileLocalPath );
+                var fileLocalHash = GetFileLocalHash( declaration );
+                var idString = AppendFileLocalSuffix( documentationId, fileLocalHash );
 
                 id = new SerializableDeclarationId( targetKind == RefTargetKind.Default ? idString : $"{idString};{targetKind}" );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
@@ -44,8 +44,10 @@ public static partial class SerializableDeclarationIdProvider
             case DeclarationKind.Parameter when declaration is IParameter parameter:
                 {
                     var parentId = DocumentationIdHelper.CreateDeclarationId( parameter.ContainingDeclaration.AssertNotNull() ).AssertNotNull();
+                    var paramFileLocalHash = GetFileLocalHash( declaration );
+                    var parentIdWithHash = AppendFileLocalSuffix( parentId, paramFileLocalHash );
 
-                    id = new SerializableDeclarationId( $"{parentId};Parameter={parameter.Index}" );
+                    id = new SerializableDeclarationId( $"{parentIdWithHash};Parameter={parameter.Index}" );
 
                     return true;
                 }
@@ -53,8 +55,10 @@ public static partial class SerializableDeclarationIdProvider
             case DeclarationKind.TypeParameter when declaration is ITypeParameter typeParameter:
                 {
                     var parentId = DocumentationIdHelper.CreateDeclarationId( typeParameter.ContainingDeclaration! ).AssertNotNull();
+                    var typeParamFileLocalHash = GetFileLocalHash( declaration );
+                    var parentIdWithHash = AppendFileLocalSuffix( parentId, typeParamFileLocalHash );
 
-                    id = new SerializableDeclarationId( $"{parentId};TypeParameter={typeParameter.Index}" );
+                    id = new SerializableDeclarationId( $"{parentIdWithHash};TypeParameter={typeParameter.Index}" );
 
                     return true;
                 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
@@ -43,22 +43,32 @@ public static partial class SerializableDeclarationIdProvider
 
             case DeclarationKind.Parameter when declaration is IParameter parameter:
                 {
-                    var parentId = DocumentationIdHelper.CreateDeclarationId( parameter.ContainingDeclaration.AssertNotNull() ).AssertNotNull();
-                    var paramFileLocalHash = GetFileLocalHash( declaration );
-                    var parentIdWithHash = AppendFileLocalSuffix( parentId, paramFileLocalHash );
+                    if ( IsInFileLocalType( declaration ) )
+                    {
+                        id = default;
 
-                    id = new SerializableDeclarationId( $"{parentIdWithHash};Parameter={parameter.Index}" );
+                        return false;
+                    }
+
+                    var parentId = DocumentationIdHelper.CreateDeclarationId( parameter.ContainingDeclaration.AssertNotNull() ).AssertNotNull();
+
+                    id = new SerializableDeclarationId( $"{parentId};Parameter={parameter.Index}" );
 
                     return true;
                 }
 
             case DeclarationKind.TypeParameter when declaration is ITypeParameter typeParameter:
                 {
-                    var parentId = DocumentationIdHelper.CreateDeclarationId( typeParameter.ContainingDeclaration! ).AssertNotNull();
-                    var typeParamFileLocalHash = GetFileLocalHash( declaration );
-                    var parentIdWithHash = AppendFileLocalSuffix( parentId, typeParamFileLocalHash );
+                    if ( IsInFileLocalType( declaration ) )
+                    {
+                        id = default;
 
-                    id = new SerializableDeclarationId( $"{parentIdWithHash};TypeParameter={typeParameter.Index}" );
+                        return false;
+                    }
+
+                    var parentId = DocumentationIdHelper.CreateDeclarationId( typeParameter.ContainingDeclaration! ).AssertNotNull();
+
+                    id = new SerializableDeclarationId( $"{parentId};TypeParameter={typeParameter.Index}" );
 
                     return true;
                 }
@@ -83,6 +93,13 @@ public static partial class SerializableDeclarationIdProvider
                 return TryGetSerializableId( eventRaisePseudoAccessor.DeclaringMember, RefTargetKind.EventRaise, out id );
 
             default:
+                if ( IsInFileLocalType( declaration ) )
+                {
+                    id = default;
+
+                    return false;
+                }
+
                 string documentationId;
 
                 try
@@ -96,12 +113,7 @@ public static partial class SerializableDeclarationIdProvider
                         exception );
                 }
 
-                // For file-local types (or members of file-local types), append a hash of the source file path
-                // to disambiguate types with the same name in different files.
-                var fileLocalHash = GetFileLocalHash( declaration );
-                var idString = AppendFileLocalSuffix( documentationId, fileLocalHash );
-
-                id = new SerializableDeclarationId( targetKind == RefTargetKind.Default ? idString : $"{idString};{targetKind}" );
+                id = new SerializableDeclarationId( targetKind == RefTargetKind.Default ? documentationId : $"{documentationId};{targetKind}" );
 
                 return true;
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromDeclaration.cs
@@ -92,7 +92,12 @@ public static partial class SerializableDeclarationIdProvider
                         exception );
                 }
 
-                id = new SerializableDeclarationId( targetKind == RefTargetKind.Default ? documentationId : $"{documentationId};{targetKind}" );
+                // For file-local types (or members of file-local types), append the source file path
+                // to disambiguate types with the same name in different files.
+                var fileLocalPath = GetFileLocalFilePath( declaration );
+                var idString = AppendFileLocalSuffix( documentationId, fileLocalPath );
+
+                id = new SerializableDeclarationId( targetKind == RefTargetKind.Default ? idString : $"{idString};{targetKind}" );
 
                 return true;
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
@@ -81,6 +81,7 @@ public static partial class SerializableDeclarationIdProvider
                 }
 
             case SymbolKind.NamedType when symbol is INamedTypeSymbol:
+                // File-local types need special handling - fall through to default but with file path appended.
                 goto default;
 
             case SymbolKind.ArrayType or SymbolKind.PointerType or SymbolKind.FunctionPointerType or SymbolKind.DynamicType or SymbolKind.ErrorType
@@ -111,13 +112,18 @@ public static partial class SerializableDeclarationIdProvider
                                 return false;
                             }
 
+                            // For file-local types (or members of file-local types), append the source file path
+                            // to disambiguate types with the same name in different files.
+                            var fileLocalPath = GetFileLocalFilePath( symbol );
+                            var idString = AppendFileLocalSuffix( documentationId, fileLocalPath );
+
                             if ( targetKind == RefTargetKind.Default )
                             {
-                                id = new SerializableDeclarationId( documentationId );
+                                id = new SerializableDeclarationId( idString );
                             }
                             else
                             {
-                                id = new SerializableDeclarationId( $"{documentationId};{targetKind}" );
+                                id = new SerializableDeclarationId( $"{idString};{targetKind}" );
                             }
 
                             return true;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
@@ -81,7 +81,7 @@ public static partial class SerializableDeclarationIdProvider
                 }
 
             case SymbolKind.NamedType when symbol is INamedTypeSymbol:
-                // File-local types need special handling - fall through to default but with file path appended.
+                // File-local types need special handling - fall through to default but with hash appended.
                 goto default;
 
             case SymbolKind.ArrayType or SymbolKind.PointerType or SymbolKind.FunctionPointerType or SymbolKind.DynamicType or SymbolKind.ErrorType
@@ -112,10 +112,10 @@ public static partial class SerializableDeclarationIdProvider
                                 return false;
                             }
 
-                            // For file-local types (or members of file-local types), append the source file path
+                            // For file-local types (or members of file-local types), append a hash of the source file path
                             // to disambiguate types with the same name in different files.
-                            var fileLocalPath = GetFileLocalFilePath( symbol );
-                            var idString = AppendFileLocalSuffix( documentationId, fileLocalPath );
+                            var fileLocalHash = GetFileLocalHash( symbol );
+                            var idString = AppendFileLocalSuffix( documentationId, fileLocalHash );
 
                             if ( targetKind == RefTargetKind.Default )
                             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
@@ -50,22 +50,32 @@ public static partial class SerializableDeclarationIdProvider
 
             case SymbolKind.Parameter when symbol is IParameterSymbol parameterSymbol:
                 {
-                    var parentId = DocumentationCommentId.CreateDeclarationId( parameterSymbol.ContainingSymbol ).AssertNotNull();
-                    var paramFileLocalHash = GetFileLocalHash( parameterSymbol );
-                    var parentIdWithHash = AppendFileLocalSuffix( parentId, paramFileLocalHash );
+                    if ( IsInFileLocalType( parameterSymbol ) )
+                    {
+                        id = default;
 
-                    id = new SerializableDeclarationId( $"{parentIdWithHash};Parameter={parameterSymbol.Ordinal}" );
+                        return false;
+                    }
+
+                    var parentId = DocumentationCommentId.CreateDeclarationId( parameterSymbol.ContainingSymbol ).AssertNotNull();
+
+                    id = new SerializableDeclarationId( $"{parentId};Parameter={parameterSymbol.Ordinal}" );
 
                     return true;
                 }
 
             case SymbolKind.TypeParameter when symbol is ITypeParameterSymbol typeParameterSymbol:
                 {
-                    var parentId = DocumentationCommentId.CreateDeclarationId( typeParameterSymbol.ContainingSymbol ).AssertNotNull();
-                    var typeParamFileLocalHash = GetFileLocalHash( typeParameterSymbol );
-                    var parentIdWithHash = AppendFileLocalSuffix( parentId, typeParamFileLocalHash );
+                    if ( IsInFileLocalType( typeParameterSymbol ) )
+                    {
+                        id = default;
 
-                    id = new SerializableDeclarationId( $"{parentIdWithHash};TypeParameter={typeParameterSymbol.Ordinal}" );
+                        return false;
+                    }
+
+                    var parentId = DocumentationCommentId.CreateDeclarationId( typeParameterSymbol.ContainingSymbol ).AssertNotNull();
+
+                    id = new SerializableDeclarationId( $"{parentId};TypeParameter={typeParameterSymbol.Ordinal}" );
 
                     return true;
                 }
@@ -85,7 +95,13 @@ public static partial class SerializableDeclarationIdProvider
                 }
 
             case SymbolKind.NamedType when symbol is INamedTypeSymbol:
-                // File-local types need special handling - fall through to default but with hash appended.
+                if ( IsInFileLocalType( symbol ) )
+                {
+                    id = default;
+
+                    return false;
+                }
+
                 goto default;
 
             case SymbolKind.ArrayType or SymbolKind.PointerType or SymbolKind.FunctionPointerType or SymbolKind.DynamicType or SymbolKind.ErrorType
@@ -107,6 +123,13 @@ public static partial class SerializableDeclarationIdProvider
                     case SymbolKind.Property:
                     case SymbolKind.TypeParameter:
                         {
+                            if ( IsInFileLocalType( symbol ) )
+                            {
+                                id = default;
+
+                                return false;
+                            }
+
                             var documentationId = DocumentationCommentId.CreateDeclarationId( symbol );
 
                             if ( documentationId == null )
@@ -116,18 +139,13 @@ public static partial class SerializableDeclarationIdProvider
                                 return false;
                             }
 
-                            // For file-local types (or members of file-local types), append a hash of the source file path
-                            // to disambiguate types with the same name in different files.
-                            var fileLocalHash = GetFileLocalHash( symbol );
-                            var idString = AppendFileLocalSuffix( documentationId, fileLocalHash );
-
                             if ( targetKind == RefTargetKind.Default )
                             {
-                                id = new SerializableDeclarationId( idString );
+                                id = new SerializableDeclarationId( documentationId );
                             }
                             else
                             {
-                                id = new SerializableDeclarationId( $"{idString};{targetKind}" );
+                                id = new SerializableDeclarationId( $"{documentationId};{targetKind}" );
                             }
 
                             return true;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.FromSymbol.cs
@@ -51,8 +51,10 @@ public static partial class SerializableDeclarationIdProvider
             case SymbolKind.Parameter when symbol is IParameterSymbol parameterSymbol:
                 {
                     var parentId = DocumentationCommentId.CreateDeclarationId( parameterSymbol.ContainingSymbol ).AssertNotNull();
+                    var paramFileLocalHash = GetFileLocalHash( parameterSymbol );
+                    var parentIdWithHash = AppendFileLocalSuffix( parentId, paramFileLocalHash );
 
-                    id = new SerializableDeclarationId( $"{parentId};Parameter={parameterSymbol.Ordinal}" );
+                    id = new SerializableDeclarationId( $"{parentIdWithHash};Parameter={parameterSymbol.Ordinal}" );
 
                     return true;
                 }
@@ -60,8 +62,10 @@ public static partial class SerializableDeclarationIdProvider
             case SymbolKind.TypeParameter when symbol is ITypeParameterSymbol typeParameterSymbol:
                 {
                     var parentId = DocumentationCommentId.CreateDeclarationId( typeParameterSymbol.ContainingSymbol ).AssertNotNull();
+                    var typeParamFileLocalHash = GetFileLocalHash( typeParameterSymbol );
+                    var parentIdWithHash = AppendFileLocalSuffix( parentId, typeParamFileLocalHash );
 
-                    id = new SerializableDeclarationId( $"{parentId};TypeParameter={typeParameterSymbol.Ordinal}" );
+                    id = new SerializableDeclarationId( $"{parentIdWithHash};TypeParameter={typeParameterSymbol.Ordinal}" );
 
                     return true;
                 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
@@ -17,22 +17,21 @@ public static partial class SerializableDeclarationIdProvider
 {
     internal static ICompilationElement? ResolveToDeclaration( this SerializableDeclarationId id, CompilationModel compilation )
     {
-        // Handle file-local type discriminator: strip the |hash suffix before further processing.
-        var (effectiveIdString, fileLocalHash) = ParseFileLocalSuffix( id.Id );
+        var idString = id.Id;
 
-        var indexOfAt = effectiveIdString.IndexOfOrdinal( ';' );
+        var indexOfAt = idString.IndexOfOrdinal( ';' );
 
         if ( indexOfAt > 0 )
         {
             // We have a parameter or a type parameter.
 
-            var parts = effectiveIdString.Split( _separators );
+            var parts = idString.Split( _separators );
 
             var parentId = parts[0];
             var kind = parts[1];
             var ordinal = parts.Length == 3 ? int.Parse( parts[2], CultureInfo.InvariantCulture ) : -1;
 
-            var parent = ResolveDeclarationForDocId( parentId, compilation, fileLocalHash );
+            var parent = DocumentationIdHelper.GetFirstDeclarationForDeclarationId( parentId, compilation );
 
             return (parent, kind) switch
             {
@@ -54,18 +53,18 @@ public static partial class SerializableDeclarationIdProvider
                 _ => null
             };
         }
-        else if ( effectiveIdString.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
+        else if ( idString.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
         {
-            if ( !AssemblyIdentity.TryParseDisplayName( effectiveIdString.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
+            if ( !AssemblyIdentity.TryParseDisplayName( idString.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
             {
                 throw new AssertionFailedException( $"Cannot parse the id '{id.Id}'." );
             }
 
             return compilation.Factory.GetAssembly( assemblyIdentity );
         }
-        else if ( effectiveIdString.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
+        else if ( idString.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
         {
-            if ( !compilation.CompilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( effectiveIdString ), out var typeSymbol ) )
+            if ( !compilation.CompilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( idString ), out var typeSymbol ) )
             {
                 return null;
             }
@@ -76,33 +75,7 @@ public static partial class SerializableDeclarationIdProvider
         }
         else
         {
-            return ResolveDeclarationForDocId( effectiveIdString, compilation, fileLocalHash );
+            return DocumentationIdHelper.GetFirstDeclarationForDeclarationId( idString, compilation );
         }
-    }
-
-    /// <summary>
-    /// Resolves a documentation comment ID to a declaration, optionally filtering by file-local hash for file-local types.
-    /// </summary>
-    private static IDeclaration? ResolveDeclarationForDocId( string docId, CompilationModel compilation, string? fileLocalHash )
-    {
-        if ( fileLocalHash == null )
-        {
-            return DocumentationIdHelper.GetFirstDeclarationForDeclarationId( docId, compilation );
-        }
-
-        // For file-local types, we may get multiple declarations with the same documentation comment ID.
-        // We need to find the one with the matching hash.
-        var allDeclarations = DocumentationIdHelper.GetDeclarationsForDeclarationId( docId, compilation );
-
-        foreach ( var candidate in allDeclarations )
-        {
-            if ( GetFileLocalHash( candidate ) == fileLocalHash )
-            {
-                return candidate;
-            }
-        }
-
-        // Fallback: return the first match if no file-local match found.
-        return allDeclarations.Count == 0 ? null : allDeclarations[0];
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
@@ -17,19 +17,22 @@ public static partial class SerializableDeclarationIdProvider
 {
     internal static ICompilationElement? ResolveToDeclaration( this SerializableDeclarationId id, CompilationModel compilation )
     {
-        var indexOfAt = id.Id.IndexOfOrdinal( ';' );
+        // Handle file-local type discriminator: strip the |filePath suffix before further processing.
+        var (effectiveIdString, fileLocalPath) = ParseFileLocalSuffix( id.Id );
+
+        var indexOfAt = effectiveIdString.IndexOfOrdinal( ';' );
 
         if ( indexOfAt > 0 )
         {
             // We have a parameter or a type parameter.
 
-            var parts = id.Id.Split( _separators );
+            var parts = effectiveIdString.Split( _separators );
 
             var parentId = parts[0];
             var kind = parts[1];
             var ordinal = parts.Length == 3 ? int.Parse( parts[2], CultureInfo.InvariantCulture ) : -1;
 
-            var parent = DocumentationIdHelper.GetFirstDeclarationForDeclarationId( parentId, compilation );
+            var parent = ResolveDeclarationForDocId( parentId, compilation, fileLocalPath );
 
             return (parent, kind) switch
             {
@@ -51,18 +54,18 @@ public static partial class SerializableDeclarationIdProvider
                 _ => null
             };
         }
-        else if ( id.Id.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
+        else if ( effectiveIdString.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
         {
-            if ( !AssemblyIdentity.TryParseDisplayName( id.Id.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
+            if ( !AssemblyIdentity.TryParseDisplayName( effectiveIdString.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
             {
                 throw new AssertionFailedException( $"Cannot parse the id '{id.Id}'." );
             }
 
             return compilation.Factory.GetAssembly( assemblyIdentity );
         }
-        else if ( id.Id.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
+        else if ( effectiveIdString.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
         {
-            if ( !compilation.CompilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( id.Id ), out var typeSymbol ) )
+            if ( !compilation.CompilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( effectiveIdString ), out var typeSymbol ) )
             {
                 return null;
             }
@@ -73,7 +76,33 @@ public static partial class SerializableDeclarationIdProvider
         }
         else
         {
-            return DocumentationIdHelper.GetFirstDeclarationForDeclarationId( id.ToString(), compilation );
+            return ResolveDeclarationForDocId( effectiveIdString, compilation, fileLocalPath );
         }
+    }
+
+    /// <summary>
+    /// Resolves a documentation comment ID to a declaration, optionally filtering by file path for file-local types.
+    /// </summary>
+    private static IDeclaration? ResolveDeclarationForDocId( string docId, CompilationModel compilation, string? fileLocalPath )
+    {
+        if ( fileLocalPath == null )
+        {
+            return DocumentationIdHelper.GetFirstDeclarationForDeclarationId( docId, compilation );
+        }
+
+        // For file-local types, we may get multiple declarations with the same documentation comment ID.
+        // We need to find the one in the correct file.
+        var allDeclarations = DocumentationIdHelper.GetDeclarationsForDeclarationId( docId, compilation );
+
+        foreach ( var candidate in allDeclarations )
+        {
+            if ( GetFileLocalFilePath( candidate ) == fileLocalPath )
+            {
+                return candidate;
+            }
+        }
+
+        // Fallback: return the first match if no file-local match found.
+        return allDeclarations.Count == 0 ? null : allDeclarations[0];
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToDeclaration.cs
@@ -17,8 +17,8 @@ public static partial class SerializableDeclarationIdProvider
 {
     internal static ICompilationElement? ResolveToDeclaration( this SerializableDeclarationId id, CompilationModel compilation )
     {
-        // Handle file-local type discriminator: strip the |filePath suffix before further processing.
-        var (effectiveIdString, fileLocalPath) = ParseFileLocalSuffix( id.Id );
+        // Handle file-local type discriminator: strip the |hash suffix before further processing.
+        var (effectiveIdString, fileLocalHash) = ParseFileLocalSuffix( id.Id );
 
         var indexOfAt = effectiveIdString.IndexOfOrdinal( ';' );
 
@@ -32,7 +32,7 @@ public static partial class SerializableDeclarationIdProvider
             var kind = parts[1];
             var ordinal = parts.Length == 3 ? int.Parse( parts[2], CultureInfo.InvariantCulture ) : -1;
 
-            var parent = ResolveDeclarationForDocId( parentId, compilation, fileLocalPath );
+            var parent = ResolveDeclarationForDocId( parentId, compilation, fileLocalHash );
 
             return (parent, kind) switch
             {
@@ -76,27 +76,27 @@ public static partial class SerializableDeclarationIdProvider
         }
         else
         {
-            return ResolveDeclarationForDocId( effectiveIdString, compilation, fileLocalPath );
+            return ResolveDeclarationForDocId( effectiveIdString, compilation, fileLocalHash );
         }
     }
 
     /// <summary>
-    /// Resolves a documentation comment ID to a declaration, optionally filtering by file path for file-local types.
+    /// Resolves a documentation comment ID to a declaration, optionally filtering by file-local hash for file-local types.
     /// </summary>
-    private static IDeclaration? ResolveDeclarationForDocId( string docId, CompilationModel compilation, string? fileLocalPath )
+    private static IDeclaration? ResolveDeclarationForDocId( string docId, CompilationModel compilation, string? fileLocalHash )
     {
-        if ( fileLocalPath == null )
+        if ( fileLocalHash == null )
         {
             return DocumentationIdHelper.GetFirstDeclarationForDeclarationId( docId, compilation );
         }
 
         // For file-local types, we may get multiple declarations with the same documentation comment ID.
-        // We need to find the one in the correct file.
+        // We need to find the one with the matching hash.
         var allDeclarations = DocumentationIdHelper.GetDeclarationsForDeclarationId( docId, compilation );
 
         foreach ( var candidate in allDeclarations )
         {
-            if ( GetFileLocalFilePath( candidate ) == fileLocalPath )
+            if ( GetFileLocalHash( candidate ) == fileLocalHash )
             {
                 return candidate;
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
@@ -42,8 +42,8 @@ public static partial class SerializableDeclarationIdProvider
 
         isReturnParameter = false;
 
-        // Handle file-local type discriminator: strip the |filePath suffix before further processing.
-        var (effectiveIdString, fileLocalPath) = ParseFileLocalSuffix( id.Id );
+        // Handle file-local type discriminator: strip the |hash suffix before further processing.
+        var (effectiveIdString, fileLocalHash) = ParseFileLocalSuffix( id.Id );
 
         var indexOfAt = effectiveIdString.IndexOfOrdinal( ';' );
 
@@ -57,7 +57,7 @@ public static partial class SerializableDeclarationIdProvider
             var kind = parts[1];
             var ordinal = parts.Length == 3 ? int.Parse( parts[2], CultureInfo.InvariantCulture ) : -1;
 
-            var parent = ResolveSymbolForDocId( parentId, compilation, fileLocalPath );
+            var parent = ResolveSymbolForDocId( parentId, compilation, fileLocalHash );
 
             if ( kind == nameof(RefTargetKind.Return) )
             {
@@ -114,7 +114,7 @@ public static partial class SerializableDeclarationIdProvider
                 }
             }
 
-            var symbol = ResolveSymbolForDocId( effectiveIdString, compilation, fileLocalPath );
+            var symbol = ResolveSymbolForDocId( effectiveIdString, compilation, fileLocalHash );
 
             // Make sure to return the non-nullable type.
             if ( symbol?.Kind is SymbolKind.NamedType or SymbolKind.ArrayType or SymbolKind.PointerType or SymbolKind.FunctionPointerType or SymbolKind.DynamicType or SymbolKind.ErrorType or SymbolKind.TypeParameter
@@ -130,22 +130,22 @@ public static partial class SerializableDeclarationIdProvider
     }
 
     /// <summary>
-    /// Resolves a documentation comment ID to a symbol, optionally filtering by file path for file-local types.
+    /// Resolves a documentation comment ID to a symbol, optionally filtering by file-local hash for file-local types.
     /// </summary>
-    private static ISymbol? ResolveSymbolForDocId( string docId, Compilation compilation, string? fileLocalPath )
+    private static ISymbol? ResolveSymbolForDocId( string docId, Compilation compilation, string? fileLocalHash )
     {
-        if ( fileLocalPath == null )
+        if ( fileLocalHash == null )
         {
             return DocumentationCommentId.GetFirstSymbolForDeclarationId( docId, compilation );
         }
 
         // For file-local types, we may get multiple symbols with the same documentation comment ID.
-        // We need to find the one in the correct file.
+        // We need to find the one with the matching hash.
         var symbols = DocumentationCommentId.GetSymbolsForDeclarationId( docId, compilation );
 
         foreach ( var candidate in symbols )
         {
-            if ( GetFileLocalFilePath( candidate ) == fileLocalPath )
+            if ( GetFileLocalHash( candidate ) == fileLocalHash )
             {
                 return candidate;
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
@@ -42,22 +42,21 @@ public static partial class SerializableDeclarationIdProvider
 
         isReturnParameter = false;
 
-        // Handle file-local type discriminator: strip the |hash suffix before further processing.
-        var (effectiveIdString, fileLocalHash) = ParseFileLocalSuffix( id.Id );
+        var idString = id.Id;
 
-        var indexOfAt = effectiveIdString.IndexOfOrdinal( ';' );
+        var indexOfAt = idString.IndexOfOrdinal( ';' );
 
         if ( indexOfAt > 0 )
         {
             // We have a parameter or a type parameter.
 
-            var parts = effectiveIdString.Split( _separators );
+            var parts = idString.Split( _separators );
 
             var parentId = parts[0];
             var kind = parts[1];
             var ordinal = parts.Length == 3 ? int.Parse( parts[2], CultureInfo.InvariantCulture ) : -1;
 
-            var parent = ResolveSymbolForDocId( parentId, compilation, fileLocalHash );
+            var parent = DocumentationCommentId.GetFirstSymbolForDeclarationId( parentId, compilation );
 
             if ( kind == nameof(RefTargetKind.Return) )
             {
@@ -78,9 +77,9 @@ public static partial class SerializableDeclarationIdProvider
                 _ => null
             };
         }
-        else if ( effectiveIdString.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
+        else if ( idString.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
         {
-            if ( !AssemblyIdentity.TryParseDisplayName( effectiveIdString.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
+            if ( !AssemblyIdentity.TryParseDisplayName( idString.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
             {
                 throw new AssertionFailedException( $"Cannot parse the id '{id.Id}'." );
             }
@@ -97,13 +96,13 @@ public static partial class SerializableDeclarationIdProvider
         else
         {
             // Special case for the global namespace that's not handled by GetFirstSymbolForDeclarationId, see https://github.com/dotnet/roslyn/issues/66976.
-            if ( effectiveIdString == "N:" )
+            if ( idString == "N:" )
             {
                 return compilation.Assembly.GlobalNamespace;
             }
-            else if ( effectiveIdString.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
+            else if ( idString.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
             {
-                if ( !compilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( effectiveIdString ), out var typeSymbol ) )
+                if ( !compilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( idString ), out var typeSymbol ) )
                 {
                     return null;
                 }
@@ -114,7 +113,7 @@ public static partial class SerializableDeclarationIdProvider
                 }
             }
 
-            var symbol = ResolveSymbolForDocId( effectiveIdString, compilation, fileLocalHash );
+            var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId( idString, compilation );
 
             // Make sure to return the non-nullable type.
             if ( symbol?.Kind is SymbolKind.NamedType or SymbolKind.ArrayType or SymbolKind.PointerType or SymbolKind.FunctionPointerType or SymbolKind.DynamicType or SymbolKind.ErrorType or SymbolKind.TypeParameter
@@ -129,29 +128,4 @@ public static partial class SerializableDeclarationIdProvider
         }
     }
 
-    /// <summary>
-    /// Resolves a documentation comment ID to a symbol, optionally filtering by file-local hash for file-local types.
-    /// </summary>
-    private static ISymbol? ResolveSymbolForDocId( string docId, Compilation compilation, string? fileLocalHash )
-    {
-        if ( fileLocalHash == null )
-        {
-            return DocumentationCommentId.GetFirstSymbolForDeclarationId( docId, compilation );
-        }
-
-        // For file-local types, we may get multiple symbols with the same documentation comment ID.
-        // We need to find the one with the matching hash.
-        var symbols = DocumentationCommentId.GetSymbolsForDeclarationId( docId, compilation );
-
-        foreach ( var candidate in symbols )
-        {
-            if ( GetFileLocalHash( candidate ) == fileLocalHash )
-            {
-                return candidate;
-            }
-        }
-
-        // Fallback: return the first match if no file-local match found.
-        return symbols.IsEmpty ? null : symbols[0];
-    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.ToSymbol.cs
@@ -42,19 +42,22 @@ public static partial class SerializableDeclarationIdProvider
 
         isReturnParameter = false;
 
-        var indexOfAt = id.Id.IndexOfOrdinal( ';' );
+        // Handle file-local type discriminator: strip the |filePath suffix before further processing.
+        var (effectiveIdString, fileLocalPath) = ParseFileLocalSuffix( id.Id );
+
+        var indexOfAt = effectiveIdString.IndexOfOrdinal( ';' );
 
         if ( indexOfAt > 0 )
         {
             // We have a parameter or a type parameter.
 
-            var parts = id.Id.Split( _separators );
+            var parts = effectiveIdString.Split( _separators );
 
             var parentId = parts[0];
             var kind = parts[1];
             var ordinal = parts.Length == 3 ? int.Parse( parts[2], CultureInfo.InvariantCulture ) : -1;
 
-            var parent = DocumentationCommentId.GetFirstSymbolForDeclarationId( parentId, compilation );
+            var parent = ResolveSymbolForDocId( parentId, compilation, fileLocalPath );
 
             if ( kind == nameof(RefTargetKind.Return) )
             {
@@ -75,9 +78,9 @@ public static partial class SerializableDeclarationIdProvider
                 _ => null
             };
         }
-        else if ( id.Id.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
+        else if ( effectiveIdString.StartsWith( _assemblyPrefix, StringComparison.OrdinalIgnoreCase ) )
         {
-            if ( !AssemblyIdentity.TryParseDisplayName( id.Id.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
+            if ( !AssemblyIdentity.TryParseDisplayName( effectiveIdString.Substring( _assemblyPrefix.Length ), out var assemblyIdentity ) )
             {
                 throw new AssertionFailedException( $"Cannot parse the id '{id.Id}'." );
             }
@@ -94,13 +97,13 @@ public static partial class SerializableDeclarationIdProvider
         else
         {
             // Special case for the global namespace that's not handled by GetFirstSymbolForDeclarationId, see https://github.com/dotnet/roslyn/issues/66976.
-            if ( id.Id == "N:" )
+            if ( effectiveIdString == "N:" )
             {
                 return compilation.Assembly.GlobalNamespace;
             }
-            else if ( id.Id.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
+            else if ( effectiveIdString.StartsWith( SerializableTypeId.Prefix, StringComparison.Ordinal ) )
             {
-                if ( !compilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( id.Id ), out var typeSymbol ) )
+                if ( !compilationContext.SerializableTypeIdResolver.TryResolveId( new SerializableTypeId( effectiveIdString ), out var typeSymbol ) )
                 {
                     return null;
                 }
@@ -111,7 +114,7 @@ public static partial class SerializableDeclarationIdProvider
                 }
             }
 
-            var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId( id.ToString(), compilation );
+            var symbol = ResolveSymbolForDocId( effectiveIdString, compilation, fileLocalPath );
 
             // Make sure to return the non-nullable type.
             if ( symbol?.Kind is SymbolKind.NamedType or SymbolKind.ArrayType or SymbolKind.PointerType or SymbolKind.FunctionPointerType or SymbolKind.DynamicType or SymbolKind.ErrorType or SymbolKind.TypeParameter
@@ -124,5 +127,31 @@ public static partial class SerializableDeclarationIdProvider
                 return symbol;
             }
         }
+    }
+
+    /// <summary>
+    /// Resolves a documentation comment ID to a symbol, optionally filtering by file path for file-local types.
+    /// </summary>
+    private static ISymbol? ResolveSymbolForDocId( string docId, Compilation compilation, string? fileLocalPath )
+    {
+        if ( fileLocalPath == null )
+        {
+            return DocumentationCommentId.GetFirstSymbolForDeclarationId( docId, compilation );
+        }
+
+        // For file-local types, we may get multiple symbols with the same documentation comment ID.
+        // We need to find the one in the correct file.
+        var symbols = DocumentationCommentId.GetSymbolsForDeclarationId( docId, compilation );
+
+        foreach ( var candidate in symbols )
+        {
+            if ( GetFileLocalFilePath( candidate ) == fileLocalPath )
+            {
+                return candidate;
+            }
+        }
+
+        // Fallback: return the first match if no file-local match found.
+        return symbols.IsEmpty ? null : symbols[0];
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.cs
@@ -4,26 +4,20 @@
 
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.CodeModel;
-using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
-using System.IO.Hashing;
-using System.Linq;
-using System.Text;
 
 namespace Metalama.Framework.Engine.SerializableIds;
 
 public static partial class SerializableDeclarationIdProvider
 {
     private const string _assemblyPrefix = "Assembly:";
-    internal const char FileLocalSeparator = '|';
 
     private static readonly char[] _separators = [';', '='];
 
     /// <summary>
-    /// For a symbol that is a file-local type or is contained within a file-local type,
-    /// returns a 64-bit hash of the source file path (hex formatted). Otherwise returns <c>null</c>.
+    /// Determines whether a symbol is a file-local type or is contained within a file-local type.
     /// </summary>
-    internal static string? GetFileLocalHash( ISymbol symbol )
+    private static bool IsInFileLocalType( ISymbol symbol )
     {
         var current = symbol.Kind == SymbolKind.NamedType && symbol is INamedTypeSymbol ? symbol : symbol.ContainingType;
 
@@ -31,84 +25,25 @@ public static partial class SerializableDeclarationIdProvider
         {
             if ( namedType.IsFileLocal )
             {
-                var filePath = namedType.DeclaringSyntaxReferences.FirstOrDefault()?.SyntaxTree.FilePath;
-
-                return filePath == null ? null : HashFilePath( filePath );
+                return true;
             }
 
             current = namedType.ContainingType;
         }
 
-        return null;
+        return false;
     }
 
     /// <summary>
-    /// For a declaration that is a file-local type or is contained within a file-local type,
-    /// returns a 64-bit hash of the source file path (hex formatted). Otherwise returns <c>null</c>.
+    /// Determines whether a declaration is a file-local type or is contained within a file-local type.
     /// </summary>
-    internal static string? GetFileLocalHash( IDeclaration declaration )
+    private static bool IsInFileLocalType( IDeclaration declaration )
     {
         if ( declaration.GetSymbol() is { } symbol )
         {
-            return GetFileLocalHash( symbol );
+            return IsInFileLocalType( symbol );
         }
 
-        return null;
-    }
-
-    /// <summary>
-    /// Computes a 64-bit XxHash64 of the file path and returns it as a lowercase hex string.
-    /// </summary>
-    private static string HashFilePath( string filePath )
-    {
-        var bytes = Encoding.UTF8.GetBytes( filePath );
-        var hash = XxHash64.HashToUInt64( bytes );
-
-        return hash.ToString( "x16", System.Globalization.CultureInfo.InvariantCulture );
-    }
-
-    /// <summary>
-    /// Splits a serializable ID into the base documentation ID and an optional file-local hash.
-    /// </summary>
-    internal static (string BaseId, string? FileLocalHash) ParseFileLocalSuffix( string idString )
-    {
-        var pipeIndex = idString.IndexOfOrdinal( FileLocalSeparator );
-
-        if ( pipeIndex < 0 )
-        {
-            return (idString, null);
-        }
-
-        // The hash is always a fixed-length hex string (16 chars), so we can simply
-        // extract it. Format: "baseDocId|hash" or "baseDocId|hash;kind=ordinal"
-        var semiAfterPipe = idString.IndexOf( ';', pipeIndex );
-
-        if ( semiAfterPipe > 0 )
-        {
-            var hash = idString.Substring( pipeIndex + 1, semiAfterPipe - pipeIndex - 1 );
-            var baseId = idString.Substring( 0, pipeIndex ) + idString.Substring( semiAfterPipe );
-
-            return (baseId, hash);
-        }
-        else
-        {
-            var hash = idString.Substring( pipeIndex + 1 );
-            var baseId = idString.Substring( 0, pipeIndex );
-
-            return (baseId, hash);
-        }
-    }
-
-    /// <summary>
-    /// Appends the file-local hash suffix to an ID string if the hash is not null.
-    /// </summary>
-    internal static string AppendFileLocalSuffix( string idString, string? fileLocalHash )
-    {
-        if ( fileLocalHash == null )
-        {
-            return idString;
-        }
-
-        return idString + FileLocalSeparator + fileLocalHash;
+        return false;
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.cs
@@ -2,11 +2,98 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Code;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Utilities;
+using Microsoft.CodeAnalysis;
+using System.Linq;
+
 namespace Metalama.Framework.Engine.SerializableIds;
 
 public static partial class SerializableDeclarationIdProvider
 {
     private const string _assemblyPrefix = "Assembly:";
+    internal const char FileLocalSeparator = '|';
 
     private static readonly char[] _separators = [';', '='];
+
+    /// <summary>
+    /// For a symbol that is a file-local type or is contained within a file-local type,
+    /// returns the source file path. Otherwise returns <c>null</c>.
+    /// </summary>
+    internal static string? GetFileLocalFilePath( ISymbol symbol )
+    {
+        var current = symbol.Kind == SymbolKind.NamedType && symbol is INamedTypeSymbol ? symbol : symbol.ContainingType;
+
+        while ( current != null && current.Kind == SymbolKind.NamedType && current is INamedTypeSymbol namedType )
+        {
+            if ( namedType.IsFileLocal )
+            {
+                return namedType.DeclaringSyntaxReferences.FirstOrDefault()?.SyntaxTree.FilePath;
+            }
+
+            current = namedType.ContainingType;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// For a declaration that is a file-local type or is contained within a file-local type,
+    /// returns the source file path. Otherwise returns <c>null</c>.
+    /// </summary>
+    internal static string? GetFileLocalFilePath( IDeclaration declaration )
+    {
+        if ( declaration.GetSymbol() is { } symbol )
+        {
+            return GetFileLocalFilePath( symbol );
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Splits a serializable ID into the base documentation ID and an optional file-local file path.
+    /// </summary>
+    internal static (string BaseId, string? FileLocalPath) ParseFileLocalSuffix( string idString )
+    {
+        var pipeIndex = idString.IndexOfOrdinal( FileLocalSeparator );
+
+        if ( pipeIndex < 0 )
+        {
+            return (idString, null);
+        }
+
+        // The | can appear before or after a ; separator.
+        // Format: "baseDocId|filePath" or "baseDocId|filePath;kind=ordinal"
+        var semiAfterPipe = idString.IndexOf( ';', pipeIndex );
+
+        if ( semiAfterPipe > 0 )
+        {
+            var filePath = idString.Substring( pipeIndex + 1, semiAfterPipe - pipeIndex - 1 );
+            var baseId = idString.Substring( 0, pipeIndex ) + idString.Substring( semiAfterPipe );
+
+            return (baseId, filePath);
+        }
+        else
+        {
+            var filePath = idString.Substring( pipeIndex + 1 );
+            var baseId = idString.Substring( 0, pipeIndex );
+
+            return (baseId, filePath);
+        }
+    }
+
+    /// <summary>
+    /// Appends the file-local suffix to an ID string if the file path is not null.
+    /// </summary>
+    internal static string AppendFileLocalSuffix( string idString, string? fileLocalPath )
+    {
+        if ( fileLocalPath == null )
+        {
+            return idString;
+        }
+
+        return idString + FileLocalSeparator + fileLocalPath;
+    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SerializableIds/SerializableDeclarationIdProvider.cs
@@ -6,7 +6,9 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
+using System.IO.Hashing;
 using System.Linq;
+using System.Text;
 
 namespace Metalama.Framework.Engine.SerializableIds;
 
@@ -19,9 +21,9 @@ public static partial class SerializableDeclarationIdProvider
 
     /// <summary>
     /// For a symbol that is a file-local type or is contained within a file-local type,
-    /// returns the source file path. Otherwise returns <c>null</c>.
+    /// returns a 64-bit hash of the source file path (hex formatted). Otherwise returns <c>null</c>.
     /// </summary>
-    internal static string? GetFileLocalFilePath( ISymbol symbol )
+    internal static string? GetFileLocalHash( ISymbol symbol )
     {
         var current = symbol.Kind == SymbolKind.NamedType && symbol is INamedTypeSymbol ? symbol : symbol.ContainingType;
 
@@ -29,7 +31,9 @@ public static partial class SerializableDeclarationIdProvider
         {
             if ( namedType.IsFileLocal )
             {
-                return namedType.DeclaringSyntaxReferences.FirstOrDefault()?.SyntaxTree.FilePath;
+                var filePath = namedType.DeclaringSyntaxReferences.FirstOrDefault()?.SyntaxTree.FilePath;
+
+                return filePath == null ? null : HashFilePath( filePath );
             }
 
             current = namedType.ContainingType;
@@ -40,22 +44,33 @@ public static partial class SerializableDeclarationIdProvider
 
     /// <summary>
     /// For a declaration that is a file-local type or is contained within a file-local type,
-    /// returns the source file path. Otherwise returns <c>null</c>.
+    /// returns a 64-bit hash of the source file path (hex formatted). Otherwise returns <c>null</c>.
     /// </summary>
-    internal static string? GetFileLocalFilePath( IDeclaration declaration )
+    internal static string? GetFileLocalHash( IDeclaration declaration )
     {
         if ( declaration.GetSymbol() is { } symbol )
         {
-            return GetFileLocalFilePath( symbol );
+            return GetFileLocalHash( symbol );
         }
 
         return null;
     }
 
     /// <summary>
-    /// Splits a serializable ID into the base documentation ID and an optional file-local file path.
+    /// Computes a 64-bit XxHash64 of the file path and returns it as a lowercase hex string.
     /// </summary>
-    internal static (string BaseId, string? FileLocalPath) ParseFileLocalSuffix( string idString )
+    private static string HashFilePath( string filePath )
+    {
+        var bytes = Encoding.UTF8.GetBytes( filePath );
+        var hash = XxHash64.HashToUInt64( bytes );
+
+        return hash.ToString( "x16", System.Globalization.CultureInfo.InvariantCulture );
+    }
+
+    /// <summary>
+    /// Splits a serializable ID into the base documentation ID and an optional file-local hash.
+    /// </summary>
+    internal static (string BaseId, string? FileLocalHash) ParseFileLocalSuffix( string idString )
     {
         var pipeIndex = idString.IndexOfOrdinal( FileLocalSeparator );
 
@@ -64,36 +79,36 @@ public static partial class SerializableDeclarationIdProvider
             return (idString, null);
         }
 
-        // The | can appear before or after a ; separator.
-        // Format: "baseDocId|filePath" or "baseDocId|filePath;kind=ordinal"
+        // The hash is always a fixed-length hex string (16 chars), so we can simply
+        // extract it. Format: "baseDocId|hash" or "baseDocId|hash;kind=ordinal"
         var semiAfterPipe = idString.IndexOf( ';', pipeIndex );
 
         if ( semiAfterPipe > 0 )
         {
-            var filePath = idString.Substring( pipeIndex + 1, semiAfterPipe - pipeIndex - 1 );
+            var hash = idString.Substring( pipeIndex + 1, semiAfterPipe - pipeIndex - 1 );
             var baseId = idString.Substring( 0, pipeIndex ) + idString.Substring( semiAfterPipe );
 
-            return (baseId, filePath);
+            return (baseId, hash);
         }
         else
         {
-            var filePath = idString.Substring( pipeIndex + 1 );
+            var hash = idString.Substring( pipeIndex + 1 );
             var baseId = idString.Substring( 0, pipeIndex );
 
-            return (baseId, filePath);
+            return (baseId, hash);
         }
     }
 
     /// <summary>
-    /// Appends the file-local suffix to an ID string if the file path is not null.
+    /// Appends the file-local hash suffix to an ID string if the hash is not null.
     /// </summary>
-    internal static string AppendFileLocalSuffix( string idString, string? fileLocalPath )
+    internal static string AppendFileLocalSuffix( string idString, string? fileLocalHash )
     {
-        if ( fileLocalPath == null )
+        if ( fileLocalHash == null )
         {
             return idString;
         }
 
-        return idString + FileLocalSeparator + fileLocalPath;
+        return idString + FileLocalSeparator + fileLocalHash;
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -12,7 +12,7 @@ using Metalama.Framework.Engine.SerializableIds;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Testing.UnitTesting;
 using Microsoft.CodeAnalysis;
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -275,220 +275,42 @@ delegate int D(int x, string y);
     }
 
     [Fact]
-    public void FileLocalTypes_HaveDistinctIds()
+    public void FileLocalTypes_CannotGetSerializableId()
     {
-        // Two file-local types with the same name and namespace but in different files
-        // must produce different SerializableDeclarationIds.
-        const string code1 = @"
+        // File-local types cannot have serializable IDs because the ID would be
+        // path-dependent, and serializable IDs must be cross-machine.
+        const string code = @"
 namespace TestNamespace;
 
 file class FileLocalType
 {
-    public int X;
-}
-";
-
-        const string code2 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public string Y;
+    public void M<T>(int p) {}
 }
 ";
 
         using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilation( code );
 
-        var compilation = testContext.CreateCompilation(
-            new Dictionary<string, string>
-            {
-                { "File1.cs", code1 },
-                { "File2.cs", code2 }
-            } );
-
-        var fileLocalTypes = compilation.GetContainedDeclarations()
+        var fileLocalType = compilation.GetContainedDeclarations()
             .OfType<INamedType>()
-            .Where( t => t.Name == "FileLocalType" )
-            .ToList();
+            .Single( t => t.Name == "FileLocalType" );
 
-        Assert.Equal( 2, fileLocalTypes.Count );
+        // The type itself should not get a serializable ID.
+        Assert.False( fileLocalType.TryGetSerializableId( out _ ) );
 
-        var id1 = fileLocalTypes[0].ToSerializableId();
-        var id2 = fileLocalTypes[1].ToSerializableId();
+        // Members should not get a serializable ID either.
+        var method = fileLocalType.Methods.OfName( "M" ).Single();
+        Assert.False( method.TryGetSerializableId( out _ ) );
 
-        this.TestOutput.WriteLine( $"File-local type 1 ID: {id1.Id}" );
-        this.TestOutput.WriteLine( $"File-local type 2 ID: {id2.Id}" );
+        // Parameters of members should not get a serializable ID.
+        var parameter = method.Parameters.Single();
+        Assert.False( parameter.TryGetSerializableId( out _ ) );
 
-        // The two file-local types must have different serializable IDs.
-        Assert.NotEqual( id1, id2 );
+        // Type parameters of members should not get a serializable ID.
+        var typeParameter = method.TypeParameters.Single();
+        Assert.False( typeParameter.TryGetSerializableId( out _ ) );
 
-        // Both must roundtrip correctly.
-        Roundtrip( fileLocalTypes[0], compilation, this.TestOutput );
-        Roundtrip( fileLocalTypes[1], compilation, this.TestOutput );
-    }
-
-    [Fact]
-    public void FileLocalTypes_MembersHaveDistinctIds()
-    {
-        // Members of file-local types with the same name must also have distinct IDs.
-        const string code1 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public void M() {}
-}
-";
-
-        const string code2 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public void M() {}
-}
-";
-
-        using var testContext = this.CreateTestContext();
-
-        var compilation = testContext.CreateCompilation(
-            new Dictionary<string, string>
-            {
-                { "File1.cs", code1 },
-                { "File2.cs", code2 }
-            } );
-
-        var fileLocalTypes = compilation.GetContainedDeclarations()
-            .OfType<INamedType>()
-            .Where( t => t.Name == "FileLocalType" )
-            .ToList();
-
-        Assert.Equal( 2, fileLocalTypes.Count );
-
-        var method1 = fileLocalTypes[0].Methods.OfName( "M" ).Single();
-        var method2 = fileLocalTypes[1].Methods.OfName( "M" ).Single();
-
-        var methodId1 = method1.ToSerializableId();
-        var methodId2 = method2.ToSerializableId();
-
-        this.TestOutput.WriteLine( $"Method 1 ID: {methodId1.Id}" );
-        this.TestOutput.WriteLine( $"Method 2 ID: {methodId2.Id}" );
-
-        // Methods on different file-local types must have different IDs.
-        Assert.NotEqual( methodId1, methodId2 );
-
-        // Both must roundtrip correctly.
-        Roundtrip( method1, compilation, this.TestOutput );
-        Roundtrip( method2, compilation, this.TestOutput );
-    }
-
-    [Fact]
-    public void FileLocalTypes_ParametersHaveDistinctIds()
-    {
-        // Parameters of methods on file-local types with the same name must have distinct IDs.
-        const string code1 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public void M(int p) {}
-}
-";
-
-        const string code2 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public void M(int p) {}
-}
-";
-
-        using var testContext = this.CreateTestContext();
-
-        var compilation = testContext.CreateCompilation(
-            new Dictionary<string, string>
-            {
-                { "File1.cs", code1 },
-                { "File2.cs", code2 }
-            } );
-
-        var fileLocalTypes = compilation.GetContainedDeclarations()
-            .OfType<INamedType>()
-            .Where( t => t.Name == "FileLocalType" )
-            .ToList();
-
-        Assert.Equal( 2, fileLocalTypes.Count );
-
-        var param1 = fileLocalTypes[0].Methods.OfName( "M" ).Single().Parameters.Single();
-        var param2 = fileLocalTypes[1].Methods.OfName( "M" ).Single().Parameters.Single();
-
-        var paramId1 = param1.ToSerializableId();
-        var paramId2 = param2.ToSerializableId();
-
-        this.TestOutput.WriteLine( $"Parameter 1 ID: {paramId1.Id}" );
-        this.TestOutput.WriteLine( $"Parameter 2 ID: {paramId2.Id}" );
-
-        // Parameters on different file-local types must have different IDs.
-        Assert.NotEqual( paramId1, paramId2 );
-
-        // Both must roundtrip correctly.
-        Roundtrip( param1, compilation, this.TestOutput );
-        Roundtrip( param2, compilation, this.TestOutput );
-    }
-
-    [Fact]
-    public void FileLocalTypes_TypeParametersHaveDistinctIds()
-    {
-        // Type parameters of methods on file-local types with the same name must have distinct IDs.
-        const string code1 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public void M<T>() {}
-}
-";
-
-        const string code2 = @"
-namespace TestNamespace;
-
-file class FileLocalType
-{
-    public void M<T>() {}
-}
-";
-
-        using var testContext = this.CreateTestContext();
-
-        var compilation = testContext.CreateCompilation(
-            new Dictionary<string, string>
-            {
-                { "File1.cs", code1 },
-                { "File2.cs", code2 }
-            } );
-
-        var fileLocalTypes = compilation.GetContainedDeclarations()
-            .OfType<INamedType>()
-            .Where( t => t.Name == "FileLocalType" )
-            .ToList();
-
-        Assert.Equal( 2, fileLocalTypes.Count );
-
-        var typeParam1 = fileLocalTypes[0].Methods.OfName( "M" ).Single().TypeParameters.Single();
-        var typeParam2 = fileLocalTypes[1].Methods.OfName( "M" ).Single().TypeParameters.Single();
-
-        var typeParamId1 = typeParam1.ToSerializableId();
-        var typeParamId2 = typeParam2.ToSerializableId();
-
-        this.TestOutput.WriteLine( $"TypeParameter 1 ID: {typeParamId1.Id}" );
-        this.TestOutput.WriteLine( $"TypeParameter 2 ID: {typeParamId2.Id}" );
-
-        // Type parameters on different file-local types must have different IDs.
-        Assert.NotEqual( typeParamId1, typeParamId2 );
-
-        // Both must roundtrip correctly.
-        Roundtrip( typeParam1, compilation, this.TestOutput );
-        Roundtrip( typeParam2, compilation, this.TestOutput );
+        // GetSerializableId should throw for file-local types.
+        Assert.Throws<ArgumentException>( () => fileLocalType.ToSerializableId() );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -12,6 +12,7 @@ using Metalama.Framework.Engine.SerializableIds;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Testing.UnitTesting;
 using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -271,5 +272,113 @@ delegate int D(int x, string y);
         {
             Roundtrip( parameter, compilation, this.TestOutput );
         }
+    }
+
+    [Fact]
+    public void FileLocalTypes_HaveDistinctIds()
+    {
+        // Two file-local types with the same name and namespace but in different files
+        // must produce different SerializableDeclarationIds.
+        const string code1 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public int X;
+}
+";
+
+        const string code2 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public string Y;
+}
+";
+
+        using var testContext = this.CreateTestContext();
+
+        var compilation = testContext.CreateCompilation(
+            new Dictionary<string, string>
+            {
+                { "File1.cs", code1 },
+                { "File2.cs", code2 }
+            } );
+
+        var fileLocalTypes = compilation.GetContainedDeclarations()
+            .OfType<INamedType>()
+            .Where( t => t.Name == "FileLocalType" )
+            .ToList();
+
+        Assert.Equal( 2, fileLocalTypes.Count );
+
+        var id1 = fileLocalTypes[0].ToSerializableId();
+        var id2 = fileLocalTypes[1].ToSerializableId();
+
+        this.TestOutput.WriteLine( $"File-local type 1 ID: {id1.Id}" );
+        this.TestOutput.WriteLine( $"File-local type 2 ID: {id2.Id}" );
+
+        // The two file-local types must have different serializable IDs.
+        Assert.NotEqual( id1, id2 );
+
+        // Both must roundtrip correctly.
+        Roundtrip( fileLocalTypes[0], compilation, this.TestOutput );
+        Roundtrip( fileLocalTypes[1], compilation, this.TestOutput );
+    }
+
+    [Fact]
+    public void FileLocalTypes_MembersHaveDistinctIds()
+    {
+        // Members of file-local types with the same name must also have distinct IDs.
+        const string code1 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public void M() {}
+}
+";
+
+        const string code2 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public void M() {}
+}
+";
+
+        using var testContext = this.CreateTestContext();
+
+        var compilation = testContext.CreateCompilation(
+            new Dictionary<string, string>
+            {
+                { "File1.cs", code1 },
+                { "File2.cs", code2 }
+            } );
+
+        var fileLocalTypes = compilation.GetContainedDeclarations()
+            .OfType<INamedType>()
+            .Where( t => t.Name == "FileLocalType" )
+            .ToList();
+
+        Assert.Equal( 2, fileLocalTypes.Count );
+
+        var method1 = fileLocalTypes[0].Methods.OfName( "M" ).Single();
+        var method2 = fileLocalTypes[1].Methods.OfName( "M" ).Single();
+
+        var methodId1 = method1.ToSerializableId();
+        var methodId2 = method2.ToSerializableId();
+
+        this.TestOutput.WriteLine( $"Method 1 ID: {methodId1.Id}" );
+        this.TestOutput.WriteLine( $"Method 2 ID: {methodId2.Id}" );
+
+        // Methods on different file-local types must have different IDs.
+        Assert.NotEqual( methodId1, methodId2 );
+
+        // Both must roundtrip correctly.
+        Roundtrip( method1, compilation, this.TestOutput );
+        Roundtrip( method2, compilation, this.TestOutput );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -381,4 +381,114 @@ file class FileLocalType
         Roundtrip( method1, compilation, this.TestOutput );
         Roundtrip( method2, compilation, this.TestOutput );
     }
+
+    [Fact]
+    public void FileLocalTypes_ParametersHaveDistinctIds()
+    {
+        // Parameters of methods on file-local types with the same name must have distinct IDs.
+        const string code1 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public void M(int p) {}
+}
+";
+
+        const string code2 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public void M(int p) {}
+}
+";
+
+        using var testContext = this.CreateTestContext();
+
+        var compilation = testContext.CreateCompilation(
+            new Dictionary<string, string>
+            {
+                { "File1.cs", code1 },
+                { "File2.cs", code2 }
+            } );
+
+        var fileLocalTypes = compilation.GetContainedDeclarations()
+            .OfType<INamedType>()
+            .Where( t => t.Name == "FileLocalType" )
+            .ToList();
+
+        Assert.Equal( 2, fileLocalTypes.Count );
+
+        var param1 = fileLocalTypes[0].Methods.OfName( "M" ).Single().Parameters.Single();
+        var param2 = fileLocalTypes[1].Methods.OfName( "M" ).Single().Parameters.Single();
+
+        var paramId1 = param1.ToSerializableId();
+        var paramId2 = param2.ToSerializableId();
+
+        this.TestOutput.WriteLine( $"Parameter 1 ID: {paramId1.Id}" );
+        this.TestOutput.WriteLine( $"Parameter 2 ID: {paramId2.Id}" );
+
+        // Parameters on different file-local types must have different IDs.
+        Assert.NotEqual( paramId1, paramId2 );
+
+        // Both must roundtrip correctly.
+        Roundtrip( param1, compilation, this.TestOutput );
+        Roundtrip( param2, compilation, this.TestOutput );
+    }
+
+    [Fact]
+    public void FileLocalTypes_TypeParametersHaveDistinctIds()
+    {
+        // Type parameters of methods on file-local types with the same name must have distinct IDs.
+        const string code1 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public void M<T>() {}
+}
+";
+
+        const string code2 = @"
+namespace TestNamespace;
+
+file class FileLocalType
+{
+    public void M<T>() {}
+}
+";
+
+        using var testContext = this.CreateTestContext();
+
+        var compilation = testContext.CreateCompilation(
+            new Dictionary<string, string>
+            {
+                { "File1.cs", code1 },
+                { "File2.cs", code2 }
+            } );
+
+        var fileLocalTypes = compilation.GetContainedDeclarations()
+            .OfType<INamedType>()
+            .Where( t => t.Name == "FileLocalType" )
+            .ToList();
+
+        Assert.Equal( 2, fileLocalTypes.Count );
+
+        var typeParam1 = fileLocalTypes[0].Methods.OfName( "M" ).Single().TypeParameters.Single();
+        var typeParam2 = fileLocalTypes[1].Methods.OfName( "M" ).Single().TypeParameters.Single();
+
+        var typeParamId1 = typeParam1.ToSerializableId();
+        var typeParamId2 = typeParam2.ToSerializableId();
+
+        this.TestOutput.WriteLine( $"TypeParameter 1 ID: {typeParamId1.Id}" );
+        this.TestOutput.WriteLine( $"TypeParameter 2 ID: {typeParamId2.Id}" );
+
+        // Type parameters on different file-local types must have different IDs.
+        Assert.NotEqual( typeParamId1, typeParamId2 );
+
+        // Both must roundtrip correctly.
+        Roundtrip( typeParam1, compilation, this.TestOutput );
+        Roundtrip( typeParam2, compilation, this.TestOutput );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #662. C# 11 `file`-local types with the same name and namespace but in different files produce identical `SerializableDeclarationId` values, making them indistinguishable. Since serializable IDs are cross-machine (code may be checked out in different directories), path-based disambiguation is not viable.

**Solution:** Refuse to generate a `SerializableDeclarationId` for file-local declarations. `TryGetSerializableId` returns `false` and `GetSerializableId`/`ToSerializableId` throw `ArgumentException` for file-local types and their members (methods, fields, parameters, type parameters, etc.).

### Changes
- **`SerializableDeclarationIdProvider.cs`**: Replaced hash/suffix helpers with simple `IsInFileLocalType` checks for both `ISymbol` and `IDeclaration`.
- **`SerializableDeclarationIdProvider.FromSymbol.cs`**: Return `false` from `TryGetSerializableId` for symbols in file-local types (all code paths: NamedType, Parameter, TypeParameter, default).
- **`SerializableDeclarationIdProvider.FromDeclaration.cs`**: Same for the declaration path.
- **`SerializableDeclarationIdProvider.ToSymbol.cs`**: Removed file-local disambiguation logic (no longer needed since file-local IDs are never generated).
- **`SerializableDeclarationIdProvider.ToDeclaration.cs`**: Same.
- **`DocumentationIdHelper.cs`**: Removed `GetDeclarationsForDeclarationId` (was only needed for multi-result disambiguation).
- **`SerializableDeclarationIdTests.cs`**: Replaced 4 roundtrip tests with 1 test verifying that `TryGetSerializableId` returns `false` and `ToSerializableId` throws for file-local types, members, parameters, and type parameters.

## Checklist

- [x] Write failing regression test
- [x] Implement fix
- [x] Address review feedback (refuse to generate ID instead of hashing)
- [x] Run all tests in solution (1733 passed)
- [x] Build with `Build.ps1 build` (zero warnings)
- [x] Finalize