### PR TITLE
Improve LAMA0263 message to suggest local functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,6 @@
     <SystemTextRegularExpressionsLatestVersion>4.3.1</SystemTextRegularExpressionsLatestVersion>
     <SystemFormatsAsn1LatestVersion>9.0.10</SystemFormatsAsn1LatestVersion>
     <SystemIOPipelinesLatestVersion>9.0.10</SystemIOPipelinesLatestVersion>
-    <SystemBuffersLatestVersion>4.6.0</SystemBuffersLatestVersion>
 
 
   </PropertyGroup>
@@ -79,7 +78,7 @@
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageVersion Include="System.Memory" Version="4.6.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsLatestVersion)" />
     <PackageVersion Include="System.Threading" Version="4.3.0" />
@@ -91,7 +90,6 @@
     <PackageVersion Include="System.Linq.Parallel" Version="4.3.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" /> 
 
@@ -127,7 +125,6 @@
     <!-- The following package is ILMerged so we can take any version we want,
      however all dependencies must be lower or equal than the minimal we must suppport. -->
 
-    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.17" />
     <!-- The following packages are dependencies of StreamJsonRpc and we must match the version. 
         We now target the .NET SDK 8 and equivalent VS.
@@ -137,8 +134,6 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 
 
-    <PackageVersion Include="Metalama.Extensions.DiffEngine" Version="$(MetalamaVersion)" />
-    <PackageVersion Include="Metalama.Extensions.HtmlWriter" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Backstage" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Backstage.Commands" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Backstage.Tools" Version="$(MetalamaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <SystemTextRegularExpressionsLatestVersion>4.3.1</SystemTextRegularExpressionsLatestVersion>
     <SystemFormatsAsn1LatestVersion>9.0.10</SystemFormatsAsn1LatestVersion>
     <SystemIOPipelinesLatestVersion>9.0.10</SystemIOPipelinesLatestVersion>
+    <SystemBuffersLatestVersion>4.6.0</SystemBuffersLatestVersion>
 
 
   </PropertyGroup>
@@ -75,9 +76,10 @@
     <PackageVersion Include="System.DirectoryServices" Version="8.0.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.16" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
+    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsLatestVersion)" />
     <PackageVersion Include="System.Threading" Version="4.3.0" />
@@ -89,6 +91,7 @@
     <PackageVersion Include="System.Linq.Parallel" Version="4.3.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" /> 
 
@@ -124,6 +127,7 @@
     <!-- The following package is ILMerged so we can take any version we want,
      however all dependencies must be lower or equal than the minimal we must suppport. -->
 
+    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.17" />
     <!-- The following packages are dependencies of StreamJsonRpc and we must match the version. 
         We now target the .NET SDK 8 and equivalent VS.
@@ -133,6 +137,8 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 
 
+    <PackageVersion Include="Metalama.Extensions.DiffEngine" Version="$(MetalamaVersion)" />
+    <PackageVersion Include="Metalama.Extensions.HtmlWriter" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Backstage" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Backstage.Commands" Version="$(MetalamaVersion)" />
     <PackageVersion Include="Metalama.Backstage.Tools" Version="$(MetalamaVersion)" />

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
@@ -474,8 +474,8 @@ namespace Metalama.Framework.Engine.Templating
         internal static readonly DiagnosticDefinition<None> DynamicInLambdaUnsupported
             = new(
                 "LAMA0263",
-                "Lambdas or anonymous functions returning a dynamic type are not supported. Consider casting the result to IExpression. For void expressions, use a lambda statement.",
-                "Lambdas or anonymous functions returning a dynamic type are not supported except. Consider casting the result to IExpression.  For void expressions, use a lambda statement.",
+                "Lambdas or anonymous functions returning a dynamic type are not supported. Consider using a local function. Alternatively, cast the result to IExpression. For void expressions, use a lambda statement.",
+                "Lambdas or anonymous functions returning a dynamic type are not supported. Consider using a local function. Alternatively, cast the result to IExpression. For void expressions, use a lambda statement.",
                 _category,
                 Error );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingDiagnosticDescriptors.cs
@@ -474,7 +474,7 @@ namespace Metalama.Framework.Engine.Templating
         internal static readonly DiagnosticDefinition<None> DynamicInLambdaUnsupported
             = new(
                 "LAMA0263",
-                "Lambdas or anonymous functions returning a dynamic type are not supported. Consider using a local function. Alternatively, cast the result to IExpression. For void expressions, use a lambda statement.",
+                "Lambdas or anonymous functions returning a dynamic type are not supported.",
                 "Lambdas or anonymous functions returning a dynamic type are not supported. Consider using a local function. Alternatively, cast the result to IExpression. For void expressions, use a lambda statement.",
                 _category,
                 Error );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Diagnostics/DynamicInLambda.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Diagnostics/DynamicInLambda.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Linq;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Aspects.Diagnostics.DynamicInLambda;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+internal class Aspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Console.WriteLine( string.Join( ", ", meta.Target.Parameters.Select( p => p.Value ) ) );
+
+        return meta.Proceed();
+    }
+}
+
+internal class TargetCode
+{
+    [Aspect]
+    private int Method( int a, int b )
+    {
+        return a + b;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Diagnostics/DynamicInLambda.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Diagnostics/DynamicInLambda.t.cs
@@ -1,3 +1,3 @@
-// TestTemplateCompiler.TryCompile failed.
+// CompileTimeAspectPipeline.ExecuteAsync failed.
 // Error LAMA0263 on `p => p.Value`: `Lambdas or anonymous functions returning a dynamic type are not supported. Consider using a local function. Alternatively, cast the result to IExpression. For void expressions, use a lambda statement.`
 // Error LAMA0104 on `p`: `The expression 'p' is run-time but it is expected to be compile-time because the expression appears in a compile-time-only member 'Value'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Lambdas/DynamicInLambda2.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.TemplateTests/Tests/Syntax/Lambdas/DynamicInLambda2.t.cs
@@ -1,3 +1,3 @@
 // TestTemplateCompiler.TryCompile failed.
-// Error LAMA0263 on `p => p.Value?.ToString()`: `Lambdas or anonymous functions returning a dynamic type are not supported except. Consider casting the result to IExpression.  For void expressions, use a lambda statement.`
+// Error LAMA0263 on `p => p.Value?.ToString()`: `Lambdas or anonymous functions returning a dynamic type are not supported. Consider using a local function. Alternatively, cast the result to IExpression. For void expressions, use a lambda statement.`
 // Error LAMA0104 on `p`: `The expression 'p' is run-time but it is expected to be compile-time because the expression appears in a compile-time-only member 'Value'.`


### PR DESCRIPTION
## Summary

Closes #803

- Updated LAMA0263 diagnostic message to add "Consider using a local function." as a suggestion when dynamic expressions are used in lambdas
- Changed "Alternatively, cast the result to IExpression" (was "Consider casting...")
- Fixed inconsistent title/message text (message previously said "not supported except" with extra space)
- Added aspect test `DynamicInLambda` verifying the updated message
- Updated existing template test expected outputs to match the new message

## Checklist
- [x] Understand the issue
- [x] Implement fix (update diagnostic message)
- [x] Add aspect test
- [x] Update existing template test expected outputs
- [x] Revert unrelated Directory.Packages.props changes (per review feedback)
- [ ] CI build passes
- [x] Mark PR as ready

## Test plan
- [x] Verify `DynamicInLambda` aspect test produces the updated error message
- [x] Verify existing `DynamicInLambda` and `DynamicInLambda2` template tests match after message update
- [ ] CI validation

— Claude for @gfraiteur