### PR TITLE
Fix VerifyNotNullableDeclarations on primary constructor properties (#1536)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -61,9 +61,9 @@ namespace Metalama.Framework.Engine.Linking
                      && this.AnalysisRegistry.IsReachable( symbol.ToSemantic( IntermediateSymbolSemanticKind.Default ) ) )
                 {
                     // Backing field for auto property.
-                    // When the property is initialized from a primary constructor parameter (e.g., `Action { get; init; } = action`),
-                    // the initializer references the primary constructor parameter which won't exist after the constructor is rewritten.
-                    // The assignment is handled in the explicit constructor body instead.
+                    // When primary-constructor removal moves this member's initialization into the synthesized constructor body,
+                    // the generated backing field must not keep the original initializer, or the initialization would be duplicated
+                    // and could reference constructor-only state.
                     var backingFieldInitializer = this.LateTransformationRegistry.IsPrimaryConstructorInitializedMember( symbol )
                         ? null
                         : propertyDeclaration.Initializer;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -61,9 +61,16 @@ namespace Metalama.Framework.Engine.Linking
                      && this.AnalysisRegistry.IsReachable( symbol.ToSemantic( IntermediateSymbolSemanticKind.Default ) ) )
                 {
                     // Backing field for auto property.
+                    // When the property is initialized from a primary constructor parameter (e.g., `Action { get; init; } = action`),
+                    // the initializer references the primary constructor parameter which won't exist after the constructor is rewritten.
+                    // The assignment is handled in the explicit constructor body instead.
+                    var backingFieldInitializer = this.LateTransformationRegistry.IsPrimaryConstructorInitializedMember( symbol )
+                        ? null
+                        : propertyDeclaration.Initializer;
+
                     var backingField = this.GetPropertyBackingField(
                         propertyDeclaration.Type,
-                        propertyDeclaration.Initializer,
+                        backingFieldInitializer,
                         FilterAttributeListsForTarget( propertyDeclaration.AttributeLists, SyntaxKind.FieldKeyword, false, false ),
                         symbol,
                         generationContext );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @RequiredConstant(ROSLYN_4_8_0_OR_GREATER)
+#endif
+
+#if ROSLYN_4_8_0_OR_GREATER
+
+using System;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Contracts.ConstructorPrimary_PropertyInitializer;
+
+/// <summary>
+/// Tests that when both a constructor contract and a property contract are applied
+/// to a class with a primary constructor, the property backing field initializer
+/// does not reference the now-removed primary constructor parameter.
+/// This reproduces issue #1536.
+/// </summary>
+internal class ValidateAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        // Apply contract to constructor parameter (triggers primary constructor removal).
+        foreach (var constructor in builder.Target.Constructors)
+        {
+            foreach (var parameter in constructor.Parameters)
+            {
+                if (parameter.Type.IsReferenceType == true && parameter.Type.IsNullable != true)
+                {
+                    builder.With( parameter ).AddContract( nameof(ValidateParameter), ContractDirection.Input );
+                }
+            }
+        }
+
+        // Apply contract to properties (triggers backing field creation).
+        foreach (var property in builder.Target.Properties)
+        {
+            if (property.IsImplicitlyDeclared)
+            {
+                continue;
+            }
+
+            if (property.Type.IsReferenceType == true && property.Type.IsNullable != true && property.Writeability != Writeability.None)
+            {
+                builder.With( property ).AddContract( nameof(ValidateProperty), ContractDirection.Input );
+            }
+        }
+    }
+
+    [Template]
+    private void ValidateParameter( dynamic? value )
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException( meta.Target.Parameter.Name );
+        }
+    }
+
+    [Template]
+    private void ValidateProperty( dynamic? value )
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException( "value" );
+        }
+    }
+}
+
+// <target>
+[Validate]
+internal sealed class Target( Action action ) : IDisposable
+{
+    private Action Action { get; init; } = action;
+
+    void IDisposable.Dispose()
+    {
+        this.Action();
+    }
+}
+
+#endif

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.cs
@@ -65,7 +65,7 @@ internal class ValidateAttribute : TypeAspect
     {
         if (value == null)
         {
-            throw new ArgumentNullException( "value" );
+            throw new ArgumentNullException( nameof(value) );
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.t.cs
@@ -12,7 +12,7 @@ internal sealed class Target : IDisposable
     {
       if (value == null)
       {
-        throw new global::System.ArgumentNullException("value");
+        throw new global::System.ArgumentNullException(nameof(value));
       }
       this._action = value;
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_PropertyInitializer.t.cs
@@ -1,0 +1,32 @@
+[Validate]
+internal sealed class Target : IDisposable
+{
+  private readonly Action _action = default !;
+  private Action Action
+  {
+    get
+    {
+      return this._action;
+    }
+    init
+    {
+      if (value == null)
+      {
+        throw new global::System.ArgumentNullException("value");
+      }
+      this._action = value;
+    }
+  }
+  void IDisposable.Dispose()
+  {
+    this.Action();
+  }
+  public Target(Action action)
+  {
+    this.Action = action;
+    if (action == null)
+    {
+      throw new global::System.ArgumentNullException("action");
+    }
+  }
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Fabric_PrimaryConstructor.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Fabric_PrimaryConstructor.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#pragma warning disable SA1649, SA1402
+
+// ReSharper disable  CheckNamespace
+
+using Metalama.Framework.Fabrics;
+using System;
+
+namespace Metalama.Patterns.Contracts.AspectTests.Fabric_PrimaryConstructor
+{
+    internal class Fabric : ProjectFabric
+    {
+        public override void AmendProject( IProjectAmender amender )
+        {
+            amender.VerifyNotNullableDeclarations( true );
+        }
+    }
+
+    public sealed class Memento( Action action ) : IDisposable
+    {
+        private Action Action { get; init; } = action;
+
+        void IDisposable.Dispose()
+        {
+            this.Action();
+        }
+    }
+}

--- a/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Fabric_PrimaryConstructor.t.cs
+++ b/Metalama.Patterns/src/tests/Metalama.Patterns.Contracts.AspectTests/Fabric_PrimaryConstructor.t.cs
@@ -1,0 +1,42 @@
+using Metalama.Framework.Fabrics;
+using System;
+namespace Metalama.Patterns.Contracts.AspectTests.Fabric_PrimaryConstructor
+{
+#pragma warning disable CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  internal class Fabric : ProjectFabric
+  {
+    public override void AmendProject(IProjectAmender amender) => throw new System.NotSupportedException("Compile-time-only code cannot be called at run-time.");
+  }
+#pragma warning restore CS0067, CS8618, CS0162, CS0169, CS0414, CA1822, CA1823, IDE0051, IDE0052
+  public sealed class Memento : IDisposable
+  {
+    private readonly Action _action = default !;
+    private Action Action
+    {
+      get
+      {
+        return _action;
+      }
+      init
+      {
+        if (value == null !)
+        {
+          throw new ArgumentNullException("value", "The 'Action' property must not be null.");
+        }
+        _action = value;
+      }
+    }
+    void IDisposable.Dispose()
+    {
+      this.Action();
+    }
+    public Memento(Action action)
+    {
+      Action = action;
+      if (action == null !)
+      {
+        throw new ArgumentNullException("action", "The 'action' parameter must not be null.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1536

## Summary

When `VerifyNotNullableDeclarations(true)` is applied via a fabric, classes with primary constructor-initialized properties fail with LAMA0611 (CS0103: parameter name does not exist). The root cause: when a contract is applied to a property that's initialized from a primary constructor parameter, the backing field gets an initializer that references the now-nonexistent primary constructor parameter (e.g., `private readonly Action _action = action;`).

## Fix

In `LinkerRewritingDriver.Properties.cs`, when creating a backing field for an auto property that is an override target, skip the initializer if the property is a primary constructor-initialized member. The assignment is already handled by the explicit constructor body generated during the primary constructor removal transformation.

## Tests

- Added `ConstructorPrimary_PropertyInitializer` in Framework aspect tests (combines constructor parameter contract + property contract on a primary constructor class)
- Added `Fabric_PrimaryConstructor` in Patterns contract aspect tests (reproduces the exact scenario from the issue)
- All 2133 Framework aspect tests pass
- All 42 Patterns contract tests pass

## Checklist

- [x] Reproduce bug with failing regression test
- [x] Implement fix
- [x] Build succeeds with zero warnings
- [x] All tests pass
- [x] Finalize

— Claude for @gfraiteur