### PR TITLE
Fix Aspect Explorer: differentiate return parameter from @return param (#689)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractBaseTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractBaseTransformation.cs
@@ -12,6 +12,7 @@ using Metalama.Framework.Engine.Templating;
 using Metalama.Framework.Engine.Templating.MetaModel;
 using Metalama.Framework.Engine.Transformations;
 using Metalama.Framework.Introspection;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
@@ -111,7 +112,8 @@ internal abstract class ContractBaseTransformation : BaseSyntaxTreeTransformatio
         var parameter = target.DeclarationKind switch
         {
             DeclarationKind.Parameter when target is IParameter { IsReturnParameter: true } => "return value",
-            DeclarationKind.Parameter when target is IParameter param => $"parameter '{param.Name}'",
+            DeclarationKind.Parameter when target is IParameter param =>
+                $"parameter '{(SyntaxFacts.GetKeywordKind( param.Name ) != SyntaxKind.None ? "@" + param.Name : param.Name)}'",
             _ => $"unexpected declaration '{target}'"
         };
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractBaseTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/ContractBaseTransformation.cs
@@ -8,11 +8,11 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Advising;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Templating;
 using Metalama.Framework.Engine.Templating.MetaModel;
 using Metalama.Framework.Engine.Transformations;
 using Metalama.Framework.Introspection;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
@@ -113,7 +113,7 @@ internal abstract class ContractBaseTransformation : BaseSyntaxTreeTransformatio
         {
             DeclarationKind.Parameter when target is IParameter { IsReturnParameter: true } => "return value",
             DeclarationKind.Parameter when target is IParameter param =>
-                $"parameter '{(SyntaxFacts.GetKeywordKind( param.Name ) != SyntaxKind.None ? "@" + param.Name : param.Name)}'",
+                $"parameter '{SyntaxFactoryEx.SafeIdentifier( param.Name ).Text}'",
             _ => $"unexpected declaration '{target}'"
         };
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/AspectDatabaseTests.cs
@@ -527,6 +527,68 @@ public sealed class AspectDatabaseTests( ITestOutputHelper testOutputHelper ) : 
     }
 
     [Fact]
+    public async Task ContractReturnParameterAndKeywordParamNameTest()
+    {
+        const string code =
+            """
+            using Metalama.Framework.Aspects;
+            using Metalama.Framework.Code;
+            using System;
+
+            internal class NotNullAttribute : ContractAspect
+            {
+                public override void Validate( dynamic? value )
+                {
+                    if (value is null)
+                    {
+                        throw new ArgumentNullException();
+                    }
+                }
+            }
+
+            class Target
+            {
+                [return: NotNull]
+                string M([NotNull] string @return) => @return;
+            }
+            """;
+
+        using var testContext = this.CreateTestContext();
+        using TestDesignTimeAspectPipelineFactory factory = new( testContext );
+
+        var workspaceProvider = factory.ServiceProvider.GetRequiredService<TestWorkspaceProvider>();
+        var projectKey = workspaceProvider.AddOrUpdateProject( testContext, "project", new Dictionary<string, string> { ["code.cs"] = code } );
+
+        var aspectDatabase = new AspectDatabase( factory.ServiceProvider );
+
+        var aspectInstances = await aspectDatabase.GetAspectInstancesAsync(
+            projectKey,
+            "project",
+            new SerializableTypeId( "Y:global::NotNullAttribute" ),
+            CancellationToken.None );
+
+        Assert.NotNull( aspectInstances );
+
+        // Both the return parameter contract and the @return parameter contract should be present
+        // with distinct target declaration IDs.
+        AssertAspectInstances(
+            [
+                "M:Target.M(System.String)~System.String",
+                "M:Target.M(System.String)~System.String;Parameter=0"
+            ],
+            aspectInstances );
+
+        // The display strings should differentiate between the return value and the @return parameter.
+        // The parameter named @return should display with the @ prefix to distinguish it from the return value.
+        AssertAspectTransformations(
+            [
+                "Add contract to parameter '@return' of method 'Target.M(string)'",
+                "Add contract to return value of method 'Target.M(string)'"
+            ],
+            aspectInstances );
+    }
+
+    [Fact]
     public async Task AddThroughFabricTest()
     {
         const string code =

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -12,6 +12,7 @@ using Metalama.Framework.Engine.SerializableIds;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Testing.UnitTesting;
 using Microsoft.CodeAnalysis;
+using System;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -283,10 +284,10 @@ class C
         Assert.NotEqual( returnParamId.Id, regularParamId.Id );
 
         // Verify the return parameter ID contains ";Return".
-        Assert.Contains( ";Return", returnParamId.Id );
+        Assert.Contains( ";Return", returnParamId.Id, StringComparison.Ordinal );
 
         // Verify the regular parameter ID contains ";Parameter=0".
-        Assert.Contains( ";Parameter=0", regularParamId.Id );
+        Assert.Contains( ";Parameter=0", regularParamId.Id, StringComparison.Ordinal );
 
         // Roundtrip both parameters.
         Roundtrip( returnParameter, compilation, this.TestOutput );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SerializableDeclarationIdTests.cs
@@ -253,6 +253,47 @@ delegate int D(int x, string y);
     }
 
     [Fact]
