### PR TITLE
Wrap IInitializable creations in field/property initializers (#1545)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisRegistry.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisRegistry.cs
@@ -19,6 +19,7 @@ internal sealed class LinkerAnalysisRegistry
     private readonly HashSet<IntermediateSymbolSemantic> _reachableSemantics;
     private readonly HashSet<IntermediateSymbolSemantic> _inlinedSemantics;
     private readonly IReadOnlyDictionary<InliningContextIdentifier, IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>> _substitutions;
+    private readonly IReadOnlyDictionary<ISymbol, IReadOnlyList<SyntaxNodeSubstitution>> _initializerSubstitutions;
     private readonly HashSet<ISymbol> _overrideTargetsWithUnsupportedNonInlinedOverrides;
     private readonly IReadOnlyDictionary<IEventSymbol, EventBrokerInfo> _eventBrokers;
     private readonly IReadOnlyDictionary<INamedTypeSymbol, IReadOnlyList<StaticFieldInfo>> _staticDelegates;
@@ -29,6 +30,7 @@ internal sealed class LinkerAnalysisRegistry
         HashSet<IntermediateSymbolSemantic> reachableSemantics,
         HashSet<IntermediateSymbolSemantic> inlinedSemantics,
         IReadOnlyDictionary<InliningContextIdentifier, IReadOnlyList<SyntaxNodeSubstitution>> substitutions,
+        IReadOnlyDictionary<ISymbol, IReadOnlyList<SyntaxNodeSubstitution>> initializerSubstitutions,
         HashSet<ISymbol> overrideTargetsWithUnsupportedNonInlinedOverrides,
         IReadOnlyDictionary<IEventSymbol, EventBrokerInfo> eventBrokers,
         IReadOnlyDictionary<INamedTypeSymbol, IReadOnlyList<StaticFieldInfo>> staticDelegates,
@@ -36,6 +38,7 @@ internal sealed class LinkerAnalysisRegistry
     {
         this._reachableSemantics = reachableSemantics;
         this._inlinedSemantics = inlinedSemantics;
+        this._initializerSubstitutions = initializerSubstitutions;
         this._overrideTargetsWithUnsupportedNonInlinedOverrides = overrideTargetsWithUnsupportedNonInlinedOverrides;
         this._eventBrokers = eventBrokers;
         this._staticDelegates = staticDelegates;
@@ -61,6 +64,36 @@ internal sealed class LinkerAnalysisRegistry
 
         return substitutions;
     }
+
+    /// <summary>
+    /// Gets the substitutions to apply inside the initializer of a field / event-field / property
+    /// whose initializer contains <c>new T()</c> or <c>with</c> expressions targeting types
+    /// implementing <c>IInitializable</c>. Returns <c>false</c> if the member has no such
+    /// substitutions.
+    /// </summary>
+    public bool TryGetInitializerSubstitutions( ISymbol memberSymbol, out IReadOnlyList<SyntaxNodeSubstitution> substitutions )
+    {
+        if ( this._initializerSubstitutions.TryGetValue( memberSymbol, out var list ) )
+        {
+            substitutions = list;
+
+            return true;
+        }
+
+        substitutions = ImmutableArray<SyntaxNodeSubstitution>.Empty;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the given field / event-field / property symbol has at least one
+    /// initializer call-site substitution registered. Used by <c>IsRewriteTarget</c> to make sure
+    /// the linker visits declarations whose only change is an <c>IInitializable</c> call-site
+    /// rewrite inside an initializer. For fields that declare multiple variables, this checks any
+    /// variable in the declaration by examining each contained field symbol separately is the
+    /// caller's responsibility.
+    /// </summary>
+    public bool HasInitializerSubstitutions( ISymbol memberSymbol ) => this._initializerSubstitutions.ContainsKey( memberSymbol );
 
     public bool HasAnySubstitutions( ISymbol symbol )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.ObjectCreationCallSiteReference.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.ObjectCreationCallSiteReference.cs
@@ -15,9 +15,12 @@ internal sealed partial class LinkerAnalysisStep
     public readonly struct ObjectCreationCallSiteReference
     {
         /// <summary>
-        /// Gets the method body that contains this call site.
+        /// Gets the symbol that lexically contains this call site. For call sites inside a method
+        /// body, accessor, constructor, destructor, operator, conversion-operator or local function,
+        /// this is an <see cref="IMethodSymbol"/>. For call sites inside a field, event-field or
+        /// property initializer, this is the corresponding field/event/property symbol.
         /// </summary>
-        public IntermediateSymbolSemantic<IMethodSymbol> ContainingSemantic { get; }
+        public ISymbol ContainingSymbol { get; }
 
         /// <summary>
         /// Gets the syntax node to be replaced (ObjectCreationExpressionSyntax,
@@ -48,14 +51,14 @@ internal sealed partial class LinkerAnalysisStep
         public string? ContextParamName { get; }
 
         public ObjectCreationCallSiteReference(
-            IntermediateSymbolSemantic<IMethodSymbol> containingSemantic,
+            ISymbol containingSymbol,
             SyntaxNode referencingNode,
             bool isWithExpression,
             InitializableTypeInfo typeInfo,
             IMethodSymbol? constructor,
             string? contextParamName )
         {
-            this.ContainingSemantic = containingSemantic;
+            this.ContainingSymbol = containingSymbol;
             this.ReferencingNode = referencingNode;
             this.IsWithExpression = isWithExpression;
             this.TypeInfo = typeInfo;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.OnInitializedCallSiteFinder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.OnInitializedCallSiteFinder.cs
@@ -63,8 +63,9 @@ internal sealed partial class LinkerAnalysisStep
         }
 
         /// <summary>
-        /// Walks a syntax tree, tracking the containing method symbol, and looking for
-        /// object creation and <c>with</c> expressions targeting types implementing <c>IInitializable</c>.
+        /// Walks a syntax tree, tracking the containing symbol (method body or field/property
+        /// initializer member), and looking for object creation and <c>with</c> expressions
+        /// targeting types implementing <c>IInitializable</c>.
         /// </summary>
         private sealed class CallSiteWalker : CSharpSyntaxWalker
         {
@@ -73,7 +74,7 @@ internal sealed partial class LinkerAnalysisStep
             private readonly INamedTypeSymbol? _initializationContextType;
             private readonly CompilationContext _compilationContext;
             private readonly ConcurrentQueue<ObjectCreationCallSiteReference> _results;
-            private IMethodSymbol? _containingMethod;
+            private ISymbol? _containingSymbol;
 
             public CallSiteWalker(
                 SemanticModel semanticModel,
@@ -91,32 +92,32 @@ internal sealed partial class LinkerAnalysisStep
 
             public override void VisitMethodDeclaration( MethodDeclarationSyntax node )
             {
-                this.VisitWithContainingMethod( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitMethodDeclaration );
+                this.VisitWithContainingSymbol( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitMethodDeclaration );
             }
 
             public override void VisitConstructorDeclaration( ConstructorDeclarationSyntax node )
             {
-                this.VisitWithContainingMethod( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitConstructorDeclaration );
+                this.VisitWithContainingSymbol( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitConstructorDeclaration );
             }
 
             public override void VisitDestructorDeclaration( DestructorDeclarationSyntax node )
             {
-                this.VisitWithContainingMethod( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitDestructorDeclaration );
+                this.VisitWithContainingSymbol( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitDestructorDeclaration );
             }
 
             public override void VisitOperatorDeclaration( OperatorDeclarationSyntax node )
             {
-                this.VisitWithContainingMethod( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitOperatorDeclaration );
+                this.VisitWithContainingSymbol( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitOperatorDeclaration );
             }
 
             public override void VisitConversionOperatorDeclaration( ConversionOperatorDeclarationSyntax node )
             {
-                this.VisitWithContainingMethod( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitConversionOperatorDeclaration );
+                this.VisitWithContainingSymbol( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitConversionOperatorDeclaration );
             }
 
             public override void VisitAccessorDeclaration( AccessorDeclarationSyntax node )
             {
-                this.VisitWithContainingMethod( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitAccessorDeclaration );
+                this.VisitWithContainingSymbol( node, this._semanticModel.GetDeclaredSymbol( node ), base.VisitAccessorDeclaration );
             }
 
             public override void VisitLocalFunctionStatement( LocalFunctionStatementSyntax node )
@@ -128,28 +129,66 @@ internal sealed partial class LinkerAnalysisStep
 #else
                 var localFunctionSymbol = (IMethodSymbol?) this._semanticModel.GetDeclaredSymbol( node );
 #endif
-                this.VisitWithContainingMethod( node, localFunctionSymbol, base.VisitLocalFunctionStatement );
+                this.VisitWithContainingSymbol( node, localFunctionSymbol, base.VisitLocalFunctionStatement );
             }
 
-            // The caller must resolve the method symbol itself — it cannot be derived here from the node.
+            public override void VisitEqualsValueClause( EqualsValueClauseSyntax node )
+            {
+                // Attribute object-creation expressions in field/property/event initializers to the
+                // declaring member, so the rewrite pipeline wraps them with WithInitialize(...).
+                // Only applies when we're not already inside a method body (in which case local
+                // variable initializers correctly inherit the enclosing method symbol).
+                if ( this._containingSymbol == null && this.GetInitializerMemberSymbol( node ) is { } memberSymbol )
+                {
+                    this.VisitWithContainingSymbol( node, memberSymbol, base.VisitEqualsValueClause );
+                }
+                else
+                {
+                    base.VisitEqualsValueClause( node );
+                }
+            }
+
+            private ISymbol? GetInitializerMemberSymbol( EqualsValueClauseSyntax node )
+            {
+                switch ( node.Parent?.Kind() )
+                {
+                    case SyntaxKind.VariableDeclarator when node.Parent is VariableDeclaratorSyntax declarator:
+                        var grandparentKind = declarator.Parent?.Parent?.Kind();
+
+                        if ( grandparentKind is SyntaxKind.FieldDeclaration or SyntaxKind.EventFieldDeclaration )
+                        {
+                            return this._semanticModel.GetDeclaredSymbol( declarator );
+                        }
+
+                        return null;
+
+                    case SyntaxKind.PropertyDeclaration when node.Parent is PropertyDeclarationSyntax propertyDeclaration:
+                        return this._semanticModel.GetDeclaredSymbol( propertyDeclaration );
+
+                    default:
+                        return null;
+                }
+            }
+
+            // The caller must resolve the declared symbol itself — it cannot be derived here from the node.
             // Calling SemanticModel.GetDeclaredSymbol( node ) with a generic T : SyntaxNode binds to the base
             // SyntaxNode overload that always returns null; only the typed CSharpExtensions overloads
-            // (e.g. GetDeclaredSymbol( MethodDeclarationSyntax )) return an IMethodSymbol. Each VisitXxx
+            // (e.g. GetDeclaredSymbol( MethodDeclarationSyntax )) return a useful symbol. Each VisitXxx
             // override therefore resolves the symbol at its own concrete type before delegating here.
-            private void VisitWithContainingMethod<T>( T node, IMethodSymbol? methodSymbol, System.Action<T> baseVisit )
+            private void VisitWithContainingSymbol<T>( T node, ISymbol? symbol, System.Action<T> baseVisit )
                 where T : SyntaxNode
             {
-                if ( methodSymbol == null )
+                if ( symbol == null )
                 {
                     return;
                 }
 
-                var previousContaining = this._containingMethod;
-                this._containingMethod = methodSymbol;
+                var previousContaining = this._containingSymbol;
+                this._containingSymbol = symbol;
 
                 baseVisit( node );
 
-                this._containingMethod = previousContaining;
+                this._containingSymbol = previousContaining;
             }
 
             public override void VisitObjectCreationExpression( ObjectCreationExpressionSyntax node )
@@ -168,7 +207,7 @@ internal sealed partial class LinkerAnalysisStep
             {
                 base.VisitWithExpression( node );
 
-                if ( this._containingMethod == null )
+                if ( this._containingSymbol == null )
                 {
                     return;
                 }
@@ -180,7 +219,7 @@ internal sealed partial class LinkerAnalysisStep
                 {
                     this._results.Enqueue(
                         new ObjectCreationCallSiteReference(
-                            this._containingMethod.ToSemantic( IntermediateSymbolSemanticKind.Default ),
+                            this._containingSymbol,
                             node,
                             isWithExpression: true,
                             onInitInfo,
@@ -191,7 +230,7 @@ internal sealed partial class LinkerAnalysisStep
 
             private void ProcessObjectCreation( ExpressionSyntax node, ArgumentListSyntax? argumentList )
             {
-                if ( this._containingMethod == null )
+                if ( this._containingSymbol == null )
                 {
                     return;
                 }
@@ -220,7 +259,7 @@ internal sealed partial class LinkerAnalysisStep
 
                 this._results.Enqueue(
                     new ObjectCreationCallSiteReference(
-                        this._containingMethod.ToSemantic( IntermediateSymbolSemanticKind.Default ),
+                        this._containingSymbol,
                         node,
                         isWithExpression: false,
                         onInitInfo,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
@@ -59,6 +59,10 @@ internal sealed partial class LinkerAnalysisStep
             IntermediateSymbolSemantic<IMethodSymbol>,
             IReadOnlyList<ObjectCreationCallSiteReference>> _onInitializedCallSitesByContainingSemantic;
 
+        private readonly IReadOnlyDictionary<
+            ISymbol,
+            IReadOnlyList<ObjectCreationCallSiteReference>> _onInitializedCallSitesByInitializerMember;
+
         private readonly IReadOnlyDictionary<IntermediateSymbolSemantic<IEventSymbol>, EventBrokerTransformationInfo?> _eventBrokerSemanticIndex;
 
         private readonly IConcurrentTaskRunner _concurrentTaskRunner;
@@ -93,10 +97,32 @@ internal sealed partial class LinkerAnalysisStep
             this._forcefullyInitializedTypes = forcefullyInitializedTypes;
             this._eventBrokerSemanticIndex = eventBrokerSemanticIndex;
 
+            // Partition OnInitialized call sites into two buckets based on the kind of their
+            // containing symbol: method-body call sites drive the inlining pipeline (same path as
+            // today), while field/property/event-field initializer call sites are applied directly
+            // by LinkerRewritingDriver when rewriting the declaration.
+            var onInitializedMethodBodyCallSites = new List<ObjectCreationCallSiteReference>();
+            var onInitializedInitializerCallSites = new List<ObjectCreationCallSiteReference>();
+
+            foreach ( var reference in onInitializedCallSites )
+            {
+                if ( reference.ContainingSymbol is IMethodSymbol )
+                {
+                    onInitializedMethodBodyCallSites.Add( reference );
+                }
+                else
+                {
+                    onInitializedInitializerCallSites.Add( reference );
+                }
+            }
+
             this._additionalTransformedSemantics =
                 redirectedSymbolReferences.SelectAsReadOnlyList( x => (IntermediateSymbolSemantic) x.ContainingSemantic )
                     .Union( eventFieldRaiseReferences.SelectAsReadOnlyList( x => (IntermediateSymbolSemantic) x.ContainingSemantic ) )
-                    .Union( onInitializedCallSites.SelectAsReadOnlyList( x => (IntermediateSymbolSemantic) x.ContainingSemantic ) )
+                    .Union(
+                        onInitializedMethodBodyCallSites.SelectAsReadOnlyList(
+                            x => (IntermediateSymbolSemantic) ((IMethodSymbol) x.ContainingSymbol).ToSemantic(
+                                IntermediateSymbolSemanticKind.Default ) ) )
                     .Except( inlinedSemantics )
                     .Distinct()
                     .ToReadOnlyList();
@@ -123,8 +149,12 @@ internal sealed partial class LinkerAnalysisStep
 
             this._onInitializedCallSitesByContainingSemantic = IndexReferenceByContainingBody(
                 intermediateCompilationContext,
-                onInitializedCallSites,
-                x => x.ContainingSemantic );
+                onInitializedMethodBodyCallSites,
+                x => ((IMethodSymbol) x.ContainingSymbol).ToSemantic( IntermediateSymbolSemanticKind.Default ) );
+
+            this._onInitializedCallSitesByInitializerMember = IndexInitializerReferencesByMember(
+                intermediateCompilationContext,
+                onInitializedInitializerCallSites );
 
             static IReadOnlyDictionary<IntermediateSymbolSemantic<IMethodSymbol>, IReadOnlyList<T>> IndexReferenceByContainingBody<T>(
                 CompilationContext compilationContext,
@@ -149,9 +179,31 @@ internal sealed partial class LinkerAnalysisStep
 
                 return dict.ToDictionary( x => x.Key, x => (IReadOnlyList<T>) x.Value );
             }
+
+            static IReadOnlyDictionary<ISymbol, IReadOnlyList<ObjectCreationCallSiteReference>> IndexInitializerReferencesByMember(
+                CompilationContext compilationContext,
+                IReadOnlyList<ObjectCreationCallSiteReference> references )
+            {
+                var dict = new Dictionary<ISymbol, List<ObjectCreationCallSiteReference>>( compilationContext.SymbolComparer );
+
+                foreach ( var reference in references )
+                {
+                    if ( !dict.TryGetValue( reference.ContainingSymbol, out var list ) )
+                    {
+                        dict[reference.ContainingSymbol] = list = new List<ObjectCreationCallSiteReference>();
+                    }
+
+                    list.Add( reference );
+                }
+
+                return dict.ToDictionary(
+                    x => x.Key,
+                    x => (IReadOnlyList<ObjectCreationCallSiteReference>) x.Value,
+                    compilationContext.SymbolComparer );
+            }
         }
 
-        public async Task<IReadOnlyDictionary<InliningContextIdentifier, IReadOnlyList<SyntaxNodeSubstitution>>> RunAsync( CancellationToken cancellationToken )
+        public async Task<SubstitutionGeneratorOutput> RunAsync( CancellationToken cancellationToken )
         {
             var substitutions = new ConcurrentDictionary<InliningContextIdentifier, ConcurrentDictionary<SyntaxNode, SyntaxNodeSubstitution>>();
 
@@ -279,18 +331,7 @@ internal sealed partial class LinkerAnalysisStep
                 {
                     foreach ( var reference in onInitializedCallSites )
                     {
-                        OnInitializedCallSiteSubstitution substitution = reference.IsWithExpression
-                            ? new OnInitializedWithExpressionSubstitution(
-                                this._intermediateCompilationContext,
-                                reference.ReferencingNode,
-                                reference.TypeInfo )
-                            : new OnInitializedObjectCreationSubstitution(
-                                this._intermediateCompilationContext,
-                                reference.ReferencingNode,
-                                reference.TypeInfo,
-                                reference.ContextParamName );
-
-                        AddSubstitution( context, substitution );
+                        AddSubstitution( context, this.CreateInitializerSubstitution( reference ) );
                     }
                 }
             }
@@ -519,8 +560,20 @@ internal sealed partial class LinkerAnalysisStep
 
             await this._concurrentTaskRunner.RunConcurrentlyAsync( this._forcefullyInitializedTypes, ProcessForcefullyInitializedType, cancellationToken );
 
+            // Materialize initializer substitutions: one OnInitializedCallSiteSubstitution per
+            // ObjectCreationCallSiteReference bucketed under a field / event-field / property symbol.
+            // These bypass the inlining pipeline and are applied directly by LinkerRewritingDriver
+            // when it rewrites the declaration.
+            var initializerSubstitutions = this._onInitializedCallSitesByInitializerMember.ToDictionary(
+                entry => entry.Key,
+                entry => (IReadOnlyList<SyntaxNodeSubstitution>) entry.Value
+                    .SelectAsArray<ObjectCreationCallSiteReference, SyntaxNodeSubstitution>( this.CreateInitializerSubstitution ),
+                this._intermediateCompilationContext.SymbolComparer );
+
             // TODO: We convert this later back to the dictionary, but for debugging it's better to have dictionary also here.
-            return substitutions.ToDictionary( x => x.Key, x => x.Value.Values.ToReadOnlyList() );
+            var contextSubstitutions = substitutions.ToDictionary( x => x.Key, x => x.Value.Values.ToReadOnlyList() );
+
+            return new SubstitutionGeneratorOutput( contextSubstitutions, initializerSubstitutions );
 
             void AddSubstitutionsForNonInlinedReference( ResolvedAspectReference nonInlinedReference, InliningContextIdentifier context )
             {
@@ -848,5 +901,32 @@ internal sealed partial class LinkerAnalysisStep
 
                 _ => throw new AssertionFailedException( $"Unexpected syntax: '{root}'." )
             };
+
+        /// <summary>
+        /// Materializes the <see cref="OnInitializedCallSiteSubstitution"/> instance for a single
+        /// <see cref="ObjectCreationCallSiteReference"/>, selecting the right derived class depending
+        /// on whether the reference is an object creation or a <c>with</c> expression.
+        /// </summary>
+        private OnInitializedCallSiteSubstitution CreateInitializerSubstitution( ObjectCreationCallSiteReference reference )
+            => reference.IsWithExpression
+                ? new OnInitializedWithExpressionSubstitution(
+                    this._intermediateCompilationContext,
+                    reference.ReferencingNode,
+                    reference.TypeInfo )
+                : new OnInitializedObjectCreationSubstitution(
+                    this._intermediateCompilationContext,
+                    reference.ReferencingNode,
+                    reference.TypeInfo,
+                    reference.ContextParamName );
     }
+
+    /// <summary>
+    /// Output of <see cref="SubstitutionGenerator.RunAsync"/>: method-body substitutions keyed by
+    /// inlining context (applied via <c>SubstitutingRewriter</c>), plus initializer substitutions
+    /// keyed by the containing field / event-field / property symbol (applied directly by the
+    /// linker rewriting driver when it rewrites the declaration's initializer).
+    /// </summary>
+    private sealed record SubstitutionGeneratorOutput(
+        IReadOnlyDictionary<InliningContextIdentifier, IReadOnlyList<SyntaxNodeSubstitution>> ContextSubstitutions,
+        IReadOnlyDictionary<ISymbol, IReadOnlyList<SyntaxNodeSubstitution>> InitializerSubstitutions );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.SubstitutionGenerator.cs
@@ -98,9 +98,9 @@ internal sealed partial class LinkerAnalysisStep
             this._eventBrokerSemanticIndex = eventBrokerSemanticIndex;
 
             // Partition OnInitialized call sites into two buckets based on the kind of their
-            // containing symbol: method-body call sites drive the inlining pipeline (same path as
-            // today), while field/property/event-field initializer call sites are applied directly
-            // by LinkerRewritingDriver when rewriting the declaration.
+            // containing symbol: method-body call sites drive the inlining pipeline, while
+            // field/property/event-field initializer call sites are applied directly by
+            // LinkerRewritingDriver when rewriting the declaration.
             var onInitializedMethodBodyCallSites = new List<ObjectCreationCallSiteReference>();
             var onInitializedInitializerCallSites = new List<ObjectCreationCallSiteReference>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerAnalysisStep.cs
@@ -314,13 +314,14 @@ namespace Metalama.Framework.Engine.Linking
                 onInitializedCallSites,
                 eventBrokerSemanticIndex );
 
-            var substitutions = await substitutionGenerator.RunAsync( cancellationToken );
+            var substitutionGeneratorOutput = await substitutionGenerator.RunAsync( cancellationToken );
 
             var analysisRegistry = new LinkerAnalysisRegistry(
                 input.IntermediateCompilation.CompilationContext,
                 reachableSemantics,
                 inlinedSemantics,
-                substitutions,
+                substitutionGeneratorOutput.ContextSubstitutions,
+                substitutionGeneratorOutput.InitializerSubstitutions,
                 overrideTargetsWithUnsupportedNonInlinedOverrides,
                 typeEventBrokers,
                 staticDelegates,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerLinkingStep.LinkingRewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerLinkingStep.LinkingRewriter.cs
@@ -158,6 +158,23 @@ internal sealed partial class LinkerLinkingStep
                         newMembers.Add( (MemberDeclarationSyntax) this.Visit( member )! );
                     }
                 }
+                else if ( member is FieldDeclarationSyntax )
+                {
+                    // Multi-variable field declaration. RewriteField processes the entire
+                    // declaration (and all its variables) in a single call, so dispatch once
+                    // for any rewrite-target symbol and skip the per-symbol loop to avoid
+                    // emitting the same FieldDeclaration multiple times.
+                    var rewriteTargetSymbol = symbols.FirstOrDefault( s => this._rewritingDriver.IsRewriteTarget( s.AssertNotNull() ) );
+
+                    if ( rewriteTargetSymbol != null )
+                    {
+                        newMembers.AddRange( this._rewritingDriver.RewriteMember( member, rewriteTargetSymbol, GetSyntaxGenerationContext() ) );
+                    }
+                    else
+                    {
+                        newMembers.Add( (MemberDeclarationSyntax) this.Visit( member )! );
+                    }
+                }
                 else
                 {
                     var remainingSymbols = new HashSet<ISymbol>( this._compilationContext.SymbolComparer );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.EventFields.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.EventFields.cs
@@ -46,7 +46,20 @@ namespace Metalama.Framework.Engine.Linking
 
                 if ( this.AnalysisRegistry.IsReachable( symbol.ToSemantic( IntermediateSymbolSemanticKind.Default ) ) )
                 {
-                    members.Add( this.GetEventBackingField( eventFieldDeclaration, symbol, context ) );
+                    var declarator = (VariableDeclaratorSyntax) symbol.GetPrimaryDeclarationSyntax().AssertNotNull();
+
+                    // Apply IInitializable call-site substitutions to the initializer that will be
+                    // copied onto the generated backing field.
+                    var rewrittenInitializer = declarator.Initializer != null
+                        ? this.RewriteInitializer( symbol, declarator.Initializer, context )
+                        : null;
+
+                    members.Add(
+                        this.GetEventBackingField(
+                            eventFieldDeclaration.Declaration.Type,
+                            rewrittenInitializer,
+                            symbol,
+                            context ) );
                 }
 
                 if ( this.InjectionRegistry.HasEventRaiseOverride( symbol ) )
@@ -103,6 +116,23 @@ namespace Metalama.Framework.Engine.Linking
                         eventFieldDeclaration.WithDeclaration(
                             eventFieldDeclaration.Declaration.WithVariables(
                                 SeparatedList( eventFieldDeclaration.Declaration.Variables.SelectAsArray( v => v.WithInitializer( default ) ) ) ) );
+                }
+                else if ( this.AnalysisRegistry.HasInitializerSubstitutions( symbol ) )
+                {
+                    // Non-override event-field with an IInitializable call-site substitution in its
+                    // initializer. Produce a declaration containing only the variable for the given
+                    // symbol (with its initializer rewritten), so the enclosing linking rewriter
+                    // naturally aggregates per-variable output for multi-variable declarations.
+                    var declarator = (VariableDeclaratorSyntax) symbol.GetPrimaryDeclarationSyntax().AssertNotNull();
+
+                    var rewrittenInitializer = declarator.Initializer != null
+                        ? this.RewriteInitializer( symbol, declarator.Initializer, context )
+                        : null;
+
+                    eventFieldDeclaration =
+                        eventFieldDeclaration.WithDeclaration(
+                            eventFieldDeclaration.Declaration.WithVariables(
+                                SingletonSeparatedList( declarator.WithInitializer( rewrittenInitializer ) ) ) );
                 }
 
                 members.Add( eventFieldDeclaration );
@@ -180,21 +210,6 @@ namespace Metalama.Framework.Engine.Linking
                         null,
                         default );
             }
-        }
-
-        private EventFieldDeclarationSyntax GetEventBackingField(
-            EventFieldDeclarationSyntax eventFieldDeclaration,
-            IEventSymbol symbol,
-            SyntaxGenerationContext context )
-        {
-            var declarator = (VariableDeclaratorSyntax) symbol.GetPrimaryDeclarationSyntax().AssertNotNull();
-
-            return
-                this.GetEventBackingField(
-                    eventFieldDeclaration.Declaration.Type,
-                    declarator.Initializer,
-                    symbol,
-                    context );
         }
 
         private MemberDeclarationSyntax GetEmptyImplEventField( TypeSyntax eventType, IEventSymbol symbol, SyntaxGenerationContext context )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Fields.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Fields.cs
@@ -45,10 +45,60 @@ namespace Metalama.Framework.Engine.Linking
                         fieldDeclaration.Declaration.WithVariables(
                             SeparatedList( fieldDeclaration.Declaration.Variables.SelectAsArray( v => v.WithInitializer( default ) ) ) ) );
             }
+            else
+            {
+                // Apply IInitializable call-site substitutions (WithInitialize(...)) to any
+                // variable whose initializer contains object-creation / with expressions targeting
+                // an IInitializable type. Each variable in a multi-variable declaration resolves to
+                // its own field symbol and may have independent substitutions.
+                fieldDeclaration = this.RewriteFieldInitializers( fieldDeclaration, context );
+            }
 
             members.Add( fieldDeclaration );
 
             return members;
+        }
+
+        private FieldDeclarationSyntax RewriteFieldInitializers( FieldDeclarationSyntax fieldDeclaration, SyntaxGenerationContext context )
+        {
+            VariableDeclaratorSyntax[]? newVariables = null;
+
+            for ( var i = 0; i < fieldDeclaration.Declaration.Variables.Count; i++ )
+            {
+                var variable = fieldDeclaration.Declaration.Variables[i];
+
+                if ( variable.Initializer == null )
+                {
+                    continue;
+                }
+
+                var fieldSymbol = (IFieldSymbol?) this.IntermediateCompilationContext.SemanticModelProvider
+                    .GetSemanticModel( variable.SyntaxTree )
+                    .GetDeclaredSymbol( variable );
+
+                if ( fieldSymbol == null )
+                {
+                    continue;
+                }
+
+                var rewrittenInitializer = this.RewriteInitializer( fieldSymbol, variable.Initializer, context );
+
+                if ( ReferenceEquals( rewrittenInitializer, variable.Initializer ) )
+                {
+                    continue;
+                }
+
+                newVariables ??= fieldDeclaration.Declaration.Variables.ToArray();
+                newVariables[i] = variable.WithInitializer( rewrittenInitializer );
+            }
+
+            if ( newVariables == null )
+            {
+                return fieldDeclaration;
+            }
+
+            return fieldDeclaration.WithDeclaration(
+                fieldDeclaration.Declaration.WithVariables( SeparatedList( newVariables ) ) );
         }
 
         private static MemberDeclarationSyntax GetEmptyImplField(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Initializers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Initializers.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Linking.Substitution;
+using Metalama.Framework.Engine.SyntaxGeneration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+
+namespace Metalama.Framework.Engine.Linking
+{
+    internal sealed partial class LinkerRewritingDriver
+    {
+        /// <summary>
+        /// Applies <see cref="OnInitializedCallSiteSubstitution"/> instances registered for a field,
+        /// event-field or property symbol to the initializer of its declaration. Returns the
+        /// initializer unchanged when no substitutions are registered.
+        /// </summary>
+        /// <remarks>
+        /// Uses <c>SyntaxNode.ReplaceNodes</c>, which applies its callback bottom-up, so nested
+        /// object-creation expressions are wrapped correctly (e.g.
+        /// <c>new X { Y = new Y { Z = new Z() } }</c> becomes
+        /// <c>WithInitialize(new X { Y = WithInitialize(new Y { Z = WithInitialize(new Z()) }) })</c>).
+        /// </remarks>
+        private EqualsValueClauseSyntax RewriteInitializer(
+            ISymbol memberSymbol,
+            EqualsValueClauseSyntax initializer,
+            SyntaxGenerationContext syntaxGenerationContext )
+        {
+            if ( !this.AnalysisRegistry.TryGetInitializerSubstitutions( memberSymbol, out var substitutions ) )
+            {
+                return initializer;
+            }
+
+            var byOriginalNode = substitutions.ToDictionary( s => s.ReplacedNode );
+            var substitutionContext = new SubstitutionContext( this, syntaxGenerationContext );
+
+            var rewritten = initializer.ReplaceNodes(
+                initializer.DescendantNodes().Where( byOriginalNode.ContainsKey ),
+                ( original, rewrittenWithChildren ) =>
+                    byOriginalNode[original].Substitute( rewrittenWithChildren, substitutionContext )! );
+
+            return rewritten;
+        }
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -60,10 +60,18 @@ namespace Metalama.Framework.Engine.Linking
                 if ( (propertyDeclaration.IsAutoPropertyDeclaration() || symbol.GetBackingField() != null)
                      && this.AnalysisRegistry.IsReachable( symbol.ToSemantic( IntermediateSymbolSemanticKind.Default ) ) )
                 {
+                    // Apply IInitializable call-site substitutions to the initializer that will
+                    // be moved to the backing field. The walker attributes call sites to the
+                    // property symbol (the lexical container in source), so we look them up by
+                    // the property symbol even though the initializer is about to be re-hosted.
+                    var backingFieldInitializer = propertyDeclaration.Initializer != null
+                        ? this.RewriteInitializer( symbol, propertyDeclaration.Initializer, generationContext )
+                        : null;
+
                     // Backing field for auto property.
                     var backingField = this.GetPropertyBackingField(
                         propertyDeclaration.Type,
-                        propertyDeclaration.Initializer,
+                        backingFieldInitializer,
                         FilterAttributeListsForTarget( propertyDeclaration.AttributeLists, SyntaxKind.FieldKeyword, false, false ),
                         symbol,
                         generationContext );
@@ -174,6 +182,20 @@ namespace Metalama.Framework.Engine.Linking
                     propertyDeclaration = propertyDeclaration.PartialUpdate(
                         initializer: default(EqualsValueClauseSyntax),
                         semicolonToken: default(SyntaxToken) );
+                }
+                else if ( propertyDeclaration.Initializer != null )
+                {
+                    // Apply IInitializable call-site substitutions (WithInitialize(...)) to a
+                    // property initializer containing object-creation / with expressions that
+                    // target an IInitializable type. This is the non-override path where the
+                    // property declaration is returned unchanged.
+                    var rewrittenInitializer =
+                        this.RewriteInitializer( symbol, propertyDeclaration.Initializer, generationContext );
+
+                    if ( !ReferenceEquals( rewrittenInitializer, propertyDeclaration.Initializer ) )
+                    {
+                        propertyDeclaration = propertyDeclaration.WithInitializer( rewrittenInitializer );
+                    }
                 }
 
                 return [propertyDeclaration];

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
@@ -422,6 +422,13 @@ internal sealed partial class LinkerRewritingDriver
             return true;
         }
 
+        if ( this.AnalysisRegistry.HasInitializerSubstitutions( symbol ) )
+        {
+            // Fields / event-fields / properties whose initializer contains IInitializable
+            // call sites that must be wrapped with WithInitialize(...).
+            return true;
+        }
+
         if ( this.InjectionRegistry.IsIntroduced( symbol ) )
         {
             // Introduced declarations need to be rewritten.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/OnInitializedCallSiteSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/OnInitializedCallSiteSubstitution.cs
@@ -36,9 +36,12 @@ internal abstract class OnInitializedCallSiteSubstitution : SyntaxNodeSubstituti
 
     /// <summary>
     /// Wraps an expression with <c>InitializableExtensions.WithInitialize(expr)</c> or
-    /// <c>InitializableExtensions.WithInitialize(expr, metadata)</c>.
+    /// <c>InitializableExtensions.WithInitialize(expr, metadata)</c>. When the wrapped
+    /// expression is a target-typed <c>new()</c> (an <see cref="ImplicitObjectCreationExpressionSyntax"/>),
+    /// an explicit generic type argument is emitted because the compiler cannot otherwise
+    /// infer <c>T</c> for <c>WithInitialize&lt;T&gt;(T)</c>.
     /// </summary>
-    protected static ExpressionSyntax WrapWithInitializeCall(
+    protected ExpressionSyntax WrapWithInitializeCall(
         SubstitutionContext substitutionContext,
         ExpressionSyntax expression,
         ExpressionSyntax? metadataArgument = null )
@@ -46,10 +49,25 @@ internal abstract class OnInitializedCallSiteSubstitution : SyntaxNodeSubstituti
         var initializableExtensionsType =
             substitutionContext.SyntaxGenerationContext.SyntaxGenerator.TypeSyntax( typeof(InitializableExtensions) );
 
+        SimpleNameSyntax methodName;
+
+        if ( expression.Kind() == SyntaxKind.ImplicitObjectCreationExpression )
+        {
+            var typeArgument = substitutionContext.SyntaxGenerationContext.SyntaxGenerator.TypeSyntax( this.TypeInfo.Type );
+
+            methodName = GenericName(
+                SyntaxFactoryEx.SafeIdentifier( nameof(InitializableExtensions.WithInitialize) ),
+                TypeArgumentList( SingletonSeparatedList( typeArgument ) ) );
+        }
+        else
+        {
+            methodName = SyntaxFactoryEx.SafeIdentifierName( nameof(InitializableExtensions.WithInitialize) );
+        }
+
         var initializedAccess = MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             initializableExtensionsType,
-            SyntaxFactoryEx.SafeIdentifierName( nameof(InitializableExtensions.WithInitialize) ) );
+            methodName );
 
         ArgumentListSyntax argList;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/OnInitializedObjectCreationSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/OnInitializedObjectCreationSubstitution.cs
@@ -43,7 +43,7 @@ internal sealed class OnInitializedObjectCreationSubstitution : OnInitializedCal
         }
 
         // Wrap with InitializableExtensions.WithInitialize(expr)
-        return WrapWithInitializeCall( substitutionContext, expression );
+        return this.WrapWithInitializeCall( substitutionContext, expression );
     }
 
     private ExpressionSyntax AppendWillInitializeArgument( ExpressionSyntax expression, SubstitutionContext substitutionContext )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/OnInitializedWithExpressionSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/OnInitializedWithExpressionSubstitution.cs
