### PR TITLE
Allow disabling telemetry and metrics via MSBuild properties

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
@@ -130,6 +130,10 @@ public class DefaultProjectOptions : IProjectOptions
 
     public virtual bool ValidateRunTimeCode => false;
 
+    public virtual bool? TelemetryEnabled => null;
+
+    public virtual bool? MetricsEnabled => null;
+
     // IProjectOptions is currently not used as a dictionary key, so we can throw here.
     public sealed override int GetHashCode() => throw new NotImplementedException();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
@@ -242,4 +242,20 @@ public interface IProjectOptions : IProjectService, IEquatable<IProjectOptions>
     /// When <c>true</c>, the validator checks that run-time code does not reference compile-time-only declarations.
     /// </summary>
     bool ValidateRunTimeCode { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether telemetry is enabled for this project. When set to <c>false</c>,
+    /// all telemetry (usage reports, exception reports) is suppressed during the build.
+    /// When <c>null</c>, the default telemetry configuration applies.
+    /// This property can be set via the <c>MetalamaTelemetryEnabled</c> MSBuild property.
+    /// </summary>
+    bool? TelemetryEnabled { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether project metrics collection is enabled for this project.
+    /// When set to <c>false</c>, project metrics (usage sessions) are not collected during the build.
+    /// When <c>null</c>, the default configuration applies.
+    /// This property can be set via the <c>MetalamaMetricsEnabled</c> MSBuild property.
+    /// </summary>
+    bool? MetricsEnabled { get; }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
@@ -192,6 +192,12 @@ public partial class MSBuildProjectOptions : DefaultProjectOptions
     public override bool AvoidLockingExtensionAssemblies => this.GetBooleanOption( MSBuildPropertyNames.MetalamaAvoidLockingExtensionAssemblies );
 
     [Memo]
+    public override bool? TelemetryEnabled => this.GetNullableBooleanOption( MSBuildPropertyNames.MetalamaTelemetryEnabled );
+
+    [Memo]
+    public override bool? MetricsEnabled => this.GetNullableBooleanOption( MSBuildPropertyNames.MetalamaMetricsEnabled );
+
+    [Memo]
     public override ImmutableArray<TargetedAssemblyReference> DesignTimeExtensionAssemblies
         => this.GetListOption( MSBuildPropertyNames.MetalamaDesignTimeExtensionAssemblies )
             .Select( TargetedAssemblyReference.ParsePipeSeparatedString )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
@@ -55,6 +55,8 @@ public static class MSBuildPropertyNames
     public const string MetalamaAssemblyLocatorSalt = nameof(MetalamaAssemblyLocatorSalt);
     public const string MetalamaValidateRunTimeCode = nameof(MetalamaValidateRunTimeCode);
     public const string TargetFrameworks = nameof(TargetFrameworks);
+    public const string MetalamaTelemetryEnabled = nameof(MetalamaTelemetryEnabled);
+    public const string MetalamaMetricsEnabled = nameof(MetalamaMetricsEnabled);
 
     public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
         MetalamaBuildTouchFile,
@@ -96,5 +98,7 @@ public static class MSBuildPropertyNames
         MSBuildBinPath,
         MetalamaAssemblyLocatorSalt,
         MetalamaValidateRunTimeCode,
-        TargetFrameworks );
+        TargetFrameworks,
+        MetalamaTelemetryEnabled,
+        MetalamaMetricsEnabled );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
@@ -116,6 +116,10 @@ public abstract class ProjectOptionsWrapper : IProjectOptions
 
     public virtual bool ValidateRunTimeCode => this.Wrapped.ValidateRunTimeCode;
 
+    public virtual bool? TelemetryEnabled => this.Wrapped.TelemetryEnabled;
+
+    public virtual bool? MetricsEnabled => this.Wrapped.MetricsEnabled;
+
     public sealed override int GetHashCode() => throw new NotImplementedException();
 
     public sealed override bool Equals( object? obj ) => this.Equals( obj as IProjectOptions );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.CompilerServiceProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.CompilerServiceProvider.cs
@@ -38,21 +38,29 @@ public sealed partial class SourceTransformer
 
             this._services.Add( typeof(ILoggerFactory), loggerFactory );
             this._services.Add( typeof(ILogger), new LoggerAdapter( loggerFactory.GetLogger( "Compiler" ) ) );
-            this._services.Add( typeof(IExceptionReporter), new ExceptionReporterAdapter( serviceProvider.GetBackstageService<IExceptionReporter>() ) );
 
-            // Initialize usage reporting.
-            try
+            // Register the exception reporter unless telemetry is explicitly disabled via MSBuild property.
+            if ( options.TelemetryEnabled != false )
             {
-                if ( serviceProvider.GetBackstageService<IUsageReporter>() is { } usageReporter && options.AssemblyName != null )
-                {
-                    this._session = usageReporter.StartSession( "TransformerUsage", options.AssemblyName );
-                }
+                this._services.Add( typeof(IExceptionReporter), new ExceptionReporterAdapter( serviceProvider.GetBackstageService<IExceptionReporter>() ) );
             }
