### PR TITLE
Fix: Aspect Explorer shows validation-only fabrics as unused aspects (#656)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,8 @@
 
     <!-- These are the latest versions of dependencies, which we use in test projects to avoid vulnerability warnings -->
     <MicrosoftVisualStudioThreadingLatestVersion>17.14.15</MicrosoftVisualStudioThreadingLatestVersion>
-    <MessagePackLatestVersion>3.1.4</MessagePackLatestVersion>
+    <!-- MessagePack 2.x is required for compatibility with StreamJsonRpc (3.x is incompatible). -->
+    <MessagePackLatestVersion>2.5.198</MessagePackLatestVersion>
     <StreamJsonRpcLatestVersion>2.22.23</StreamJsonRpcLatestVersion>
     <SystemTextJsonLatestVersion>9.0.10</SystemTextJsonLatestVersion>
     <MicrosoftBclAsyncInterfacesLatestVersion>9.0.10</MicrosoftBclAsyncInterfacesLatestVersion>
@@ -41,6 +42,7 @@
     <SystemTextRegularExpressionsLatestVersion>4.3.1</SystemTextRegularExpressionsLatestVersion>
     <SystemFormatsAsn1LatestVersion>9.0.10</SystemFormatsAsn1LatestVersion>
     <SystemIOPipelinesLatestVersion>9.0.10</SystemIOPipelinesLatestVersion>
+    <SystemBuffersLatestVersion>4.6.1</SystemBuffersLatestVersion>
 
 
   </PropertyGroup>
@@ -78,7 +80,8 @@
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Buffers" Version="4.5.1" /> <!-- Given by System.Memory -->
+    <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsLatestVersion)" />
     <PackageVersion Include="System.Threading" Version="4.3.0" />
@@ -125,6 +128,7 @@
     <!-- The following package is ILMerged so we can take any version we want,
      however all dependencies must be lower or equal than the minimal we must suppport. -->
 
+    <PackageVersion Include="MessagePack" Version="$(MessagePackLatestVersion)" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.17" />
     <!-- The following packages are dependencies of StreamJsonRpc and we must match the version. 
         We now target the .NET SDK 8 and equivalent VS.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricManager.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricManager.cs
@@ -74,15 +74,22 @@ internal sealed class FabricManager
             .SelectMany( x => this.CreateDrivers( compileTimeProject, x, compilationModel, diagnosticAdder ) )
             .ToOrderedList( x => x );
 
-        var allFabricTypeNames = fabricTypeNames.Concat( transitiveFabricTypeNames ).ToImmutableArray();
-
         var typeFabricDrivers = fabricDrivers.OfType<TypeFabricDriver>().Concat( transitiveFabricDrivers.OfType<TypeFabricDriver>() ).ToImmutableArray();
 
         var contributors = ImmutableArray.CreateBuilder<IPipelineContributor>();
 
+        // Track fabric type names that contribute aspects (for the Aspect Explorer).
+        // Validation-only fabrics should not appear as aspect classes.
+        var aspectContributingFabricTypeNames = new HashSet<string>();
+
         if ( !typeFabricDrivers.IsEmpty )
         {
             contributors.Add( new FabricAspectSource( this, typeFabricDrivers ) );
+
+            foreach ( var driver in typeFabricDrivers )
+            {
+                aspectContributingFabricTypeNames.Add( driver.FabricTypeFullName );
+            }
         }
 
         // Execute static drivers now.
