### PR TITLE
Fix NRE in TransformCompileTimeType for nested type declarations (#1533)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.ProduceCompileTimeCodeRewriter.cs
@@ -536,6 +536,22 @@ namespace Metalama.Framework.Engine.CompileTime
 
                                 break;
 
+                            case TypeDeclarationSyntax nestedType:
+                                members.AddRange( this.VisitTypeDeclaration( nestedType ) );
+
+                                break;
+
+                            case EnumDeclarationSyntax:
+                            case DelegateDeclarationSyntax:
+                                var visited = (MemberDeclarationSyntax?) this.Visit( member );
+
+                                if ( visited != null )
+                                {
+                                    members.Add( visited );
+                                }
+
+                                break;
+
                             default:
                                 members.Add( (MemberDeclarationSyntax) this.Visit( member ).AssertNotNull() );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1533.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1533.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1533;
+
+/*
+ * Regression test for #1533: NullReferenceException in ProduceCompileTimeCodeRewriter.TransformCompileTimeType
+ * when a compile-time type (aspect) contains nested type declarations (class, record, enum, delegate).
+ * These nested types fall through to the default case in TransformCompileTimeType's member switch,
+ * where Visit() returns null for runtime-only types, causing NRE in SyntaxList.CreateNode().
+ */
+
+public sealed class AspectWithNestedTypes : TypeAspect
+{
+    // Nested class inside the aspect (a compile-time type).
+    // This is runtime-only and triggers the bug in the default case.
+    public class NestedClass
+    {
+        public string? Name { get; set; }
+    }
+
+    // Nested record class inside the aspect.
+    public record NestedRecord( string Value );
+
+    // Nested enum inside the aspect.
+    public enum NestedEnum
+    {
+        None,
+        First,
+        Second
+    }
+
+    // Nested delegate inside the aspect.
+    public delegate void NestedDelegate( string message );
+
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceMethod( nameof(IntroducedMethod) );
+    }
+
+    [Template]
+    public void IntroducedMethod()
+    {
+        Console.WriteLine( "Introduced" );
+    }
+}
+
+// <target>
+[AspectWithNestedTypes]
+public class TargetClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1533.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1533.t.cs
@@ -1,0 +1,8 @@
+[AspectWithNestedTypes]
+public class TargetClass
+{
+  public void IntroducedMethod()
+  {
+    global::System.Console.WriteLine("Introduced");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1533 — `NullReferenceException` in `ProduceCompileTimeCodeRewriter.TransformCompileTimeType` during compile-time type transformation.

### Root cause

The `default` case in `TransformCompileTimeType`'s member processing switch called `this.Visit(member).AssertNotNull()` for all unhandled member types, including nested type declarations (class, struct, interface, record, enum, delegate). However, `Visit()` dispatches to `VisitClassDeclaration`/`VisitRecordDeclaration`/etc., which call `VisitTypeDeclaration(...).SingleOrDefault()` — returning `null` for runtime-only types (empty enumerable). In debug builds `AssertNotNull()` catches this, but in release builds it's a no-op, so null gets added to the `members` list, causing `SyntaxList<T>.CreateNode()` to throw `NullReferenceException`.

### Fix

Added explicit switch cases for `TypeDeclarationSyntax` (class/struct/interface/record), `EnumDeclarationSyntax`, and `DelegateDeclarationSyntax` with proper null handling — matching the pattern already used in `VisitTypeOrNamespaceMembers`.

### Commits

1. **d9289e75db** — Failing regression test: aspect with nested class, record, enum, and delegate
2. **cd660ab536** — Fix + expected output

### Checklist

- [x] Regression test added (Bug1533) — exercises nested types in compile-time types
- [x] Test verified to FAIL before fix (commit d9289e75db)
- [x] All aspect tests pass (1871/1871)
- [x] All unit tests pass (1494/1494)
- [x] Build.ps1 build succeeds with zero warnings
- [x] No breaking changes

— Claude for @gfraiteur