### PR TITLE
Allow out/ref contracts on constructors (#708)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
@@ -124,82 +124,9 @@ internal sealed partial class LinkerInjectionStep
                 case IFullRef<IIndexer> indexer:
                     return this.GetAuxiliaryContractIndexer( indexer, aspectLayerInstance, returnVariableName );
 
-                case IFullRef<IConstructor> constructor:
-                    return this.GetAuxiliaryContractConstructor( constructor );
-
                 default:
                     throw new AssertionFailedException( $"Unsupported kind: {member}" );
             }
-        }
-
-        private ConstructorDeclarationSyntax GetAuxiliaryContractConstructor( IFullRef<IConstructor> constructorRef )
-        {
-            var constructor = constructorRef.Definition;
-
-            ParameterListSyntax parameters;
-            SeparatedSyntaxList<ParameterSyntax> originalParameters;
-
-            if ( constructor.IsPrimary )
-            {
-#if ROSLYN_4_8_0_OR_GREATER
-                var syntax = (TypeDeclarationSyntax) constructor.GetPrimaryDeclarationSyntax().AssertNotNull();
-#else
-                var syntax = (RecordDeclarationSyntax) constructor.GetPrimaryDeclarationSyntax().AssertNotNull();
-#endif
-
-                parameters = syntax.ParameterList.AssertNotNull();
-                originalParameters = parameters.Parameters;
-
-                if ( this._transformationCollection.TryGetMemberLevelTransformations( syntax, out var memberTransformations )
-                     && memberTransformations.Parameters.Length > 0 )
-                {
-                    var syntaxGenerationContext = this.CompilationContext.GetSyntaxGenerationContext( this.SyntaxGenerationOptions, syntax );
-
-                    parameters =
-                        parameters.AddParameters(
-                            memberTransformations.Parameters.SelectAsArray( p => p.ToSyntax( syntaxGenerationContext, this._finalCompilationModel ) ) );
-
-                    originalParameters = parameters.Parameters;
-                }
-            }
-            else
-            {
-                var syntax = (ConstructorDeclarationSyntax) constructor.GetPrimaryDeclarationSyntax().AssertNotNull();
-                parameters = syntax.ParameterList;
-                originalParameters = parameters.Parameters;
-            }
-
-            parameters =
-                parameters.WithAdditionalParameters(
-                    Parameter(
-                        List<AttributeListSyntax>(),
-                        TokenList(),
-                        this._injectionNameProvider.GetSourceType(),
-                        WellKnownIdentifier( AspectReferenceSyntaxProvider.LinkerOverrideParamName ),
-                        EqualsValueClause(
-                            LiteralExpression(
-                                SyntaxKind.DefaultLiteralExpression,
-                                Token( SyntaxKind.DefaultKeyword ) ) ) ) );
-
-            return ConstructorDeclaration(
-                List<AttributeListSyntax>(),
-                constructor.GetSyntaxModifierList( ModifierCategories.Unsafe )
-                    .Insert( 0, TokenWithTrailingSpace( SyntaxKind.PrivateKeyword ) ),
-                SyntaxFactoryEx.SafeIdentifier( constructor.DeclaringType.AssertNotNull().Name.AssertNotNull() ),
-                parameters,
-                ConstructorInitializer(
-                    SyntaxKind.ThisConstructorInitializer,
-                    ArgumentList(
-                        SeparatedList(
-                            originalParameters.SelectAsArray(
-                                p =>
-                                    Argument(
-                                        null,
-                                        p.Modifiers.FirstOrDefault( m => !m.IsKind( SyntaxKind.ParamsKeyword ) ),
-                                        SyntaxFactoryEx.WellKnownIdentifierName( p.Identifier ) ) ) ) ) ),
-                Block(),
-                null,
-                default );
         }
 
         private MemberDeclarationSyntax GetAuxiliaryContractMethod(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.AuxiliaryMemberFactory.cs
@@ -124,9 +124,82 @@ internal sealed partial class LinkerInjectionStep
                 case IFullRef<IIndexer> indexer:
                     return this.GetAuxiliaryContractIndexer( indexer, aspectLayerInstance, returnVariableName );
 
+                case IFullRef<IConstructor> constructor:
+                    return this.GetAuxiliaryContractConstructor( constructor );
+
                 default:
                     throw new AssertionFailedException( $"Unsupported kind: {member}" );
             }
