### PR TITLE
Add regression tests for InitializationContract record support (#1526)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_RecordStruct_With.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_RecordStruct_With.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_RecordStruct_With;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public record struct TargetRecordStruct( int Value );
+
+// <target>
+public class Caller
+{
+    public void Method()
+    {
+        var r1 = new TargetRecordStruct( 1 );
+        var r2 = r1 with { Value = 2 };
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_RecordStruct_With.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_RecordStruct_With.t.cs
@@ -1,0 +1,16 @@
+[TheAspect]
+public record struct TargetRecordStruct(int Value) : global::Metalama.Framework.RunTime.Initialization.IInitializable
+{
+  public void Initialize(global::Metalama.Framework.RunTime.Initialization.InitializationContext context = default)
+  {
+    global::System.Console.WriteLine("Initialized!");
+  }
+}
+public class Caller
+{
+  public void Method()
+  {
+    var r1 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetRecordStruct(1));
+    var r2 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize((r1 with { Value = 2 }), global::Metalama.Framework.RunTime.Initialization.InitializationMetadata.Modify);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_ChainedWith.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_ChainedWith.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_Record_ChainedWith;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public record TargetRecord( int A, int B );
+
+// <target>
+public class Caller
+{
+    public void Method()
+    {
+        var r1 = new TargetRecord( 1, 2 );
+        var r2 = r1 with { A = 10 } with { B = 20 };
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_ChainedWith.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_ChainedWith.t.cs
@@ -1,0 +1,16 @@
+[TheAspect]
+public record TargetRecord(int A, int B) : global::Metalama.Framework.RunTime.Initialization.IInitializable
+{
+  public virtual void Initialize(global::Metalama.Framework.RunTime.Initialization.InitializationContext context = default)
+  {
+    global::System.Console.WriteLine("Initialized!");
+  }
+}
+public class Caller
+{
+  public void Method()
+  {
+    var r1 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetRecord(1, 2));
+    var r2 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize((global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize((r1 with { A = 10 }), global::Metalama.Framework.RunTime.Initialization.InitializationMetadata.Modify)with { B = 20 }), global::Metalama.Framework.RunTime.Initialization.InitializationMetadata.Modify);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Inheritance_AspectOnBase.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Inheritance_AspectOnBase.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_Record_Inheritance_AspectOnBase;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public record BaseRecord( int X );
+
+// <target>
+public record DerivedRecord( int X, int Y ) : BaseRecord( X );
+
+// <target>
+public class Caller
+{
+    public void Method()
+    {
+        var d = new DerivedRecord( 1, 2 );
+        var d2 = d with { Y = 5 };
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Inheritance_AspectOnBase.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Inheritance_AspectOnBase.t.cs
@@ -1,0 +1,17 @@
+[TheAspect]
+public record BaseRecord(int X) : global::Metalama.Framework.RunTime.Initialization.IInitializable
+{
+  public virtual void Initialize(global::Metalama.Framework.RunTime.Initialization.InitializationContext context = default)
+  {
+    global::System.Console.WriteLine("Initialized!");
+  }
+}
+public record DerivedRecord(int X, int Y) : BaseRecord(X);
+public class Caller
+{
+  public void Method()
+  {
+    var d = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new DerivedRecord(1, 2));
+    var d2 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize((d with { Y = 5 }), global::Metalama.Framework.RunTime.Initialization.InitializationMetadata.Modify);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_NonPositional.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_NonPositional.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_Record_NonPositional;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public record TargetRecord
+{
+    public int Value { get; init; }
+}
+
+// <target>
+public class Caller
+{
+    public void Method()
+    {
+        var r1 = new TargetRecord { Value = 1 };
+        var r2 = r1 with { Value = 2 };
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_NonPositional.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_NonPositional.t.cs
@@ -1,0 +1,17 @@
+[TheAspect]
+public record TargetRecord : global::Metalama.Framework.RunTime.Initialization.IInitializable
+{
+  public int Value { get; init; }
+  public virtual void Initialize(global::Metalama.Framework.RunTime.Initialization.InitializationContext context = default)
+  {
+    global::System.Console.WriteLine("Initialized!");
+  }
+}
+public class Caller
+{
+  public void Method()
+  {
+    var r1 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize(new TargetRecord { Value = 1 });
+    var r2 = global::Metalama.Framework.RunTime.Initialization.InitializableExtensions.WithInitialize((r1 with { Value = 2 }), global::Metalama.Framework.RunTime.Initialization.InitializationMetadata.Modify);
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Positional_Target.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Positional_Target.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Linker_Record_Positional_Target;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterObjectInitializer );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( "Initialized!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public record TargetRecord( int X )
+{
+    public int Y { get; init; } = X * 2;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Positional_Target.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Linker_Record_Positional_Target.t.cs
@@ -1,0 +1,9 @@
+[TheAspect]
+public record TargetRecord(int X) : global::Metalama.Framework.RunTime.Initialization.IInitializable
+{
+  public int Y { get; init; } = X * 2;
+  public virtual void Initialize(global::Metalama.Framework.RunTime.Initialization.InitializationContext context = default)
+  {
+    global::System.Console.WriteLine("Initialized!");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/PrimaryConstructorTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/PrimaryConstructorTests.cs
@@ -349,6 +349,78 @@ record struct D(int x) {}
     }
 
     [Fact]
+    public void IsRecordCopyConstructor_PositionalRecordClass()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string code =
+#if NETFRAMEWORK
+            @"namespace System.Runtime.CompilerServices { internal static class IsExternalInit {}}" +
+#endif
+            @"
+record class C(int x) {}
+";
+
+        var compilation = testContext.CreateCompilationModel( code );
+
+        var typeRecordClass = compilation.Types.OfName( "C" ).Single();
+
+        // Positional record has 2 constructors: primary (matches primary params) + synthesized copy constructor.
+        Assert.Equal( 2, typeRecordClass.Constructors.Count );
+
+        var primaryCtor = typeRecordClass.PrimaryConstructor.AssertNotNull();
+        var copyCtor = typeRecordClass.Constructors.Single( c => !c.IsPrimary );
+
+        Assert.False( primaryCtor.IsRecordCopyConstructor() );
+        Assert.True( copyCtor.IsRecordCopyConstructor() );
+    }
+
+    [Fact]
+    public void IsRecordCopyConstructor_NonPositionalRecordClass()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string code =
+#if NETFRAMEWORK
+            @"namespace System.Runtime.CompilerServices { internal static class IsExternalInit {}}" +
+#endif
+            @"
+record class C { public int X { get; init; } }
+";
+
+        var compilation = testContext.CreateCompilationModel( code );
+
+        var typeRecordClass = compilation.Types.OfName( "C" ).Single();
+
+        // Non-positional record has 2 constructors: implicit parameterless + synthesized copy constructor.
+        var copyCtor = typeRecordClass.Constructors.SingleOrDefault( c => c.Parameters.Count == 1 );
+        var parameterlessCtor = typeRecordClass.Constructors.SingleOrDefault( c => c.Parameters.Count == 0 );
+
+        Assert.NotNull( copyCtor );
+        Assert.NotNull( parameterlessCtor );
+        Assert.True( copyCtor.IsRecordCopyConstructor() );
+        Assert.False( parameterlessCtor.IsRecordCopyConstructor() );
+    }
+
+    [Fact]
+    public void IsRecordCopyConstructor_NonRecordClass()
+    {
+        using var testContext = this.CreateTestContext();
+
+        const string code = @"
+class A { public A(int x) {} }
+";
+
+        var compilation = testContext.CreateCompilationModel( code );
+
+        var typeClass = compilation.Types.OfName( "A" ).Single();
+
+        // User-authored unary-parameter ctor on a non-record class must not be flagged as a copy ctor.
+        var ctor = typeClass.Constructors.Single();
+        Assert.False( ctor.IsRecordCopyConstructor() );
+    }
+
+    [Fact]
     public void InitializerKind()
     {
         using var testContext = this.CreateTestContext();


### PR DESCRIPTION
## Summary

Regression-guard tests for InitializationContract spec §7 (Record Support). Closes #1526.

- 5 aspect-test pairs under `Tests/Aspects/Initialization/` covering every §7 shape: non-positional record, `record struct` with-expression, positional record as transformation target, chained `with` expressions, and record inheritance with the aspect applied to the base only.
- 3 `[Fact]` methods in `PrimaryConstructorTests` pinning the `IsRecordCopyConstructor()` predicate shape (positional/non-positional record, non-record class) — guards the §7.2 copy-ctor carve-out relied on by `PullConstructorParameterAdviceImpl` and `IntroduceConstructorTransformation`.

**No engine changes.** Audit confirmed every §7 requirement is already implemented on the #1522 base (primary-ctor append + `Deconstruct` via `RecordDeconstructSyntaxHelper`, copy-ctor carve-out via `IsRecordCopyConstructor`, `with`-expression wrapping with `InitializationMetadata.Modify` via `OnInitializedWithExpressionSubstitution`). These tests lock that behavior in as a regression boundary.

Every `.t.cs` matched the actual linker output on first run.

## Test plan

- [x] `dotnet build` of AspectTests and UnitTests projects — clean
- [x] 5 new Record aspect tests pass
- [x] 3 new `IsRecordCopyConstructor` unit tests pass
- [x] Full `Initialization` aspect-test sweep — 95/95 passing, no regressions

— Claude for @gfraiteur