### PR TITLE
Fix EOL normalization around inserted #pragma (#813)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
@@ -235,6 +235,15 @@ public sealed partial class CodeFormatter : IProjectService
             var newSyntaxRoot = (await formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull().GetSyntaxRootAsync( cancellationToken ))
                 .AssertNotNull();
 
+            // Normalize EOLs to match the original syntax tree's style, because Roslyn's Formatter
+            // may have changed them (e.g. to \r\n on Windows).
+            var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
+
+            if ( originalEol != "\r\n" )
+            {
+                newSyntaxRoot = EndOfLineHelper.NormalizeEndOfLines( newSyntaxRoot, originalEol );
+            }
+
             var newSyntaxTree = oldSyntaxTree.WithRootAndOptions( newSyntaxRoot, oldSyntaxTree.Options );
 
             syntaxTreeReplacements.Add( SyntaxTreeTransformation.ReplaceTree( oldSyntaxTree, newSyntaxTree ) );
@@ -249,6 +258,29 @@ public sealed partial class CodeFormatter : IProjectService
 
         var formattedSolution = await this.FormatAsync( project.Solution, syntaxTreeMap.Values, null, true, cancellationToken );
 
-        return (await formattedSolution.Projects.Single().GetCompilationAsync( cancellationToken )).AssertNotNull();
+        var formattedCompilation = (await formattedSolution.Projects.Single().GetCompilationAsync( cancellationToken )).AssertNotNull();
+
+        // Normalize EOLs to match each original syntax tree's style.
+        foreach ( var syntaxTreePair in syntaxTreeMap )
+        {
+            var oldSyntaxTree = syntaxTreePair.Key;
+            var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
+
+            if ( originalEol != "\r\n" )
+            {
+                var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
+                var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
+                var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
+
+                // Find and replace the corresponding syntax tree in the compilation.
+                var formattedSyntaxTree = formattedCompilation.SyntaxTrees.Single( t => t.FilePath == oldSyntaxTree.FilePath );
+
+                formattedCompilation = formattedCompilation.ReplaceSyntaxTree(
+                    formattedSyntaxTree,
+                    formattedSyntaxTree.WithRootAndOptions( normalizedRoot, formattedSyntaxTree.Options ) );
+            }
+        }
+
+        return formattedCompilation;
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
@@ -263,23 +263,23 @@ public sealed partial class CodeFormatter : IProjectService
         // Normalize EOLs to match each original syntax tree's style, processing trees in parallel.
         var eolReplacements = new ConcurrentBag<(string FilePath, SyntaxNode NormalizedRoot)>();
 
-        await Task.WhenAll(
-            syntaxTreeMap.AsEnumerable()
-                .Select(
-                    async syntaxTreePair =>
-                    {
-                        var oldSyntaxTree = syntaxTreePair.Key;
-                        var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
+        await this._concurrentTaskRunner.RunConcurrentlyAsync(
+            syntaxTreeMap.AsEnumerable(),
+            async syntaxTreePair =>
+            {
+                var oldSyntaxTree = syntaxTreePair.Key;
+                var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
 
-                        if ( originalEol != "\r\n" )
-                        {
-                            var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
-                            var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
-                            var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
+                if ( originalEol != "\r\n" )
+                {
+                    var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
+                    var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
+                    var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
 
-                            eolReplacements.Add( (oldSyntaxTree.FilePath, normalizedRoot) );
-                        }
-                    } ) );
+                    eolReplacements.Add( (oldSyntaxTree.FilePath, normalizedRoot) );
+                }
+            },
+            cancellationToken );
 
         foreach ( var replacement in eolReplacements )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
@@ -260,25 +260,34 @@ public sealed partial class CodeFormatter : IProjectService
 
         var formattedCompilation = (await formattedSolution.Projects.Single().GetCompilationAsync( cancellationToken )).AssertNotNull();
 