+        }
+
+        private ConstructorDeclarationSyntax GetAuxiliaryContractConstructor( IFullRef<IConstructor> constructorRef )
+        {
+            var constructor = constructorRef.Definition;
+
+            ParameterListSyntax parameters;
+            SeparatedSyntaxList<ParameterSyntax> originalParameters;
+
+            if ( constructor.IsPrimary )
+            {
+#if ROSLYN_4_8_0_OR_GREATER
+                var syntax = (TypeDeclarationSyntax) constructor.GetPrimaryDeclarationSyntax().AssertNotNull();
+#else
+                var syntax = (RecordDeclarationSyntax) constructor.GetPrimaryDeclarationSyntax().AssertNotNull();
+#endif
+
+                parameters = syntax.ParameterList.AssertNotNull();
+                originalParameters = parameters.Parameters;
+
+                if ( this._transformationCollection.TryGetMemberLevelTransformations( syntax, out var memberTransformations )
+                     && memberTransformations.Parameters.Length > 0 )
+                {
+                    var syntaxGenerationContext = this.CompilationContext.GetSyntaxGenerationContext( this.SyntaxGenerationOptions, syntax );
+
+                    parameters =
+                        parameters.AddParameters(
+                            memberTransformations.Parameters.SelectAsArray( p => p.ToSyntax( syntaxGenerationContext, this._finalCompilationModel ) ) );
+
+                    originalParameters = parameters.Parameters;
+                }
+            }
+            else
+            {
+                var syntax = (ConstructorDeclarationSyntax) constructor.GetPrimaryDeclarationSyntax().AssertNotNull();
+                parameters = syntax.ParameterList;
+                originalParameters = parameters.Parameters;
+            }
+
+            parameters =
+                parameters.WithAdditionalParameters(
+                    Parameter(
+                        List<AttributeListSyntax>(),
+                        TokenList(),
+                        this._injectionNameProvider.GetSourceType(),
+                        WellKnownIdentifier( AspectReferenceSyntaxProvider.LinkerOverrideParamName ),
+                        EqualsValueClause(
+                            LiteralExpression(
+                                SyntaxKind.DefaultLiteralExpression,
+                                Token( SyntaxKind.DefaultKeyword ) ) ) ) );
+
+            return ConstructorDeclaration(
+                List<AttributeListSyntax>(),
+                constructor.GetSyntaxModifierList( ModifierCategories.Unsafe )
+                    .Insert( 0, TokenWithTrailingSpace( SyntaxKind.PrivateKeyword ) ),
+                SyntaxFactoryEx.SafeIdentifier( constructor.DeclaringType.AssertNotNull().Name.AssertNotNull() ),
+                parameters,
+                ConstructorInitializer(
+                    SyntaxKind.ThisConstructorInitializer,
+                    ArgumentList(
+                        SeparatedList(
+                            originalParameters.SelectAsArray(
+                                p =>
+                                    Argument(
+                                        null,
+                                        p.Modifiers.FirstOrDefault( m => !m.IsKind( SyntaxKind.ParamsKeyword ) ),
+                                        SyntaxFactoryEx.WellKnownIdentifierName( p.Identifier ) ) ) ) ) ),
+                Block(),
+                null,
+                default );
         }
 
         private MemberDeclarationSyntax GetAuxiliaryContractMethod(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -1455,11 +1455,27 @@ internal sealed partial class LinkerInjectionStep
                 var constructor = this._compilation.RefFactory.FromSymbol<IConstructor>( symbol );
                 var entryStatements = this._transformationCollection.GetInjectedEntryStatements( constructor );
                 var epilogueStatements = this._transformationCollection.GetInjectedEpilogueStatements( constructor );
+                var outputContractStatements = this._transformationCollection.GetInjectedOutputContractStatements( constructor );
+
+                IReadOnlyList<StatementSyntax> exitStatements;
+
+                if ( outputContractStatements.Count > 0 && epilogueStatements.Count > 0 )
+                {
+                    exitStatements = [..outputContractStatements, ..epilogueStatements];
+                }
+                else if ( outputContractStatements.Count > 0 )
+                {
+                    exitStatements = outputContractStatements;
+                }
+                else
+                {
+                    exitStatements = epilogueStatements;
+                }
 
                 node = (ConstructorDeclarationSyntax) this.InjectStatementsIntoMemberDeclaration(
                     constructor,
                     entryStatements,
-                    epilogueStatements,
+                    exitStatements,
                     node );
             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -621,6 +621,31 @@ internal sealed partial class LinkerInjectionStep
         }
 
         /// <summary>