-            catch ( Exception e )
-            {
-                ReportException( e, serviceProvider, false );
 
-                // We don't re-throw here as we don't want compiler to crash because of usage reporting exceptions.
+            // Initialize usage reporting unless telemetry or metrics are explicitly disabled via MSBuild properties.
+            if ( options.TelemetryEnabled != false && options.MetricsEnabled != false )
+            {
+                try
+                {
+                    if ( serviceProvider.GetBackstageService<IUsageReporter>() is { } usageReporter && options.AssemblyName != null )
+                    {
+                        this._session = usageReporter.StartSession( "TransformerUsage", options.AssemblyName );
+                    }
+                }
+                catch ( Exception e )
+                {
+                    ReportException( e, serviceProvider, false );
+
+                    // We don't re-throw here as we don't want compiler to crash because of usage reporting exceptions.
+                }
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
@@ -41,6 +41,8 @@
         <CompilerVisibleProperty Include="MetalamaAssemblyLocatorSalt"/>
         <CompilerVisibleProperty Include="MetalamaValidateRunTimeCode"/>
         <CompilerVisibleProperty Include="TargetFrameworks"/>
+        <CompilerVisibleProperty Include="MetalamaTelemetryEnabled"/>
+        <CompilerVisibleProperty Include="MetalamaMetricsEnabled"/>
     </ItemGroup>
 
     <!-- More properties are already exported by Metalama.Compiler and don't need to be exported a second time. -->

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/MSBuildProjectOptionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/MSBuildProjectOptionsTests.cs
@@ -70,6 +70,60 @@ public sealed class MSBuildProjectOptionsTests
         Assert.Equal( touchFilePath, options.SourceGeneratorTouchFile );
     }
 
+    [Fact]
+    public void TelemetryEnabled_NotSet_ReturnsNull()
+    {
+        var source = new DictionaryOptionsSource( new Dictionary<string, string>() );
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Null( options.TelemetryEnabled );
+    }
+
+    [Theory]
+    [InlineData( "True", true )]
+    [InlineData( "true", true )]
+    [InlineData( "False", false )]
+    [InlineData( "false", false )]
+    public void TelemetryEnabled_SetToValue_ReturnsExpected( string value, bool expected )
+    {
+        var source = new DictionaryOptionsSource(
+            new Dictionary<string, string>
+            {
+                [MSBuildPropertyNames.MetalamaTelemetryEnabled] = value
+            } );
+
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Equal( expected, options.TelemetryEnabled );
+    }
+
+    [Fact]
+    public void MetricsEnabled_NotSet_ReturnsNull()
+    {
+        var source = new DictionaryOptionsSource( new Dictionary<string, string>() );
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Null( options.MetricsEnabled );
+    }
+
+    [Theory]
+    [InlineData( "True", true )]
+    [InlineData( "true", true )]
+    [InlineData( "False", false )]
+    [InlineData( "false", false )]
+    public void MetricsEnabled_SetToValue_ReturnsExpected( string value, bool expected )
+    {
+        var source = new DictionaryOptionsSource(
+            new Dictionary<string, string>
+            {
+                [MSBuildPropertyNames.MetalamaMetricsEnabled] = value
+            } );
+
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Equal( expected, options.MetricsEnabled );
+    }
+
     private sealed class TestableMSBuildProjectOptions : MSBuildProjectOptions
     {
         public TestableMSBuildProjectOptions( IProjectOptionsSource source ) : base( source ) { }


### PR DESCRIPTION
## Summary

Closes #1206

Adds two new MSBuild properties that allow disabling telemetry and metrics at the project/solution level:

- `MetalamaTelemetryEnabled` — when set to `false`, disables all telemetry (usage reports, exception reports) during build
- `MetalamaMetricsEnabled` — when set to `false`, disables project metrics collection during build (exception reporting still works)

These properties can be set in `Directory.Build.props` for version-controlled, team-wide configuration:

```xml
<PropertyGroup>
    <MetalamaTelemetryEnabled>false</MetalamaTelemetryEnabled>
    <MetalamaMetricsEnabled>false</MetalamaMetricsEnabled>
</PropertyGroup>
```

When not set (null), the default telemetry configuration applies (environment variable, CLI settings).

## Changes

- `MSBuildPropertyNames.cs`: Added `MetalamaTelemetryEnabled` and `MetalamaMetricsEnabled` constants
- `IProjectOptions.cs`: Added `TelemetryEnabled` and `MetricsEnabled` nullable bool properties
- `DefaultProjectOptions.cs`, `ProjectOptionsWrapper.cs`, `MSBuildProjectOptions.cs`: Implementations
- `Metalama.CompilerVisibleProperties.props`: Declared as compiler-visible properties
- `SourceTransformer.CompilerServiceProvider.cs`: Wired properties to control exception reporter registration and usage session creation
- `MSBuildProjectOptionsTests.cs`: Unit tests for property reading

## Checklist

- [x] Add MSBuild property names and CompilerVisibleProperties
- [x] Add IProjectOptions interface members
- [x] Add default/wrapper implementations
- [x] Add MSBuildProjectOptions reading
- [x] Add unit tests for property reading
- [x] Wire properties to telemetry system (usage reporting)
- [x] Wire properties to exception reporting
- [x] Build passes with zero warnings
- [x] All tests pass

## Test plan

- [x] Unit tests verify MSBuild property reading (TelemetryEnabled, MetricsEnabled)
- [x] Full build (Build.ps1 build) passes with zero warnings
- [x] Full test (Build.ps1 test) passes — all tests pass

— Claude for @gfraiteur