@@ -33,7 +33,7 @@ internal sealed class OnInitializedWithExpressionSubstitution : OnInitializedCal
         var parenthesized = ParenthesizedExpression( (ExpressionSyntax) currentNode );
 
         // Wrap with InitializableExtensions.WithInitialize(expr, InitializationMetadata.Modify)
-        return WrapWithInitializeCall( substitutionContext, parenthesized, CreateModifyMetadataExpression( substitutionContext ) );
+        return this.WrapWithInitializeCall( substitutionContext, parenthesized, CreateModifyMetadataExpression( substitutionContext ) );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/SubstitutionContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/SubstitutionContext.cs
@@ -29,6 +29,20 @@ namespace Metalama.Framework.Engine.Linking.Substitution
                 new Lazy<IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>?>( () => this.RewritingDriver.GetSubstitutions( inliningContextId ) );
         }
 
+        /// <summary>
+        /// Creates a substitution context that is not bound to an inlining context. Used by the
+        /// initializer-rewrite path, which applies <see cref="OnInitializedCallSiteSubstitution"/>
+        /// instances explicitly and never calls <see cref="GetSubstitutions"/>.
+        /// </summary>
+        public SubstitutionContext(
+            LinkerRewritingDriver rewritingDriver,
+            SyntaxGenerationContext syntaxGenerationContext )
+        {
+            this.RewritingDriver = rewritingDriver;
+            this.SyntaxGenerationContext = syntaxGenerationContext;
+            this._substitutionDictionary = new Lazy<IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>?>( () => null );
+        }
+
         internal SubstitutionContext WithInliningContext( InliningContextIdentifier inliningContextId )
         {
             return new SubstitutionContext( this.RewritingDriver, this.SyntaxGenerationContext, inliningContextId );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/SubstitutionContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/SubstitutionContext.cs
@@ -11,7 +11,7 @@ namespace Metalama.Framework.Engine.Linking.Substitution
 {
     internal sealed class SubstitutionContext
     {
-        private readonly Lazy<IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>?> _substitutionDictionary;
+        private readonly Lazy<IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>?>? _substitutionDictionary;
 
         public LinkerRewritingDriver RewritingDriver { get; }
 
@@ -40,7 +40,6 @@ namespace Metalama.Framework.Engine.Linking.Substitution
         {
             this.RewritingDriver = rewritingDriver;
             this.SyntaxGenerationContext = syntaxGenerationContext;
-            this._substitutionDictionary = new Lazy<IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>?>( () => null );
         }
 
         internal SubstitutionContext WithInliningContext( InliningContextIdentifier inliningContextId )
@@ -50,7 +49,7 @@ namespace Metalama.Framework.Engine.Linking.Substitution
 
         public IReadOnlyDictionary<SyntaxNode, SyntaxNodeSubstitution>? GetSubstitutions()
         {
-            return this._substitutionDictionary.Value;
+            return this._substitutionDictionary?.Value;
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_EventFieldInitializer.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_EventFieldInitializer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_EventFieldInitializer;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class TargetCode
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    private event Func<TargetCode> _factory = () => new TargetCode();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_EventFieldInitializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_EventFieldInitializer.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  private event Func<TargetCode> _factory = () => global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetCode());
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class TargetCode
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    private TargetCode _t = new TargetCode();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  private TargetCode _t = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetCode());
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_ImplicitNew.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_ImplicitNew.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_ImplicitNew;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class TargetCode
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    private TargetCode _t = new();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_ImplicitNew.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_ImplicitNew.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  private TargetCode _t = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize<global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_ImplicitNew.TargetCode>(new());
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Lambda.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Lambda.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_Lambda;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class TargetCode
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    private Func<TargetCode> _factory = () => new TargetCode();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Lambda.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Lambda.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  private Func<TargetCode> _factory = () => global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetCode());
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_MultipleVariables.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_MultipleVariables.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_MultipleVariables;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class TargetCode
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    private TargetCode _a = new(), _b = new();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_MultipleVariables.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_MultipleVariables.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  private TargetCode _a = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize<global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_MultipleVariables.TargetCode>(new()), _b = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize<global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_MultipleVariables.TargetCode>(new());
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Nested.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Nested.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_FieldInitializer_Nested;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class X
+{
+    public Y? Y { get; set; }
+}
+
+[TheAspect]
+public class Y
+{
+    public Z? Z { get; set; }
+}
+
+[TheAspect]
+public class Z
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    private X _x = new X { Y = new Y { Z = new Z() } };
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Nested.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_FieldInitializer_Nested.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  private X _x = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new X { Y = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new Y { Z = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new Z()) }) });
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_MethodBody_NestedInitializer.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_MethodBody_NestedInitializer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_MethodBody_NestedInitializer;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class X
+{
+    public Y? Y { get; set; }
+}
+
+[TheAspect]
+public class Y
+{
+    public Z? Z { get; set; }
+}
+
+[TheAspect]
+public class Z
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    public void Method()
+    {
+        var x = new X { Y = new Y { Z = new Z() } };
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_MethodBody_NestedInitializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_MethodBody_NestedInitializer.t.cs
@@ -1,0 +1,7 @@
+public class Caller
+{
+  public void Method()
+  {
+    var x = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new X { Y = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new Y { Z = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new Z()) }) });
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_PropertyInitializer;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public class TargetCode
+{
+    public int Value { get; set; }
+}
+
+// <target>
+public class Caller
+{
+    public TargetCode Bar { get; } = new TargetCode();
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer.t.cs
@@ -1,0 +1,4 @@
+public class Caller
+{
+  public TargetCode Bar { get; } = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetCode());
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer_WithExpression.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer_WithExpression.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_PropertyInitializer_WithExpression;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+[TheAspect]
+public record TargetRecord( int Value );
+
+// <target>
+public class Caller
+{
+    private static readonly TargetRecord _template = new TargetRecord( 0 );
+
+    public TargetRecord Bar { get; } = _template with { Value = 42 };
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer_WithExpression.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_PropertyInitializer_WithExpression.t.cs
@@ -1,0 +1,5 @@
+public class Caller
+{
+  private static readonly TargetRecord _template = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetRecord(0));
+  public TargetRecord Bar { get; } = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize((_template with { Value = 42 }), global::Metalama.Framework.RunTime.Initialization.InitializationMetadata.Modify);
+}


### PR DESCRIPTION
## Summary

Fixes #1545 — OnInitializedCallSiteFinder previously skipped object-creation expressions inside field and property initializers, so `new T()` / `with T { ... }` in those positions was never wrapped with `InitializableExtensions.WithInitialize(...)`. This PR threads the call-site walker, substitution generator, analysis registry, and `LinkerRewritingDriver` to apply `WithInitialize` to field, event-field, and property initializers.

### Changes
- **Walker** (`LinkerAnalysisStep.OnInitializedCallSiteFinder`): collapsed `_containingMethod` to a single `_containingSymbol` slot and added a `VisitEqualsValueClause` override that attributes object creations inside field / event-field / property initializers to the declaring member.
- **Reference** (`LinkerAnalysisStep.ObjectCreationCallSiteReference`): replaced `ContainingSemantic` with a raw `ContainingSymbol`.
- **SubstitutionGenerator**: partitioned references into the existing method-body bucket and a new initializer-member bucket; `RunAsync` now returns a `SubstitutionGeneratorOutput` record.
- **AnalysisRegistry**: exposes `TryGetInitializerSubstitutions` / `HasInitializerSubstitutions`.
- **LinkerRewritingDriver**: `IsRewriteTarget` now considers initializer substitutions; new `LinkerRewritingDriver.Initializers.cs` adds a `RewriteInitializer` helper that uses bottom-up `ReplaceNodes` (correctly handles nested `new X { Y = new Y { Z = new Z() } }`); `RewriteField` and `RewriteProperty` invoke it.
- **OnInitializedCallSiteSubstitution**: when wrapping target-typed `new()` (`ImplicitObjectCreationExpressionSyntax`), emits an explicit generic type argument so the C# compiler can resolve `T` for `WithInitialize<T>(T)`.
- **LinkingRewriter**: special-cases multi-variable `FieldDeclarationSyntax` to call `RewriteMember` only once, since `RewriteField` processes the entire declaration internally.

### Out of scope
Top-level statement initializers (synthetic `<Main>` method) are not handled — filed as a follow-up.

## Test plan
- [x] 8 new aspect-test pairs under `Tests/Aspects/Initialization/` covering: simple field/property initializer, implicit `new()`, multi-variable field, lambda inside field initializer, `with` expression in property initializer, nested `new X { Y = new Y { Z = new Z() } }` in field initializer, and the equivalent nested case inside a method body (regression guard for the existing path).
- [x] All 89 `Initialization` tests pass (was 81 before).
- [x] All 2167 AspectTests pass (no regressions).
- [x] All 1811 UnitTests pass.
- [x] Zero build warnings.

— Claude for @gfraiteur