+        /// Returns the ordered list of output contract statements for a source constructor.
+        /// Used when output contracts are applied to out/ref constructor parameters without an explicit override.
+        /// </summary>
+        internal IReadOnlyList<StatementSyntax> GetInjectedOutputContractStatements( IRef<IConstructor> targetConstructor )
+        {
+            if ( !this._insertedStatementsByTargetMethodBase.TryGetValue( targetConstructor, out var insertedStatements ) )
+            {
+                return ImmutableArray<StatementSyntax>.Empty;
+            }
+
+            var outputContractStatements = OrderContractStatements(
+                insertedStatements.Where( s => s.Kind == InsertedStatementKind.OutputContract ) );
+
+            return outputContractStatements
+                .Select(
+                    s =>
+                        s.Statement.Kind() switch
+                        {
+                            SyntaxKind.Block when s.Statement is BlockSyntax block => block.WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock ),
+                            _ => s.Statement
+                        } )
+                .ToReadOnlyList();
+        }
+
+        /// <summary>
         /// Returns the ordered list of epilogue statements (kind <see cref="InsertedStatementKind.InitializerEpilogue"/>)
         /// to be injected at the end of a source constructor body. Used by <c>AfterLastInstanceConstructor</c> to emit
         /// the trailing <c>this.OnConstructed(context);</c> call.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
@@ -1159,7 +1159,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
     private static bool RequiresAuxiliaryContractMember(
         IFullRef<IMember> member,
         InsertStatementTransformationContextImpl insertStatementContext )