@@ -95,6 +102,11 @@ internal sealed class FabricManager
                 {
                     contributors.AddRange( result.Contributors );
                     this._listener?.AddStaticFabricResult( result );
+
+                    if ( result.Contributors.Any( c => c is IAspectSource ) )
+                    {
+                        aspectContributingFabricTypeNames.Add( driver.FabricTypeFullName );
+                    }
                 }
                 else
                 {
@@ -109,6 +121,10 @@ internal sealed class FabricManager
         Execute( fabricDrivers.OfType<NamespaceFabricDriver>() );
 
         var pipelineContributorSources = new PipelineContributorSources( contributors.ToImmutable() );
+
+        var allFabricTypeNames = fabricTypeNames.Concat( transitiveFabricTypeNames )
+            .Where( aspectContributingFabricTypeNames.Contains )
+            .ToImmutableArray();
 
         return (pipelineContributorSources, allFabricTypeNames);
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
@@ -707,8 +707,8 @@ public sealed class AspectDatabaseTests( ITestOutputHelper testOutputHelper ) : 
         var aspectClasses = await aspectDatabase.GetAspectClassesAsync( projectKey, testContext.CancellationToken );
 
         // A fabric that only validates (reports diagnostics) should not appear as an "aspect class"
-        // in the Aspect Explorer. It should either not be listed, or be listed with validation info.
-        // Currently it is listed as an aspect class with no instances, making it falsely appear "unused".
+        // in the Aspect Explorer. It should not be listed among aspect classes.
+        // Previously it was listed as an aspect class with no instances, making it falsely appear "unused".
         AssertAspectClasses( [], aspectClasses );
     }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
@@ -668,6 +668,51 @@ public sealed class AspectDatabaseTests( ITestOutputHelper testOutputHelper ) : 
     }
 
     [Fact]
+    public async Task ValidationOnlyFabricNotShownAsUnusedAspectTest()
+    {
+        const string code =
+            """
+            using Metalama.Framework.Code;
+            using Metalama.Framework.Diagnostics;
+            using Metalama.Framework.Fabrics;
+            using System.Linq;
+
+            class ValidatingFabric : ProjectFabric
+            {
+                private static readonly DiagnosticDefinition<IDeclaration> _warning =
+                    new( "MY001", Severity.Warning, "Warning on {0}." );
+
+                public override void AmendProject(IProjectAmender amender)
+                {
+                    amender.SelectMany( x => x.Types.SelectMany( t => t.Methods ) ).ReportDiagnostic( t => _warning.WithArguments( t ) );
+                }
+            }
+
+            class Target
+            {
+                void M() { }
+            }
+            """;
+
+        using var testContext = this.CreateTestContext();
+        using TestDesignTimeAspectPipelineFactory factory = new( testContext );
+
+        var workspaceProvider = factory.ServiceProvider.GetRequiredService<TestWorkspaceProvider>();
+        var projectKey = workspaceProvider.AddOrUpdateProject( testContext, "project", new Dictionary<string, string> { ["code.cs"] = code } );
+
+        var aspectDatabase = new AspectDatabase( factory.ServiceProvider );
+
+        Assert.True( await aspectDatabase.HasValidConfigurationAsync( projectKey, testContext.CancellationToken ) );
+
+        var aspectClasses = await aspectDatabase.GetAspectClassesAsync( projectKey, testContext.CancellationToken );
+
+        // A fabric that only validates (reports diagnostics) should not appear as an "aspect class"
+        // in the Aspect Explorer. It should either not be listed, or be listed with validation info.
+        // Currently it is listed as an aspect class with no instances, making it falsely appear "unused".
+        AssertAspectClasses( [], aspectClasses );
+    }
+
+    [Fact]
     public async Task HideFromAspectExplorerTest()
     {
         const string code =


### PR DESCRIPTION
## Summary

Fixes #656 — Aspect Explorer incorrectly shows fabrics that only use validators (e.g., `ReportDiagnostic`, `Verify().CannotBeUsedFrom()`) as "unused aspects".

**Root cause**: `FabricManager.ExecuteFabrics()` returns ALL fabric type names to `AspectPipelineConfiguration.FabricTypeNames`, which `AspectDatabase.GetAspectClassesAsync()` then includes in the Aspect Explorer. Validation-only fabrics produce `IDiagnosticSource` contributors but no `IAspectSource` contributors, so they appear as aspect classes with zero instances (i.e., "unused").

**Fix**: In `FabricManager.ExecuteFabrics()`, track which fabric type names actually produce `IAspectSource` contributors. Only include those in the returned `FabricTypeNames`. Fabrics that only produce diagnostic/validation contributors are excluded from the Aspect Explorer.

Also fixes pre-existing `Directory.Packages.props` merge issues (missing `PackageVersion` entries for MessagePack, System.Buffers; System.Memory version too low for Roslyn 5.0.0).

## Checklist

- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build and test (1732 unit tests pass, 0 warnings)
- [x] Finalize

— Claude for @gfraiteur