-        // Normalize EOLs to match each original syntax tree's style.
-        foreach ( var syntaxTreePair in syntaxTreeMap )
+        // Normalize EOLs to match each original syntax tree's style, processing trees in parallel.
+        var eolReplacements = new ConcurrentBag<(string FilePath, SyntaxNode NormalizedRoot)>();
+
+        await Task.WhenAll(
+            syntaxTreeMap.AsEnumerable()
+                .Select(
+                    async syntaxTreePair =>
+                    {
+                        var oldSyntaxTree = syntaxTreePair.Key;
+                        var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
+
+                        if ( originalEol != "\r\n" )
+                        {
+                            var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
+                            var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
+                            var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
+
+                            eolReplacements.Add( (oldSyntaxTree.FilePath, normalizedRoot) );
+                        }
+                    } ) );
+
+        foreach ( var replacement in eolReplacements )
         {
-            var oldSyntaxTree = syntaxTreePair.Key;
-            var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
+            var formattedSyntaxTree = formattedCompilation.SyntaxTrees.Single( t => t.FilePath == replacement.FilePath );
 
-            if ( originalEol != "\r\n" )
-            {
-                var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
-                var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
-                var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
-
-                // Find and replace the corresponding syntax tree in the compilation.
-                var formattedSyntaxTree = formattedCompilation.SyntaxTrees.Single( t => t.FilePath == oldSyntaxTree.FilePath );
-
-                formattedCompilation = formattedCompilation.ReplaceSyntaxTree(
-                    formattedSyntaxTree,
-                    formattedSyntaxTree.WithRootAndOptions( normalizedRoot, formattedSyntaxTree.Options ) );
-            }
+            formattedCompilation = formattedCompilation.ReplaceSyntaxTree(
+                formattedSyntaxTree,
+                formattedSyntaxTree.WithRootAndOptions( replacement.NormalizedRoot, formattedSyntaxTree.Options ) );
         }
 
         return formattedCompilation;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/CodeFormatter.cs
@@ -238,11 +238,7 @@ public sealed partial class CodeFormatter : IProjectService
             // Normalize EOLs to match the original syntax tree's style, because Roslyn's Formatter
             // may have changed them (e.g. to \r\n on Windows).
             var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
-
-            if ( originalEol != "\r\n" )
-            {
-                newSyntaxRoot = EndOfLineHelper.NormalizeEndOfLines( newSyntaxRoot, originalEol );
-            }
+            newSyntaxRoot = EndOfLineHelper.NormalizeEndOfLines( newSyntaxRoot, originalEol );
 
             var newSyntaxTree = oldSyntaxTree.WithRootAndOptions( newSyntaxRoot, oldSyntaxTree.Options );
 
@@ -269,15 +265,11 @@ public sealed partial class CodeFormatter : IProjectService
             {
                 var oldSyntaxTree = syntaxTreePair.Key;
                 var originalEol = EndOfLineHelper.DetermineEndOfLineStyleFast( oldSyntaxTree );
+                var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
+                var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
+                var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
 
-                if ( originalEol != "\r\n" )
-                {
-                    var formattedDocument = formattedSolution.GetDocument( syntaxTreePair.Value ).AssertNotNull();
-                    var formattedRoot = (await formattedDocument.GetSyntaxRootAsync( cancellationToken )).AssertNotNull();
-                    var normalizedRoot = EndOfLineHelper.NormalizeEndOfLines( formattedRoot, originalEol );
-
-                    eolReplacements.Add( (oldSyntaxTree.FilePath, normalizedRoot) );
-                }
+                eolReplacements.Add( (oldSyntaxTree.FilePath, normalizedRoot) );
             },
             cancellationToken );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/EndOfLineHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/EndOfLineHelper.cs
@@ -10,6 +10,12 @@ namespace Metalama.Framework.Engine.Formatting
     internal static class EndOfLineHelper
     {
         /// <summary>
+        /// Normalizes all <see cref="SyntaxKind.EndOfLineTrivia"/> in a syntax tree to use the specified EOL string.
+        /// </summary>
+        public static SyntaxNode NormalizeEndOfLines( SyntaxNode root, string endOfLine )
+            => new EndOfLineNormalizingRewriter( endOfLine ).Visit( root )!;
+
+        /// <summary>
         /// Returns the first EOL string without allocating memory.
         /// </summary>
         public static string DetermineEndOfLineStyleFast( SyntaxTree syntaxTree )
@@ -87,6 +93,21 @@ namespace Metalama.Framework.Engine.Formatting
             }
 
             return null;