-        => insertStatementContext.WasUsedForOutputContracts
+        => (insertStatementContext.WasUsedForOutputContracts && member is not IFullRef<IConstructor>)
            || member is IFullRef<IFieldOrProperty> { Definition.IsAutoPropertyOrField: true } || (member is IFullRef<IMethod>
            {
                Definition: { ContainingDeclaration: IFieldOrProperty { IsAutoPropertyOrField: true } } or

--- a/Metalama.Framework/src/Metalama.Framework/Eligibility/EligibilityRuleFactory.Contracts.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Eligibility/EligibilityRuleFactory.Contracts.cs
@@ -147,7 +147,6 @@ public static partial class EligibilityRuleFactory
                     parameter =>
                     {
                         parameter.MustSatisfyAny( p => p.MustBeWritable(), p => p.MustBeReturnParameter() );
-                        parameter.MustSatisfy( p => p.DeclaringMember is not IConstructor, _ => $"output contracts on constructors are not supported" );
                         AddCommonParameterRules( parameter );
                         AddCommonReturnParameterRules( parameter );
                         parameter.DeclaringMember().DeclaringType().AddRule( declaringTypeRule );
@@ -159,7 +158,6 @@ public static partial class EligibilityRuleFactory
                     {
                         parameter.MustNotBeReturnParameter();
                         parameter.MustBeRef();
-                        parameter.MustSatisfy( p => p.DeclaringMember is not IConstructor, _ => $"output contracts on constructors are not supported" );
                         AddCommonParameterRules( parameter );
                         AddCommonReturnParameterRules( parameter );
                         parameter.DeclaringMember().DeclaringType().AddRule( declaringTypeRule );
@@ -169,10 +167,6 @@ public static partial class EligibilityRuleFactory
                 CreateRule<IParameter>(
                     parameter =>
                     {
-                        parameter.MustSatisfy(
-                            p => !(p is { RefKind: RefKind.Out, DeclaringMember: IConstructor }),
-                            _ => $"output contracts on constructors are not supported" );
-
                         AddCommonParameterRules( parameter );
                         AddCommonReturnParameterRules( parameter );
                         parameter.DeclaringMember().DeclaringType().AddRule( declaringTypeRule );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_Parameter_Out.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/ConstructorPrimary_Parameter_Out.t.cs
@@ -1,2 +1,13 @@
-// CompileTimeAspectPipeline.ExecuteAsync failed.
-// Error LAMA0037 on `NotNull`: `The aspect 'NotNull' cannot be applied to the parameter 'Target.Target(out int)/x' because output contracts on constructors are not supported.`
+internal class Target
+{
+  // This is just to keep out parameter possible.
+  private int _z;
+  public Target([NotNull] out int x)
+  {
+    this._z = x = 42;
+    if (x == null)
+    {
+      throw new global::System.ArgumentNullException("x");
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Out.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Out.t.cs
@@ -1,2 +1,11 @@
-// CompileTimeAspectPipeline.ExecuteAsync failed.
-// Error LAMA0037 on `NotNull`: `The aspect 'NotNull' cannot be applied to the parameter 'Target.Target(out string)/m' because output contracts on constructors are not supported.`
+internal class Target
+{
+  public Target([NotNull] out string m)
+  {
+    m = "";
+    if (m == null)
+    {
+      throw new global::System.ArgumentNullException("m");
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Out_Allowed.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Out_Allowed.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+
+#pragma warning disable CS8618
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Contracts.Constructor_Parameter_Out_Allowed;
+
+internal class NotNullAttribute : ContractAspect
+{
+    public override void Validate( dynamic? value )
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException( meta.Target.Parameter.Name );
+        }
+    }
+}
+
+// <target>
+internal class Target
+{
+    public Target( [NotNull] out string m )
+    {
+        m = "hello";
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Out_Allowed.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Out_Allowed.t.cs
@@ -1,0 +1,11 @@
+internal class Target
+{
+  public Target([NotNull] out string m)
+  {
+    m = "hello";
+    if (m == null)
+    {
+      throw new global::System.ArgumentNullException("m");
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Ref_BothWays.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Ref_BothWays.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Contracts.Constructor_Parameter_Ref_BothWays;
+
+#pragma warning disable CS8618
+
+internal class NotNullAttribute : ContractAspect
+{
+    protected override ContractDirection GetDefinedDirection( IAspectBuilder builder ) => ContractDirection.Both;
+
+    public override void Validate( dynamic? value )
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException( meta.Target.Parameter.Name );
+        }
+    }
+}
+
+// <target>
+internal class Target
+{
+    public Target( [NotNull] ref string m )
+    {
+        m = "hello";
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Ref_BothWays.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Contracts/Constructor_Parameter_Ref_BothWays.t.cs
@@ -1,0 +1,15 @@
+internal class Target
+{
+  public Target([NotNull] ref string m)
+  {
+    if (m == null)
+    {
+      throw new global::System.ArgumentNullException("m");
+    }
+    m = "hello";
+    if (m == null)
+    {
+      throw new global::System.ArgumentNullException("m");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Enables output contracts (`[NotNull]`, etc.) on constructor `out` and `ref` parameters. Previously these were blocked by eligibility rules.

### Changes:
- **Eligibility rules** (`EligibilityRuleFactory.Contracts.cs`): Removed three restrictions that blocked output contracts on constructor parameters
- **Linker injection** (`LinkerInjectionStep.cs`): Modified `RequiresAuxiliaryContractMember` to exclude constructors — output contracts are injected directly as exit statements instead of requiring auxiliary contract members
- **Constructor rewriting** (`LinkerInjectionStep.Rewriter.cs`): Modified `VisitConstructorDeclarationCore` to inject output contract statements as exit statements alongside epilogue statements
- **New helper** (`LinkerInjectionStep.TransformationCollection.cs`): Added `GetInjectedOutputContractStatements` to retrieve output contract statements for constructors
- **Cleanup**: Removed unreachable `GetAuxiliaryContractConstructor` method

### Tests:
- `Constructor_Parameter_Out_Allowed.cs` — `[NotNull]` on `out string` constructor parameter
- `Constructor_Parameter_Ref_BothWays.cs` — `ContractDirection.Both` on `ref string` constructor parameter
- Updated `Constructor_Parameter_Out.t.cs` and `ConstructorPrimary_Parameter_Out.t.cs` from error expectations to successful transformation output

## Checklist

- [x] Reproduce bug (failing tests)
- [x] Implement fix
- [x] Build (Build.ps1 build) — 0 warnings
- [x] Run tests — 2248 aspect tests + 1826 unit tests pass
- [x] Finalize PR

Closes #708

— Claude for @PostSharpAgent