+    public void KeywordParameterAndReturnParameterDistinctIds()
+    {
+        const string code = @"
+class C
+{
+    string M(string @return) => @return;
+}
+";
+
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilation( code );
+        var type = compilation.Types.Single();
+        var method = type.Methods.OfName( "M" ).Single();
+        var returnParameter = method.ReturnParameter;
+        var regularParameter = method.Parameters.Single();
+
+        // Verify the parameter name is "return" (without @, as Roslyn strips it).
+        Assert.Equal( "return", regularParameter.Name );
+
+        // Get IDs for both parameters.
+        var returnParamId = returnParameter.ToSerializableId();
+        var regularParamId = regularParameter.ToSerializableId();
+
+        this.TestOutput.WriteLine( $"Return parameter ID: {returnParamId.Id}" );
+        this.TestOutput.WriteLine( $"Regular parameter ID: {regularParamId.Id}" );
+
+        // The IDs must be different.
+        Assert.NotEqual( returnParamId.Id, regularParamId.Id );
+
+        // Verify the return parameter ID contains ";Return".
+        Assert.Contains( ";Return", returnParamId.Id );
+
+        // Verify the regular parameter ID contains ";Parameter=0".
+        Assert.Contains( ";Parameter=0", regularParamId.Id );
+
+        // Roundtrip both parameters.
+        Roundtrip( returnParameter, compilation, this.TestOutput );
+        Roundtrip( regularParameter, compilation, this.TestOutput );
+    }
+
+    [Fact]
     public void DelegateParameterRoundtrip()
     {
         const string code = @"


### PR DESCRIPTION
## Summary
- Add `@` prefix to parameter display names when the parameter name is a C# keyword (verbatim identifier) in `ContractBaseTransformation.ToDisplayString()`
- This fixes the Aspect Explorer showing identical "return" for both the return value and a parameter named `@return`
- Added unit tests for both SerializableDeclarationId roundtrip and AspectDatabase display string verification

Fixes #689

## Test plan
- [x] `KeywordParameterAndReturnParameterDistinctIds` - verifies SerializableDeclarationId correctly distinguishes return parameter from `@return` parameter
- [x] `ContractReturnParameterAndKeywordParamNameTest` - verifies AspectDatabase shows distinct descriptions: "parameter '@return'" vs "return value"
- [x] Full unit test suite (1733 tests passed, 0 failures)

## Checklist
- [x] Reproduce bug with failing test
- [x] Implement fix
- [x] Build (Metalama.Framework solution - success)
- [x] Test (all unit tests pass)
- [x] Finalize

— Claude for @gfraiteur