+        }
+
+        private sealed class EndOfLineNormalizingRewriter : CSharpSyntaxRewriter
+        {
+            private readonly SyntaxTrivia _endOfLineTrivia;
+
+            public EndOfLineNormalizingRewriter( string endOfLine ) : base( visitIntoStructuredTrivia: true )
+            {
+                this._endOfLineTrivia = SyntaxFactory.EndOfLine( endOfLine );
+            }
+
+            public override SyntaxTrivia VisitTrivia( SyntaxTrivia trivia )
+                => trivia.IsKind( SyntaxKind.EndOfLineTrivia )
+                    ? this._endOfLineTrivia
+                    : base.VisitTrivia( trivia );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/EndOfLineHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Formatting/EndOfLineHelper.cs
@@ -97,17 +97,48 @@ namespace Metalama.Framework.Engine.Formatting
 
         private sealed class EndOfLineNormalizingRewriter : CSharpSyntaxRewriter
         {
+            private readonly string _endOfLine;
             private readonly SyntaxTrivia _endOfLineTrivia;
 
             public EndOfLineNormalizingRewriter( string endOfLine ) : base( visitIntoStructuredTrivia: true )
             {
+                this._endOfLine = endOfLine;
                 this._endOfLineTrivia = SyntaxFactory.EndOfLine( endOfLine );
             }
 
             public override SyntaxTrivia VisitTrivia( SyntaxTrivia trivia )
-                => trivia.IsKind( SyntaxKind.EndOfLineTrivia )
-                    ? this._endOfLineTrivia
-                    : base.VisitTrivia( trivia );
+            {
+                if ( !trivia.IsKind( SyntaxKind.EndOfLineTrivia ) )
+                {
+                    return base.VisitTrivia( trivia );
+                }
+
+                // If the trivia already has the target content, return it unchanged
+                // to avoid allocating a new object and forcing reallocation of the tree branch.
+                if ( this.IsAlreadyNormalized( trivia ) )
+                {
+                    return trivia;
+                }
+
+                return this._endOfLineTrivia;
+            }
+
+            private bool IsAlreadyNormalized( SyntaxTrivia trivia )
+            {
+                if ( trivia.Span.Length != this._endOfLine.Length )
+                {
+                    return false;
+                }
+
+                // Length 2 is unambiguously \r\n for EndOfLineTrivia. For length 1, check the character.
+                if ( this._endOfLine.Length == 1
+                     && trivia.SyntaxTree?.TryGetText( out var text ) == true )
+                {
+                    return text[trivia.SpanStart] == this._endOfLine[0];
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CR.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CR.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @ExpectedEndOfLine(CR)
-// @Skipped
 #endif
 
 using System;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CR.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CR.t.cs
@@ -1,4 +1,3 @@
-// ERROR: Expected "\r" end of lines, but got "\n" at position 294.
 public class Target
 {
   [TestAspect1]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CRLF.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CRLF.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @ExpectedEndOfLine(CRLF)
-// @Skipped
 #endif
 
 using System;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CRLF.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_CRLF.t.cs
@@ -1,4 +1,3 @@
-// ERROR: Expected "\r\n" end of lines, but got "\n" at position 307.
 public class Target
 {
   [TestAspect1]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_LF.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_LF.cs
@@ -4,7 +4,6 @@
 
 #if TEST_OPTIONS
 // @ExpectedEndOfLine(LF)
-// @Skipped
 #endif
 
 using System;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_LF.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_LF.t.cs
@@ -1,4 +1,3 @@
-// ERROR: Expected "\n" end of lines, but got "\r\n" at position 1299.
 public class Target
 {
   [TestAspect1]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_Pragma_LF.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_Pragma_LF.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @ExpectedEndOfLine(LF)
+#endif
+
+using System;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Formatting.EndOfLines_Pragma_LF
+{
+    public class TestAspect : OverrideMethodAspect
+    {
+        public override dynamic? OverrideMethod()
+        {
+            Console.WriteLine( "Before" );
+
+            return meta.Proceed();
+        }
+    }
+
+    // <target>
+    public class Target
+    {
+        [TestAspect]
+        private static int Add( int a, int b )
+        {
+            return a + b;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_Pragma_LF.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/EndOfLines/EndOfLines_Pragma_LF.t.cs
@@ -1,0 +1,9 @@
+public class Target
+{
+  [TestAspect]
+  private static int Add(int a, int b)
+  {
+    Console.WriteLine("Before");
+    return a + b;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #813 — EOL normalization does not work around inserted `#pragma` and other locations.

**Root cause:** Roslyn's `Formatter.FormatAsync()` normalizes all EOLs to `\r\n` (Windows default), and there was no step to restore the original EOL style afterward.

**Fix:** Added EOL normalization in `CodeFormatter.FormatAsync` (both `PartialCompilation` and `FormatAllAsync` paths). After Roslyn's formatter runs, the fix detects the original EOL style from the source syntax tree and rewrites all `EndOfLineTrivia` in the formatted output to match.

## Changes
- `EndOfLineHelper.cs`: Added `NormalizeEndOfLines` method and `EndOfLineNormalizingRewriter` class
- `CodeFormatter.cs`: Added EOL normalization step after formatting in both `FormatAsync(PartialCompilation)` and `FormatAllAsync`
- Unskipped existing `EndOfLines_LF`, `EndOfLines_CRLF`, `EndOfLines_CR` tests (previously skipped due to known failures)
- Added new `EndOfLines_Pragma_LF` test

## Checklist
- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build (`Build.ps1 build`) — 0 warnings
- [x] Run tests — all pass
- [x] Finalize

## Test plan
- `EndOfLines_Pragma_LF`: verifies LF EOLs are preserved with an override aspect
- `EndOfLines_LF`, `EndOfLines_CRLF`, `EndOfLines_CR`: verify all EOL styles are preserved with insert statement aspects

— Claude for @PostSharpAgent