### PR TITLE
Preserve comments and directives on brace trivia in linker rewrites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ For `Metalama.Framework.Tests.UnitTests` (see `InvokerTests.cs`, `ExpressionFact
 
 The syntax generation pipeline intentionally produces over-specified syntax (redundant casts, fully-qualified type names, explicit `new DelegateType(methodGroup)` wrappers) to ensure correctness. The `CodeFormatter` pipeline then simplifies in context:
 
-- **Annotation**: Nodes that may be redundant are annotated with `FormattingAnnotations.WithSimplifierAnnotation<T>()` (or `WithSimplifierAnnotationIfNecessary` which checks `SyntaxGenerationOptions.AddFormattingAnnotations`)
+- **Annotation**: Nodes that may be redundant are annotated with `FormattingAnnotations.WithSimplifierAnnotation<T>()` (or `WithSimplifierAnnotationIfNecessary` which checks `SyntaxGenerationOptions.WillBeFormatted`)
 - **Roslyn Simplifier**: `Simplifier.ReduceAsync` removes unnecessary namespace qualifications, redundant casts, etc.
 - **Custom Simplifier** (`CodeFormatter.CustomSimplifier`): Handles Metalama-specific patterns — delegate creation simplification (e.g., `new Action(() => { ... })` → `() => { ... }` in target-typed contexts), tuple cast simplification, nullable suppression removal
 - **Key files**: `FormattingAnnotations.cs` (SDK layer), `SyntaxExtensions.WithSimplifierAnnotationIfNecessary` (Engine), `CodeFormatter.cs` (pipeline), `CodeFormatter.CustomSimplifier.cs`

--- a/Metalama.Framework/docs/trivia-and-formatting.md
+++ b/Metalama.Framework/docs/trivia-and-formatting.md
@@ -60,6 +60,24 @@ Two subtleties:
 - A single predicate (`WillBeTextualized`) gates both per-node elastic-trivia emission *and* the `NormalizeWhitespace(elasticTrivia: true)` call during generation. Both are required whenever the tree will be textualized — `Default` and `Formatted` therefore behave identically at the per-node level: both produce trivia, both normalize. The difference between them lives entirely in `WillBeFormatted` and the later `CodeFormatter` pass (see §6). The XML doc on `WillBeTextualized` explains why normalization is still needed in `Formatted` mode: *Roslyn's `Formatter` reflows only elastic trivia and preserves non-elastic trivia verbatim — it does not synthesize new trivia between tokens that have none*. `NormalizeWhitespace(elasticTrivia: true)` is what sprays those elastic markers through the tree so the formatter has something to reflow.
 - **Directives are always preserved, even in `None`.** Preprocessor directives (`#if`, `#pragma`, `#line`, etc.) affect compilation semantics, so the `WithOptional*` helpers check `ContainsDirectives()` and fall through to the real `With*` call when found.
 
+### The directive-preservation invariant (load-bearing)
+
+> **`#` directives must NEVER be dropped from the output, even when the syntax node that carries them as trivia is itself dropped or rewritten. The only trivia class that may be dropped is XML documentation comments.**
+
+The reason this rule is absolute: `#if` / `#endif`, `#region` / `#endregion`, `#pragma warning disable` / `restore`, `#nullable enable` / `restore`, and `#line` come in **balanced pairs that span across nodes**. The opening directive is leading trivia of one node; the closing directive is trailing trivia of another. The two ends typically have *no syntactic relationship* — `#if FOO` may be leading trivia of the first `using` directive while `#endif` is trailing trivia of the EOF token, with hundreds of unrelated declarations in between. Dropping just one end produces invalid C# (e.g. CS1028 *Unexpected preprocessor directive*) even when every node in between is well-formed.
+
+Because the rewriters in this codebase work declaration-by-declaration, no single rewriter has the global view needed to "drop both ends together". The only safe rule is therefore: **never drop directive trivia, even from a node you intend to remove**. Reattach the trivia to a sibling, the parent, or a synthesized stub. If a node is replaced (for example, the `RunTimeAssemblyRewriter` replacing a compile-time-only method body with `throw new NotSupportedException(...)`), the replacement node must carry over the original node's leading and trailing trivia in full — not just the whitespace, but every directive too.
+
+XML documentation comments (`/// <summary>...`) are the *only* trivia that may be discarded. They have no spanning semantics, they are not load-bearing for compilation, and discarding them is a deliberate design choice (the run-time stripped assembly intentionally drops compile-time-only XML doc).
+
+How the rule shows up in code:
+
+- `WithOptionalLeadingTrivia` / `WithOptionalTrailingTrivia` already enforce the rule on the *attachment* side: they fall through to a real `With*` call whenever `ContainsDirectives()` is true, regardless of mode.
+- The rule is *not* enforced on the *removal* side. Any rewriter that calls `node.WithLeadingTrivia(SyntaxTriviaList.Empty)` or replaces a node without forwarding its trivia is on the hook to verify (by inspection or by `ContainsDirectives`) that no directives are being dropped.
+- When you visit a node and decide to drop it entirely (`return null` from a `CSharpSyntaxRewriter`), check the leading/trailing trivia for directives first. If there are any, attach them to a sibling node or to a no-op placeholder so the final tree still has them.
+
+If you find yourself wanting to "fix" an unbalanced-directive bug by suppressing the surviving end, stop — the bug is upstream, in the rewriter that dropped the other end. Find that rewriter and forward the trivia instead.
+
 Static instances: `SyntaxGenerationOptions.Formatted` (public) and `SyntaxGenerationOptions.Unformatted` (internal, `None`).
 
 ## Who picks which mode

--- a/Metalama.Framework/docs/trivia-and-formatting.md
+++ b/Metalama.Framework/docs/trivia-and-formatting.md
@@ -1,0 +1,270 @@
+# Trivia and Formatting
+
+This document describes how Metalama manages whitespace, trivia, and C# code formatting across the generation and output pipeline. For the broader pipeline context, see [pipeline.md](pipeline.md); for the short version of this document, see the "Syntax Generation and Simplification" section in the repository root `CLAUDE.md`.
+
+## Overview
+
+Metalama intentionally separates two concerns:
+
+- **Correctness**, handled during syntax generation. The generator produces over-specified, explicit C# — fully-qualified type names, redundant casts, explicit `new DelegateType(methodGroup)` wrappers, and so on. This guarantees the Roslyn compiler accepts the tree regardless of surrounding context.
+- **Presentation**, handled in a later simplify-and-format pass (`CodeFormatter`). That pass removes the redundant qualifications and reflows whitespace only when the output is meant for human eyes.
+
+Trivia (whitespace, comments, end-of-line markers, directives) follows the same split. There are three handling modes, selected per project and per pipeline — from "don't emit any trivia at all" (fastest) to "fully indent and simplify" (human-readable).
+
+## Why three modes? The allocation budget
+
+Roslyn syntax nodes are immutable green/red trees. Every `node.WithLeadingTrivia(...)`, `node.WithTrailingTrivia(...)`, or `node.NormalizeWhitespace()` call allocates — a new green node, usually a new token, and a new `SyntaxTriviaList`. Across a compilation that passes through thousands of generated nodes, decorating every node with elastic EOLs, indentation whitespace, and line-feed separators is measurable GC pressure and CPU time.
+
+The `Optional*` / `*IfNecessary` vocabulary pervasive throughout `Metalama.Framework.Engine.SyntaxGeneration` and `Metalama.Framework.Engine.Utilities.Roslyn` exists to turn those allocations into no-ops when the output will not be textualized, or doesn't need to be pretty. Choosing a formatting mode is therefore primarily choosing a trivia-allocation budget, not just a styling preference.
+
+Three diagnostic analyzers enforce this discipline (`MetalamaPerformanceAnalyzer`, warning range `LAMA0830`–`LAMA0832`):
+
+| Analyzer | Rule | Preferred alternative |
+|---|---|---|
+| `LAMA0830` | `NormalizeWhitespace` is expensive | `NormalizeWhitespaceIfNecessary` |
+| `LAMA0831` | Avoid chained `With*` calls on syntax nodes | `PartialUpdate` extensions (generated) |
+| `LAMA0832` | Avoid `WithLeadingTrivia`/`WithTrailingTrivia` | `WithOptional*` / `WithRequired*` helpers |
+
+These warnings are *suggestions* in engine code (`.editorconfig` at `Metalama.Framework.Engine/.editorconfig`) and silenced entirely in test projects (`Metalama.Testing.UnitTesting/.editorconfig`, `Metalama.Testing.AspectTesting/.editorconfig`). Production engine code that bypasses them uses `#pragma warning disable LAMA083x` with an explanation.
+
+## The three modes — `CodeFormattingOptions`
+
+Defined in `Metalama.Framework.Sdk/Formatting/CodeFormattingOptions.cs`:
+
+```csharp
+public enum CodeFormattingOptions
+{
+    Default,    // Syntactically correct; no pretty formatting.
+    None,       // No text output required, only a syntax tree.
+    Formatted   // Proper indentation and spacing.
+}
+```
+
+The enum is wrapped by `SyntaxGenerationOptions` (`Metalama.Framework.Engine/SyntaxGeneration/SyntaxGenerationOptions.cs`), which exposes two booleans that gate every trivia-related call site:
+
+```csharp
+internal bool WillBeTextualized => _codeFormattingOptions != CodeFormattingOptions.None;
+internal bool WillBeFormatted   => _codeFormattingOptions == CodeFormattingOptions.Formatted;
+```
+
+Mapping:
+
+| Mode | `WillBeTextualized` | `WillBeFormatted` | Typical use |
+|---|---|---|---|
+| `None` | false | false | AST-only flows (test validation; no textualization) |
+| `Default` | **true** | false | Compiled-assembly output — fast, verbose, machine-readable |
+| `Formatted` | true | **true** | Design-time, preview, HTML, live templates, compile-time assembly |
+
+Two subtleties:
+
+- A single predicate (`WillBeTextualized`) gates both per-node elastic-trivia emission *and* the `NormalizeWhitespace(elasticTrivia: true)` call during generation. Both are required whenever the tree will be textualized — `Default` and `Formatted` therefore behave identically at the per-node level: both produce trivia, both normalize. The difference between them lives entirely in `WillBeFormatted` and the later `CodeFormatter` pass (see §6). The XML doc on `WillBeTextualized` explains why normalization is still needed in `Formatted` mode: *Roslyn's `Formatter` reflows only elastic trivia and preserves non-elastic trivia verbatim — it does not synthesize new trivia between tokens that have none*. `NormalizeWhitespace(elasticTrivia: true)` is what sprays those elastic markers through the tree so the formatter has something to reflow.
+- **Directives are always preserved, even in `None`.** Preprocessor directives (`#if`, `#pragma`, `#line`, etc.) affect compilation semantics, so the `WithOptional*` helpers check `ContainsDirectives()` and fall through to the real `With*` call when found.
+
+Static instances: `SyntaxGenerationOptions.Formatted` (public) and `SyntaxGenerationOptions.Unformatted` (internal, `None`).
+
+## Who picks which mode
+
+Each pipeline overrides `AspectPipeline.GetSyntaxGenerationOptions()`:
+
+| Pipeline | Mode | File |
+|---|---|---|
+| `CompileTimeAspectPipeline` | Project-configured (`IProjectOptions.CodeFormattingOptions`) | `Pipeline/CompileTime/CompileTimeAspectPipeline.cs:43` |
+| `BaseDesignTimeAspectPipeline` | Always `Formatted` | `Pipeline/DesignTime/BaseDesignTimeAspectPipeline.cs:18` |
+| `PreviewAspectPipeline` | Always `Formatted` | `Pipeline/DesignTime/PreviewAspectPipeline.cs:29` |
+| `LiveTemplateAspectPipeline` | Always `Formatted` | `Pipeline/LiveTemplates/LiveTemplateAspectPipeline.cs:43` |
+
+The compile-time assembly built by `CompileTimeCompilationBuilder` always uses `Formatted` regardless of the pipeline it is invoked from — its construction is not on the hot path, and the generated compile-time code is a debugging surface that should be readable.
+
+Tests have one more lever: the `@TestUnformattedOutput` directive in aspect tests re-runs the pipeline in `None` mode to verify that the generator produces syntactically correct trees even when no trivia is emitted. This catches bugs where code generation silently relies on elastic EOLs for correctness.
+
+The user-facing entry points on `IProjectOptions`:
+
+- `CodeFormattingOptions` — the mode chosen above. Defaults to `Default` and is upgraded to `Formatted` when the user sets `FormatOutput=true` or `WriteHtml=true` in their project.
+- `FormatCompileTimeCode` — independently triggers a `CodeFormatter` pass over the compile-time assembly after it is built.
+- `WriteHtml` — triggers HTML rendering, which needs readable code.
+
+The `CodeFormatter` service is only registered in the project service provider when at least one of these is enabled (`ServiceProviderFactory.cs`). In plain `Default`-mode compilation the formatter is never instantiated.
+
+## Generation: conditional trivia
+
+### `SyntaxGenerationContext` and cached trivia lists
+
+`SyntaxGenerationContext` (`SyntaxGeneration/SyntaxGenerationContext.cs`) holds the active `SyntaxGenerationOptions` plus memoized trivia lists that respect them:
+
+```csharp
+[Memo]
+public SyntaxTriviaList OptionalElasticEndOfLineTriviaList
+    => this.Options.WillBeTextualized
+        ? new SyntaxTriviaList( this.ElasticEndOfLineTrivia )
+        : default;
+
+[Memo]
+internal SyntaxTriviaList TwoElasticEndOfLinesTriviaList
+    => this.Options.WillBeTextualized
+        ? new SyntaxTriviaList( this.ElasticEndOfLineTrivia, this.ElasticEndOfLineTrivia )
+        : default;
+```
+
+In `None` mode these return `default(SyntaxTriviaList)` — an empty value-type instance, zero allocation. In any other mode the `[Memo]` attribute ensures the list is built once per context and reused at every call site.
+
+### The `Optional` / `Required` / `IfNecessary` convention
+
+The extension methods in `Utilities/Roslyn/SyntaxExtensions.cs` (lines ~156–319) follow a strict naming convention:
+
+- **`*IfNecessary`** — checks a mode flag; no-op when the flag is off. Example: `NormalizeWhitespaceIfNecessary` no-ops in `None`.
+- **`WithOptional*`** — checks `WillBeTextualized`; returns the original node unchanged when false, except when the trivia contains directives.
+- **`WithRequired*`** — always allocates. Used when the trivia is load-bearing for syntax itself (pragmas on their own line, region markers).
+
+Representative implementations:
+
+```csharp
+internal static TNode NormalizeWhitespaceIfNecessary<TNode>( this TNode node, SyntaxGenerationContext context )
+    where TNode : SyntaxNode
+{
+    if ( !context.Options.WillBeTextualized ) return node;
+
+#pragma warning disable LAMA0830 // NormalizeWhitespace is expensive.
+    return node.NormalizeWhitespace( elasticTrivia: true, eol: context.EndOfLine );
+#pragma warning restore LAMA0830
+}
+
+internal static TNode WithOptionalLeadingTrivia<TNode>(
+    this TNode node, SyntaxTriviaList leadingTrivia, SyntaxGenerationOptions options )
+    where TNode : SyntaxNode
+{
+    if ( !options.WillBeTextualized && !leadingTrivia.ContainsDirectives() )
+        return node;
+
+    return node.WithLeadingTrivia( leadingTrivia );
+}
+
+internal static TNode WithSimplifierAnnotationIfNecessary<TNode>(
+    this TNode node, SyntaxGenerationOptions options )
+    where TNode : SyntaxNode
+{
+    if ( !options.WillBeFormatted ) return node;
+    return node.WithSimplifierAnnotation();
+}
+```
+
+The `ContainsDirectives` helper is a hand-rolled loop rather than `trivias.Any(t => t.IsDirective)` specifically to avoid allocations: the predicate would materialize a delegate, and calling `Any` via `IEnumerable<T>` boxes the struct enumerator. The hand-rolled `foreach` over `SyntaxTriviaList` uses its struct enumerator directly. This guard sits on the hot path of every optional-trivia attachment.
+
+### `ContextualSyntaxGenerator`
+
+`SyntaxGeneration/ContextualSyntaxGenerator.cs` wraps Roslyn's `SyntaxGenerator` with the "annotate then maybe-normalize" two-step and adds caching. A typical factory method looks like:
+
+```csharp
+internal ArrayCreationExpressionSyntax ArrayCreationExpression( TypeSyntax elementType, IEnumerable<SyntaxNode> elements )
+{
+    var array = (ArrayCreationExpressionSyntax) _roslynSyntaxGenerator.ArrayCreationExpression( elementType, elements );
+
+    return array.WithType( array.Type.WithSimplifierAnnotationIfNecessary( this.SyntaxGenerationContext ) )
+        .NormalizeWhitespaceIfNecessary( this.SyntaxGenerationContext );
+}
+```
+
+The generator also maintains a type-syntax cache (`_typeSyntaxCache` keyed by `IRef<IType>`) to avoid re-constructing identical type references — another allocation hedge orthogonal to the trivia mode.
+
+### Elastic vs. non-elastic trivia
+
+Every Roslyn `SyntaxTrivia` carries an "elastic" bit. The bit does not change what the trivia *is* (a space is a space, an EOL is an EOL); it is a marker of **provenance and intent** that tells downstream formatters whether they are allowed to alter it. The authoritative definition lives in the XML doc comments on [`SyntaxFactory.cs`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs) in the `dotnet/roslyn` repo:
+
+> Elastic trivia are used to denote trivia that was not produced by parsing source text, and are usually not preserved during formatting.
+> — repeated on `ElasticSpace`, `ElasticTab`, `ElasticCarriageReturnLineFeed`, `ElasticLineFeed`, `ElasticWhitespace(text)`, etc.
+
+> Syntax formatting will replace elastic markers with appropriate trivia.
+> — on `ElasticMarker`
+
+**Non-elastic trivia — verbatim, preserve as-is.**
+This is what the Roslyn parsers emit. When you parse source text, every existing whitespace character, line break, and comment is materialized as non-elastic trivia that reflects the source exactly, character-for-character. Non-elastic trivia carries the contract: *"this matches what the user wrote; don't touch it."* `Formatter.Format` and friends leave it alone.
+
+**Elastic trivia — hand-constructed placeholder, formatter may rewrite.**
+This is what you produce with the [`SyntaxFactory.Elastic*`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs) family — `ElasticSpace`, `ElasticMarker` (zero-width — "included automatically by factory methods when trivia is not specified"), `ElasticEndOfLine(eol)`, `ElasticCarriageReturnLineFeed`, `ElasticLineFeed`, `ElasticTab`, `ElasticWhitespace(text)`. A parser *never* produces elastic trivia; it only appears in programmatically built trees. Elastic trivia carries the contract: *"this was synthesized because a token has to be separated from its neighbors somehow, but the exact whitespace is a placeholder — a formatter is free to substitute, lengthen, collapse, or remove it."*
+
+Concretely, when [`Formatter.Format`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.formatting.formatter) (or [`SyntaxNode.NormalizeWhitespace`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.csharp.syntaxextensions.normalizewhitespace)) runs, it walks the tree and reflows only the elastic trivia to match the active formatting rules; non-elastic trivia is preserved exactly. `NormalizeWhitespace` additionally rewrites every token's trivia to elastic as it runs (`elasticTrivia: true` — the parameter Metalama always passes), which is what makes it so expensive and why it produces output that the formatter can later re-reflow at will.
+
+**How Metalama uses the distinction.**
+Generated code is the classic "hand-constructed" case, so Metalama's generation pipeline emits elastic trivia throughout (`SyntaxGenerationContext.ElasticEndOfLineTrivia`, `OptionalElasticEndOfLineTriviaList`, `TwoElasticEndOfLinesTriviaList`). This is what lets the `CodeFormatter` pass (§6) freely reflow generated sections in `Formatted` mode while leaving user source untouched. Non-elastic trivia is used sparingly, and only where the exact spacing is semantically load-bearing — most notably around preprocessor directives, which must sit on their own line regardless of what the formatter would otherwise prefer.
+
+Two practical consequences:
+
+- **Elastic trivia is still an allocation.** The bit is a flag on the already-allocated trivia; emitting elastic EOLs is just as expensive as emitting non-elastic ones. The `Optional*` guards suppress *either* kind when no formatter will ever run.
+- **Don't hand-write non-elastic whitespace into generated code unless you mean it.** If you use `SyntaxFactory.Space` or `SyntaxFactory.EndOfLine(...)`, the `CodeFormatter` won't touch it during a `Formatted` pass and your output may look wrong relative to the rest of the generated code. Prefer `context.ElasticEndOfLineTrivia` / `SyntaxFactory.ElasticSpace` / `SyntaxFactory.ElasticMarker`.
+
+See also the Roslyn issue [#302 — "Elastic marker only when necessary"](https://github.com/dotnet/roslyn/issues/302) and [#2435 — "Whitespace and EndOfLine trivia should default to non-elastic"](https://github.com/dotnet/roslyn/issues/2435) for historical design discussions on when elastic is (and is not) the right default.
+
+## Template expansion: active indentation
+
+One place Metalama performs active pretty-printing during generation rather than deferring is `MetaSyntaxRewriter` (`Templating/MetaSyntaxRewriter.cs`). It maintains an indent stack so nested compile-time expressions emit with sensible indentation:
+
+- A `Stack<string>` of indent prefixes; `Indent()` pushes a new `"    "` on top.
+- `GetIndentation(bool lineFeed)` returns a trivia list combining the elastic EOL (optionally) and the current indent whitespace.
+- A nested `IndentRewriter` uses an 80-character threshold to decide whether to break an `ArgumentList` across lines.
+- Interpolation content is never indented — CRLF inside an interpolated string would change the literal's value.
+
+This is the exception to the "defer to the formatter" rule: template output is read in compile-time-troubleshooting files and benefits from being indented even in `Default` mode.
+
+## The `CodeFormatter` pipeline
+
+When pretty output is required, `Metalama.Framework.Engine/Formatting/CodeFormatter.cs` runs a multi-stage pass. Public entry points:
+
+- `FormatAsync(Document document, diagnostics?, reformatAll, ct)` — single document, partial-format capable.
+- `FormatAsync(PartialCompilation compilation, ct)` — used by the compile-time pipeline; always calls `reformatAll: false`.
+- `FormatAllAsync(Compilation compilation, ct)` — whole compilation, used at end-of-pipeline and in tests.
+
+The pipeline runs five stages against a Roslyn `Solution`:
+
+1. **Diagnostic annotations.** If diagnostics are passed, `FormattedCodeWriter.AddDiagnosticAnnotations` attaches them as `SyntaxAnnotation`s for downstream renderers (HTML output, preview UI).
+2. **Custom simplifications** (`CodeFormatter.CustomSimplifier.cs`). A `SafeSyntaxRewriter` runs twice: first without a semantic model (syntactic patterns), then with a semantic model if the first pass set `RequiresSemanticModel`. Handles Metalama-specific simplifications:
+   - `new Action(() => { ... })` → `() => { ... }` in target-typed positions
+   - Redundant tuple casts (semantic comparison required)
+   - Redundant nullable suppression (`x!` where `x` is already non-nullable)
+3. **Import addition.** `ImportAdder.AddImportsAsync(document, Simplifier.Annotation, ...)` resolves annotated type references and adds the necessary `using` directives.
+4. **Roslyn simplifier + fix-up.** `Simplifier.ReduceAsync(document, Simplifier.Annotation, ...)` removes unnecessary namespace qualifications and redundant casts on annotated nodes. `SimplifierFixer` then post-processes to work around a Roslyn bug where EOL trivia after `//` comments can be dropped. The simplifier then runs **once more** as a final polish — see `CodeFormatter.cs:159–183`.
+5. **Reformat.** `Formatter.FormatAsync`. When `reformatAll == true`, the entire document is reflowed. When `reformatAll == false`, a `MarkTextSpansVisitor` walks the tree and classifies spans as `GeneratedCode` vs `SourceCode` based on annotations, and only the generated spans are formatted — preserving the user's original whitespace in their own code.
+
+After the Solution-level pipeline, both `FormatAsync(PartialCompilation)` and `FormatAllAsync(Compilation)` normalize line endings back to each source file's original EOL style via `EndOfLineHelper.NormalizeEndOfLines`, because Roslyn's `Formatter` may have normalized them to `\r\n`.
+
+Invocation sites:
+
+- `CompileTimeAspectPipeline.cs:199–210` — runs `FormatAsync(resultPartialCompilation, ...)` only if `CodeFormattingOptions == Formatted || WriteHtml`. When enabled on a non-test build, reports the informational diagnostic `GeneralDiagnosticDescriptors.CodeFormattingEnabled` so users are aware they are paying the cost.
+- `CompileTimeCompilationBuilder.cs` — runs it on the compile-time assembly when `FormatCompileTimeCode` is set.
+- Design-time preview (`UserProcessTransformationPreviewService`) — passes `reformatAll: false` so only generated spans are touched.
+
+## `FormattingAnnotations` — the bridge between generation and formatting
+
+`Metalama.Framework.Sdk/Formatting/FormattingAnnotations.cs` defines the annotations that let the generator communicate hints to the later formatter:
+
+- **`Simplifier.Annotation`** — Roslyn's "try to simplify me" annotation. The SDK can't reference `Microsoft.CodeAnalysis.Simplification` directly (it would pull in a workspace dependency), so `MetalamaEngineModuleInitializer` injects the annotation at engine startup:
+
+  ```csharp
+  FormattingAnnotations.Initialize( Simplifier.Annotation );
+  ```
+
+  `WithSimplifierAnnotation<T>` then attaches the injected annotation to a node. `WithSimplifierAnnotationIfNecessary` attaches it only in `Formatted` mode.
+- **`SystemGeneratedCodeAnnotation`** / **`SourceCodeAnnotation`** — distinguish Metalama-emitted spans from user source. Used by `MarkTextSpansVisitor` in the `reformatAll: false` branch so the formatter only touches generated code.
+- **`PossibleRedundantAnnotation`** — reserved for future use (marking locals/return statements that *may* be removable).
+- Public helpers: `WithSimplifierAnnotation<T>`, `WithGeneratedCodeAnnotation<T>`, `WithSourceCodeAnnotation<T>`.
+
+Annotations are themselves allocations on the node. `WithSimplifierAnnotationIfNecessary` skipping them outside `Formatted` mode is a double win: direct allocation saved, and the downstream simplifier has nothing to visit, so stages 3 and 4 of the `CodeFormatter` collapse to cheap no-ops.
+
+## What the compiler sees vs. what the human sees
+
+- The **Roslyn compiler** always sees the verbose, over-specified syntax tree. It doesn't care about whitespace at all — the emitted IL is identical regardless of mode.
+- In **`Default`** mode, this verbose syntax is what hits disk (and is what the debugger sees if source is embedded). Fast, correct, ugly. The compiler's own subsequent normalization passes do any cleanup the IL layer requires.
+- In **`Formatted`** mode, the simplify-and-format pass runs *before* the text is serialized, producing human-readable output. Cost is in the hundreds of milliseconds per document — acceptable because this mode is used for design-time preview, HTML rendering, and debug-output troubleshooting.
+- In **`None`** mode, no text is produced at all. Only the tree exists for downstream analysis.
+
+## Performance: rules of thumb for contributors
+
+- Prefer the `Optional*` / `*IfNecessary` variants unless the trivia is semantically required.
+- Route all whitespace normalization through `NormalizeWhitespaceIfNecessary`. Direct `NormalizeWhitespace` calls trip `LAMA0830` and are banned outside explicitly marked hot-paths.
+- Use `PartialUpdate` (generated into `.generated/<roslyn>/...SyntaxNodePartialUpdateExtensions.g.cs`) instead of chained `With*` calls on a syntax node — a single `Update` allocates one node instead of N. Enforced by `LAMA0831`.
+- Read trivia lists from `SyntaxGenerationContext.OptionalElasticEndOfLineTriviaList` rather than constructing them per call — `[Memo]`-cached and allocation-free in `None` mode.
+- If you catch yourself writing `node.WithLeadingTrivia(...)` in engine code, suspect a bug. Use `WithOptionalLeadingTrivia` / `WithRequiredLeadingTrivia` so the intent is explicit and the mode-aware shortcut is honored. Enforced by `LAMA0832`.
+
+## Related
+
+- [`pipeline.md`](pipeline.md) — where these modes are picked per pipeline and how transformations compose.
+- [`linker-architecture.md`](linker-architecture.md) — the linker also produces syntax and must follow the same trivia rules.
+- The "Syntax Generation and Simplification" section in the repository-root `CLAUDE.md` — a one-paragraph operational summary.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
@@ -366,6 +366,24 @@ namespace Metalama.Framework.Engine.Diagnostics
                 Error,
                 "Unknown transitive aspect class." );
 
+        internal static readonly DiagnosticDefinition<(string FilePath, string ExceptionType, string ExceptionMessage)>
+            GeneratedCodeParseFailed = new(
+                "LAMA0073",
+                _category,
+                "Failed to parse generated code for file '{0}'. " +
+                "This indicates a code generation issue where the generated syntax tree produces invalid text. " +
+                "Exception: {1}: {2}",
+                Error,
+                "Failed to parse generated code." );
+
+        internal static readonly DiagnosticDefinition<(string FilePath, string OriginalMessage, int Line, int Column, string ProblematicCode)>
+            GeneratedCodeSyntaxError = new(
+                "LAMA0074",
+                _category,
+                "Syntax error in generated code for file '{0}': {1}. Location: Line {2}, Column {3}. Problematic code: '{4}'.",
+                Error,
+                "Syntax error in generated code." );
+
         // TODO: Use formattable string (C# does not seem to find extension methods).
         internal static readonly DiagnosticDefinition<string>
             UnsupportedFeature = new(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -431,7 +431,7 @@ internal sealed partial class LinkerInjectionStep
                         .WithIdentifier(
                             node.Identifier.WithOptionalTrailingTrivia(
                                 default,
-                                syntaxGenerationContext.Options.TriviaMatters || node.Identifier.ContainsDirectives ) )
+                                syntaxGenerationContext.Options.WillBeTextualized || node.Identifier.ContainsDirectives ) )
                         .WithBaseList(
                             BaseList( SeparatedList( additionalBaseList.SelectAsReadOnlyList( i => i.Syntax ) ) )
                                 .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) )
@@ -1732,7 +1732,7 @@ internal sealed partial class LinkerInjectionStep
                     var eventDeclaration = EventFieldDeclaration(
                         default,
                         node.Modifiers,
-                        Token( TriviaList(), SyntaxKind.EventKeyword, TriviaList( Space ) ),
+                        Token( TriviaList(), SyntaxKind.EventKeyword, SyntaxFactoryEx.ElasticSpaceTriviaList ),
                         declaration,
                         Token( default, SyntaxKind.SemicolonToken, context.TwoElasticEndOfLinesTriviaList ) );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -439,11 +439,30 @@ internal sealed partial class LinkerInjectionStep
                 }
                 else
                 {
-                    node = (T) node.WithBaseList(
-                        BaseList(
-                            baseList.Types.AddRange(
-                                additionalBaseList.SelectAsReadOnlyList(
-                                    i => i.Syntax.WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) ) ) ) );
+                    // Give each new base type a leading space so the comma separator that AddRange
+                    // inserts renders as ", IIntroducedInterface" instead of ",IIntroducedInterface".
+                    // Also move the previously last base type's trailing trivia (typically an EndOfLine
+                    // before the open brace) to the new last base type, so the appended commas are not
+                    // split across a line break (e.g. ": Exception\n,IIntroducedInterface").
+                    var newBaseTypes = additionalBaseList.SelectAsArray(
+                        i => (BaseTypeSyntax) i.Syntax
+                            .WithLeadingTrivia( Space )
+                            .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) );
+
+                    var existingTypes = baseList.Types;
+                    var previousLast = existingTypes[^1];
+                    var trailingToMove = previousLast.GetTrailingTrivia();
+
+                    var combined = existingTypes.Replace( previousLast, previousLast.WithTrailingTrivia() );
+
+                    for ( var i = 0; i < newBaseTypes.Length - 1; i++ )
+                    {
+                        combined = combined.Add( newBaseTypes[i] );
+                    }
+
+                    combined = combined.Add( newBaseTypes[^1].WithTrailingTrivia( trailingToMove ) );
+
+                    node = (T) node.WithBaseList( baseList.WithTypes( combined ) );
                 }
             }
             else if ( baseList != null )
@@ -687,14 +706,43 @@ internal sealed partial class LinkerInjectionStep
                 {
                     var injectedInterfaces = this._transformationCollection.GetIntroducedInterfacesForTypeBuilder( typeBuilder );
 
-                    if ( injectedInterfaces.Count > 0 )
-                    {
-                        return (TypeDeclarationSyntax) typeDeclaration.AddBaseListTypes( injectedInterfaces.SelectAsArray( i => i.Syntax ) );
-                    }
-                    else
+                    if ( injectedInterfaces.Count == 0 )
                     {
                         return typeDeclaration;
                     }
+
+                    // Give each new base type a leading space so the comma separator that AddRange
+                    // inserts renders as ", IIntroducedInterface" instead of ",IIntroducedInterface".
+                    var newBaseTypes = injectedInterfaces.SelectAsArray( i => (BaseTypeSyntax) i.Syntax.WithLeadingTrivia( Space ) );
+
+                    var existingBaseList = typeDeclaration.BaseList;
+
+                    if ( existingBaseList == null || existingBaseList.Types.Count == 0 )
+                    {
+                        return (TypeDeclarationSyntax) typeDeclaration.AddBaseListTypes( newBaseTypes );
+                    }
+
+                    // The previously last base type carries the trailing trivia that sits between
+                    // the base list and the open brace (typically an EndOfLine). Move that trivia
+                    // to the new last base type so the appended commas/types are not split across
+                    // a line break (e.g. ": Exception\n,IIntroducedInterface" → ": Exception, IIntroducedInterface\n").
+                    var existingTypes = existingBaseList.Types;
+                    var previousLast = existingTypes[^1];
+                    var trailingToMove = previousLast.GetTrailingTrivia();
+
+                    var rebasedExisting = existingTypes.Replace( previousLast, previousLast.WithTrailingTrivia() );
+                    var newLast = newBaseTypes[^1].WithTrailingTrivia( trailingToMove );
+
+                    var combined = rebasedExisting;
+
+                    for ( var i = 0; i < newBaseTypes.Length - 1; i++ )
+                    {
+                        combined = combined.Add( newBaseTypes[i] );
+                    }
+
+                    combined = combined.Add( newLast );
+
+                    return (TypeDeclarationSyntax) typeDeclaration.WithBaseList( existingBaseList.WithTypes( combined ) );
                 }
             }
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.Rewriter.cs
@@ -439,30 +439,7 @@ internal sealed partial class LinkerInjectionStep
                 }
                 else
                 {
-                    // Give each new base type a leading space so the comma separator that AddRange
-                    // inserts renders as ", IIntroducedInterface" instead of ",IIntroducedInterface".
-                    // Also move the previously last base type's trailing trivia (typically an EndOfLine
-                    // before the open brace) to the new last base type, so the appended commas are not
-                    // split across a line break (e.g. ": Exception\n,IIntroducedInterface").
-                    var newBaseTypes = additionalBaseList.SelectAsArray(
-                        i => (BaseTypeSyntax) i.Syntax
-                            .WithLeadingTrivia( Space )
-                            .WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation ) );
-
-                    var existingTypes = baseList.Types;
-                    var previousLast = existingTypes[^1];
-                    var trailingToMove = previousLast.GetTrailingTrivia();
-
-                    var combined = existingTypes.Replace( previousLast, previousLast.WithTrailingTrivia() );
-
-                    for ( var i = 0; i < newBaseTypes.Length - 1; i++ )
-                    {
-                        combined = combined.Add( newBaseTypes[i] );
-                    }
-
-                    combined = combined.Add( newBaseTypes[^1].WithTrailingTrivia( trailingToMove ) );
-
-                    node = (T) node.WithBaseList( baseList.WithTypes( combined ) );
+                    node = (T) node.WithBaseList( AppendInjectedInterfaces( baseList, additionalBaseList, withGeneratedCodeAnnotation: true ) );
                 }
             }
             else if ( baseList != null )
@@ -711,40 +688,53 @@ internal sealed partial class LinkerInjectionStep
                         return typeDeclaration;
                     }
 
-                    // Give each new base type a leading space so the comma separator that AddRange
-                    // inserts renders as ", IIntroducedInterface" instead of ",IIntroducedInterface".
-                    var newBaseTypes = injectedInterfaces.SelectAsArray( i => (BaseTypeSyntax) i.Syntax.WithLeadingTrivia( Space ) );
-
                     var existingBaseList = typeDeclaration.BaseList;
 
                     if ( existingBaseList == null || existingBaseList.Types.Count == 0 )
                     {
-                        return (TypeDeclarationSyntax) typeDeclaration.AddBaseListTypes( newBaseTypes );
+                        return (TypeDeclarationSyntax) typeDeclaration.AddBaseListTypes( injectedInterfaces.SelectAsArray( i => i.Syntax ) );
                     }
 
-                    // The previously last base type carries the trailing trivia that sits between
-                    // the base list and the open brace (typically an EndOfLine). Move that trivia
-                    // to the new last base type so the appended commas/types are not split across
-                    // a line break (e.g. ": Exception\n,IIntroducedInterface" → ": Exception, IIntroducedInterface\n").
-                    var existingTypes = existingBaseList.Types;
-                    var previousLast = existingTypes[^1];
-                    var trailingToMove = previousLast.GetTrailingTrivia();
-
-                    var rebasedExisting = existingTypes.Replace( previousLast, previousLast.WithTrailingTrivia() );
-                    var newLast = newBaseTypes[^1].WithTrailingTrivia( trailingToMove );
-
-                    var combined = rebasedExisting;
-
-                    for ( var i = 0; i < newBaseTypes.Length - 1; i++ )
-                    {
-                        combined = combined.Add( newBaseTypes[i] );
-                    }
-
-                    combined = combined.Add( newLast );
-
-                    return (TypeDeclarationSyntax) typeDeclaration.WithBaseList( existingBaseList.WithTypes( combined ) );
+                    return typeDeclaration.WithBaseList( AppendInjectedInterfaces( existingBaseList, injectedInterfaces, withGeneratedCodeAnnotation: false ) );
                 }
             }
+        }
+
+        // Appends introduced interfaces to an existing base list. Without trivia adjustments, AddRange would
+        // insert the comma separator after the previously last base type's trailing trivia (typically the
+        // EndOfLine before the open brace), producing output like ": Exception\n,IIntroducedInterface".
+        // We give each new base type a leading space so the comma separator renders as ", IFoo", and we
+        // move the previously last type's trailing trivia onto the new last type to keep the EOL at the end
+        // of the base list. Reusing existingBaseList.WithTypes preserves the original colon token's trivia.
+        private static BaseListSyntax AppendInjectedInterfaces(
+            BaseListSyntax existingBaseList,
+            IReadOnlyList<LinkerInjectedInterface> injectedInterfaces,
+            bool withGeneratedCodeAnnotation )
+        {
+            var newBaseTypes = injectedInterfaces.SelectAsArray(
+                i =>
+                {
+                    var syntax = i.Syntax.WithRequiredLeadingTrivia( ElasticSpaceTriviaList );
+
+                    return withGeneratedCodeAnnotation
+                        ? syntax.WithGeneratedCodeAnnotation( FormattingAnnotations.SystemGeneratedCodeAnnotation )
+                        : syntax;
+                } );
+
+            var existingTypes = existingBaseList.Types;
+            var previousLast = existingTypes[^1];
+            var trailingToMove = previousLast.GetTrailingTrivia();
+
+            var combined = existingTypes.Replace( previousLast, previousLast.WithRequiredTrailingTrivia( default ) );
+
+            for ( var i = 0; i < newBaseTypes.Length - 1; i++ )
+            {
+                combined = combined.Add( newBaseTypes[i] );
+            }
+
+            combined = combined.Add( newBaseTypes[^1].WithRequiredTrailingTrivia( trailingToMove ) );
+
+            return existingBaseList.WithTypes( combined );
         }
 
         private MemberDeclarationSyntax InjectStatementsIntoMemberDeclaration(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
@@ -193,14 +193,16 @@ internal sealed partial class LinkerRewritingDriver
                             new InliningContextIdentifier( symbol.ToSemantic( semanticKind ) ) ) )
                     : null;
 
-            // For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-            // Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+            // For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+            // from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
             var (openBraceLeadingTrivia, openBraceTrailingTrivia, closeBraceLeadingTrivia, closeBraceTrailingTrivia) =
                 constructorDeclaration switch
                 {
                     { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                        (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                         GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                        (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, context ),
+                         StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, context ),
+                         StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, context ),
+                         StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, context )),
                     { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                         (arrowToken.LeadingTrivia.AddOptionalLineFeed( context ),
                          arrowToken.TrailingTrivia.AddOptionalLineFeed( context ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Constructors.cs
@@ -193,16 +193,19 @@ internal sealed partial class LinkerRewritingDriver
                             new InliningContextIdentifier( symbol.ToSemantic( semanticKind ) ) ) )
                     : null;
 
-            // For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-            // from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+            // For block bodies, the four brace slots are handled asymmetrically because the inlining mechanism
+            // (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and `}`-TRAILING trivia
+            // INSIDE the body via flattening (issue #838). We therefore use GetIndentationTrivia for those two
+            // slots to avoid duplication, and StripVerticalWhitespaceAndDocComments for `{`-TRAILING and
+            // `}`-LEADING which the inlining path does NOT preserve.
             var (openBraceLeadingTrivia, openBraceTrailingTrivia, closeBraceLeadingTrivia, closeBraceTrailingTrivia) =
                 constructorDeclaration switch
                 {
                     { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                        (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, context ),
+                        (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                          StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, context ),
                          StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, context ),
-                         StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, context )),
+                         GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                     { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                         (arrowToken.LeadingTrivia.AddOptionalLineFeed( context ),
                          arrowToken.TrailingTrivia.AddOptionalLineFeed( context ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.ConversionOperators.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.ConversionOperators.cs
@@ -72,8 +72,12 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( new IntermediateSymbolSemantic<IMethodSymbol>( symbol, semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -82,10 +86,10 @@ namespace Metalama.Framework.Engine.Linking
                     operatorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.ConversionOperators.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.ConversionOperators.cs
@@ -72,8 +72,8 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( new IntermediateSymbolSemantic<IMethodSymbol>( symbol, semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -82,8 +82,10 @@ namespace Metalama.Framework.Engine.Linking
                     operatorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Destructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Destructors.cs
@@ -74,8 +74,8 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( symbol.ToSemantic( semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -84,8 +84,10 @@ namespace Metalama.Framework.Engine.Linking
                     destructorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Destructors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Destructors.cs
@@ -74,8 +74,12 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( symbol.ToSemantic( semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -84,10 +88,10 @@ namespace Metalama.Framework.Engine.Linking
                     destructorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Events.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Events.cs
@@ -192,8 +192,8 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( semantic ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -202,8 +202,10 @@ namespace Metalama.Framework.Engine.Linking
                     accessorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, context ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, context ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, context ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, context )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( context ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( context ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Events.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Events.cs
@@ -192,8 +192,12 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( semantic ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -202,10 +206,10 @@ namespace Metalama.Framework.Engine.Linking
                     accessorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, context ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, context ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, context ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, context )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( context ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( context ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Indexers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Indexers.cs
@@ -221,8 +221,12 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( methodSymbol.ToSemantic( semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -231,10 +235,10 @@ namespace Metalama.Framework.Engine.Linking
                     accessorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, context ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, context ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, context ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, context )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( context ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( context ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Indexers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Indexers.cs
@@ -221,8 +221,8 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( methodSymbol.ToSemantic( semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -231,8 +231,10 @@ namespace Metalama.Framework.Engine.Linking
                     accessorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, context ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, context ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, context ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, context )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( context ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( context ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
@@ -125,8 +125,12 @@ namespace Metalama.Framework.Engine.Linking
                 }
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -135,10 +139,10 @@ namespace Metalama.Framework.Engine.Linking
                     methodDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Methods.cs
@@ -125,8 +125,8 @@ namespace Metalama.Framework.Engine.Linking
                 }
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -135,8 +135,10 @@ namespace Metalama.Framework.Engine.Linking
                     methodDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Operators.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Operators.cs
@@ -74,8 +74,12 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( symbol.ToSemantic( semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -84,10 +88,10 @@ namespace Metalama.Framework.Engine.Linking
                     operatorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Operators.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Operators.cs
@@ -74,8 +74,8 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( symbol.ToSemantic( semanticKind ) ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -84,8 +84,10 @@ namespace Metalama.Framework.Engine.Linking
                     operatorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -322,8 +322,12 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( semantic ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
-                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
+                //   * For block bodies, the four brace slots are handled asymmetrically because the inlining
+                //     mechanism (Inliner.Inline → AddTriviaFromIfNecessary) preserves source `{`-LEADING and
+                //     `}`-TRAILING trivia INSIDE the body via flattening (issue #838). We therefore use
+                //     GetIndentationTrivia for those two slots to avoid duplication, and
+                //     StripVerticalWhitespaceAndDocComments for `{`-TRAILING and `}`-LEADING which the
+                //     inlining path does NOT preserve.
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -332,10 +336,10 @@ namespace Metalama.Framework.Engine.Linking
                     accessorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ),
                              StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
                              StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
-                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
+                             GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.Properties.cs
@@ -322,8 +322,8 @@ namespace Metalama.Framework.Engine.Linking
                         new InliningContextIdentifier( semantic ) ) );
 
                 // Trivia processing:
-                //   * For block bodies, we preserve only whitespace trivia (for indentation) from the opening/closing brace.
-                //     Non-whitespace trivia (comments, pragmas) is already preserved in the linkedBody through GetSubstitutedBody (issue #838).
+                //   * For block bodies, we keep the indentation plus any user-authored trivia (comments, directives)
+                //     from the four brace slots. Trivia inside the body is preserved via linkedBody (issue #838).
                 //   * For expression bodied methods:
                 //       int Foo() <trivia_leading_equals_value> => <trivia_trailing_equals_value> <expression> <trivia_leading_semicolon> ; <trivia_trailing_semicolon>
                 //       int Foo() <trivia_leading_equals_value> { <trivia_trailing_equals_value> <linked_body> <trivia_leading_semicolon> } <trivia_trailing_semicolon>
@@ -332,8 +332,10 @@ namespace Metalama.Framework.Engine.Linking
                     accessorDeclaration switch
                     {
                         { Body: { OpenBraceToken: var openBraceToken, CloseBraceToken: var closeBraceToken } } =>
-                            (GetIndentationTrivia( openBraceToken.LeadingTrivia ), GetIndentationTrivia( openBraceToken.TrailingTrivia ),
-                             GetIndentationTrivia( closeBraceToken.LeadingTrivia ), GetIndentationTrivia( closeBraceToken.TrailingTrivia )),
+                            (StripVerticalWhitespaceAndDocComments( openBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( openBraceToken.TrailingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.LeadingTrivia, generationContext ),
+                             StripVerticalWhitespaceAndDocComments( closeBraceToken.TrailingTrivia, generationContext )),
                         { ExpressionBody.ArrowToken: var arrowToken, SemicolonToken: var semicolonToken } =>
                             (arrowToken.LeadingTrivia.AddOptionalLineFeed( generationContext ),
                              arrowToken.TrailingTrivia.AddOptionalLineFeed( generationContext ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
@@ -601,10 +601,71 @@ internal sealed partial class LinkerRewritingDriver
     internal bool ShouldGenerateSourceMember( ISymbol symbol ) => this.InjectionRegistry.IsOverrideTarget( symbol );
 
     /// <summary>
+    /// Builds trivia for a brace token of a rewritten member body by stripping <em>vertical
+    /// whitespace</em> (whitespace and end-of-lines) and <em>XML documentation comments</em> from
+    /// the original brace token's trivia, while keeping directives and ordinary comments intact.
+    /// The indentation of the original brace is appended at the end.
+    /// <para>
+    /// Why strip vertical whitespace: the linker controls vertical positioning via the containing
+    /// member's leading/trailing line feeds (see
+    /// <c>Metalama.Framework/docs/trivia-and-formatting.md</c>); copying original EOLs verbatim
+    /// double-spaces the output. Each surviving item is therefore re-framed with a fresh EOL.
+    /// </para>
+    /// <para>
+    /// Why strip XML doc comments: they attach to a <em>member declaration</em>, not to a brace
+    /// slot — surfacing one on a brace would attach it to the wrong scope.
+    /// </para>
+    /// <para>
+    /// Why keep directives and ordinary comments: directives must NEVER be dropped
+    /// (directive-preservation invariant — a missing <c>#endregion</c> or <c>#endif</c> breaks
+    /// compilation with CS1038/CS1028), and ordinary comments (<c>//</c>, <c>/* */</c>) are
+    /// user-authored content.
+    /// </para>
+    /// </summary>
+    private static SyntaxTriviaList StripVerticalWhitespaceAndDocComments(
+        SyntaxTriviaList originalTrivia,
+        SyntaxGenerationContext generationContext )
+    {
+        List<SyntaxTrivia>? result = null;
+
+        foreach ( var t in originalTrivia )
+        {
+            if ( ShouldKeep( t ) )
+            {
+                result ??= new List<SyntaxTrivia>();
+                result.Add( SyntaxFactory.EndOfLine( generationContext.EndOfLine ) );
+                result.Add( t );
+            }
+        }
+
+        var indentation = GetIndentationTrivia( originalTrivia );
+
+        if ( result == null )
+        {
+            return indentation;
+        }
+
+        result.Add( SyntaxFactory.EndOfLine( generationContext.EndOfLine ) );
+
+        return new SyntaxTriviaList( result ).AddRange( indentation );
+
+        static bool ShouldKeep( SyntaxTrivia t )
+            => !t.IsKind( SyntaxKind.WhitespaceTrivia )
+               && !t.IsKind( SyntaxKind.EndOfLineTrivia )
+               && !t.IsKind( SyntaxKind.SingleLineDocumentationCommentTrivia )
+               && !t.IsKind( SyntaxKind.MultiLineDocumentationCommentTrivia );
+    }
+
+    /// <summary>
     /// Gets only the indentation trivia (whitespace after the last line break) from a trivia list.
     /// This ensures we preserve indentation without duplicating comments, pragmas, or line breaks
     /// that are already in the inlined body (issue #838).
     /// </summary>
+    /// <remarks>
+    /// This deliberately does <em>not</em> preserve directives or comments. When salvaging those
+    /// is required (any brace slot whose original trivia may carry user-authored content), use
+    /// <see cref="StripVerticalWhitespaceAndDocComments" /> instead.
+    /// </remarks>
     private static SyntaxTriviaList GetIndentationTrivia( SyntaxTriviaList trivia )
     {
         // Gets only the indentation trivia (whitespace after the last line break).

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerRewritingDriver.cs
@@ -626,6 +626,8 @@ internal sealed partial class LinkerRewritingDriver
         SyntaxTriviaList originalTrivia,
         SyntaxGenerationContext generationContext )
     {
+        var indentation = GetIndentationTrivia( originalTrivia );
+
         List<SyntaxTrivia>? result = null;
 
         foreach ( var t in originalTrivia )
@@ -634,11 +636,10 @@ internal sealed partial class LinkerRewritingDriver
             {
                 result ??= new List<SyntaxTrivia>();
                 result.Add( SyntaxFactory.EndOfLine( generationContext.EndOfLine ) );
+                result.AddRange( indentation );
                 result.Add( t );
             }
         }
-
-        var indentation = GetIndentationTrivia( originalTrivia );
 
         if ( result == null )
         {
@@ -646,8 +647,9 @@ internal sealed partial class LinkerRewritingDriver
         }
 
         result.Add( SyntaxFactory.EndOfLine( generationContext.EndOfLine ) );
+        result.AddRange( indentation );
 
-        return new SyntaxTriviaList( result ).AddRange( indentation );
+        return new SyntaxTriviaList( result );
 
         static bool ShouldKeep( SyntaxTrivia t )
             => !t.IsKind( SyntaxKind.WhitespaceTrivia )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseBrokerCallSubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/EventRaiseBrokerCallSubstitution.cs
@@ -55,14 +55,15 @@ internal sealed class EventRaiseBrokerCallSubstitution : SyntaxNodeSubstitution
 
         var leadingTrivia = currentNode.GetLeadingTrivia();
 
-        var eventBrokerExpression =
+        ExpressionSyntax eventBrokerExpression =
             this._targetSemantic.Symbol.IsStatic
-                ? (ExpressionSyntax) SyntaxFactoryEx.SafeIdentifierName( currentEventBrokerInfo.EventBrokerFieldName )
+                ? SyntaxFactoryEx.SafeIdentifierName( currentEventBrokerInfo.EventBrokerFieldName )
                     .WithOptionalLeadingTrivia( leadingTrivia, substitutionContext.SyntaxGenerationContext )
                 : MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    ThisExpression( Token( TriviaList( leadingTrivia ), SyntaxKind.ThisKeyword, TriviaList() ) ),
-                    SyntaxFactoryEx.SafeIdentifierName( currentEventBrokerInfo.EventBrokerFieldName ) );
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        ThisExpression(),
+                        SyntaxFactoryEx.SafeIdentifierName( currentEventBrokerInfo.EventBrokerFieldName ) )
+                    .WithOptionalLeadingTrivia( leadingTrivia, substitutionContext.SyntaxGenerationContext );
 
         switch ( currentNode.Kind() )
         {
@@ -96,7 +97,7 @@ internal sealed class EventRaiseBrokerCallSubstitution : SyntaxNodeSubstitution
                         ArgumentList(
                             Token( SyntaxKind.OpenParenToken ),
                             SingletonSeparatedList( Argument( TupleExpression( invokeArguments ) ) ),
-                            Token( TriviaList(), SyntaxKind.CloseParenToken, trailingTrivia ) ) );
+                            Token( SyntaxKind.CloseParenToken ).WithOptionalTrailingTrivia( trailingTrivia, substitutionContext.SyntaxGenerationContext.Options ) ) );
 
             case SyntaxKind.InvocationExpression when currentNode is InvocationExpressionSyntax
             {
@@ -113,7 +114,7 @@ internal sealed class EventRaiseBrokerCallSubstitution : SyntaxNodeSubstitution
                         ArgumentList(
                             Token( SyntaxKind.OpenParenToken ),
                             SingletonSeparatedList( Argument( TupleExpression( SeparatedList( arguments ) ) ) ),
-                            Token( TriviaList(), SyntaxKind.CloseParenToken, trailingTrivia ) ) );
+                            Token( SyntaxKind.CloseParenToken ).WithOptionalTrailingTrivia( trailingTrivia, substitutionContext.SyntaxGenerationContext.Options ) ) );
 
             default:
                 throw new AssertionFailedException( $"Unsupported syntax: {currentNode}" );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ExpressionBodySubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ExpressionBodySubstitution.cs
@@ -78,7 +78,7 @@ namespace Metalama.Framework.Engine.Linking.Substitution
                             return
                                 syntaxGenerator.FormattedBlock(
                                         ReturnStatement(
-                                            Token( arrowExpressionClause.Expression.GetLeadingTrivia(), SyntaxKind.ReturnKeyword, TriviaList( Space ) ),
+                                            Token( arrowExpressionClause.Expression.GetLeadingTrivia(), SyntaxKind.ReturnKeyword, SyntaxFactoryEx.ElasticSpaceTriviaList ),
                                             arrowExpressionClause.Expression,
                                             Token(
                                                 TriviaList(),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
@@ -130,6 +130,8 @@ public class DefaultProjectOptions : IProjectOptions
 
     public virtual bool ValidateRunTimeCode => false;
 
+    public virtual bool VerifyOutputCode => false;
+
     // IProjectOptions is currently not used as a dictionary key, so we can throw here.
     public sealed override int GetHashCode() => throw new NotImplementedException();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
@@ -242,4 +242,11 @@ public interface IProjectOptions : IProjectService, IEquatable<IProjectOptions>
     /// When <c>true</c>, the validator checks that run-time code does not reference compile-time-only declarations.
     /// </summary>
     bool ValidateRunTimeCode { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether generated output code should be verified for syntax correctness.
+    /// When <c>true</c>, the output code will be parsed as a syntax tree and checked for errors.
+    /// This helps detect issues like missing whitespace that can cause syntax errors.
+    /// </summary>
+    bool VerifyOutputCode { get; }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
@@ -187,6 +187,9 @@ public partial class MSBuildProjectOptions : DefaultProjectOptions
     public override bool ValidateRunTimeCode => this.GetBooleanOption( MSBuildPropertyNames.MetalamaValidateRunTimeCode );
 
     [Memo]
+    public override bool VerifyOutputCode => this.GetBooleanOption( MSBuildPropertyNames.MetalamaVerifyOutputCode );
+
+    [Memo]
     public override ImmutableArray<string> SourceGeneratorAttributes => this.GetListOption( MSBuildPropertyNames.MetalamaSourceGeneratorAttributes );
 
     public override bool AvoidLockingExtensionAssemblies => this.GetBooleanOption( MSBuildPropertyNames.MetalamaAvoidLockingExtensionAssemblies );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
@@ -55,6 +55,7 @@ public static class MSBuildPropertyNames
     public const string MetalamaAssemblyLocatorSalt = nameof(MetalamaAssemblyLocatorSalt);
     public const string MetalamaValidateRunTimeCode = nameof(MetalamaValidateRunTimeCode);
     public const string TargetFrameworks = nameof(TargetFrameworks);
+    public const string MetalamaVerifyOutputCode = nameof(MetalamaVerifyOutputCode);
 
     public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
         MetalamaBuildTouchFile,
@@ -96,5 +97,6 @@ public static class MSBuildPropertyNames
         MSBuildBinPath,
         MetalamaAssemblyLocatorSalt,
         MetalamaValidateRunTimeCode,
-        TargetFrameworks );
+        TargetFrameworks,
+        MetalamaVerifyOutputCode );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
@@ -116,6 +116,8 @@ public abstract class ProjectOptionsWrapper : IProjectOptions
 
     public virtual bool ValidateRunTimeCode => this.Wrapped.ValidateRunTimeCode;
 
+    public virtual bool VerifyOutputCode => this.Wrapped.VerifyOutputCode;
+
     public sealed override int GetHashCode() => throw new NotImplementedException();
 
     public sealed override bool Equals( object? obj ) => this.Equals( obj as IProjectOptions );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
@@ -322,7 +322,13 @@ public class CompileTimeAspectPipeline : AspectPipeline
                         diagnosticAdder.Report( diagnostic );
                     }
 
-                    return default;
+                    // When dumping of transformed files is requested, keep flowing the transformations to
+                    // Metalama.Compiler so that it writes the failing trees to disk for inspection.
+                    // The reported diagnostics still cause the build to fail.
+                    if ( this.ProjectOptions.WriteTransformedFiles != true && this.ProjectOptions.DebugTransformedCode != true )
+                    {
+                        return default;
+                    }
                 }
             }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
@@ -308,6 +308,24 @@ public class CompileTimeAspectPipeline : AspectPipeline
             var resultingCompilation =
                 (PartialCompilation) await RunTimeAssemblyRewriter.RewriteAsync( resultPartialCompilation, configuration.ServiceProvider );
 
+            // Verify output code if requested.
+            if ( this.ProjectOptions.VerifyOutputCode )
+            {
+                var verifier = new SyntaxTreeVerifier( configuration.ServiceProvider );
+
+                var (isSuccessful, syntaxDiagnostics) = await verifier.VerifyAsync( resultingCompilation.Compilation, cancellationToken );
+
+                if ( !isSuccessful )
+                {
+                    foreach ( var diagnostic in syntaxDiagnostics! )
+                    {
+                        diagnosticAdder.Report( diagnostic );
+                    }
+
+                    return default;
+                }
+            }
+
             var syntaxTreeTransformations = resultingCompilation.ToTransformations();
 
             return new CompileTimeAspectPipelineResult(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/PreviewAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/PreviewAspectPipeline.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Metalama.Framework.Engine.Pipeline.DesignTime;
 
-public sealed class PreviewAspectPipeline : AspectPipeline
+public class PreviewAspectPipeline : AspectPipeline
 {
     public PreviewAspectPipeline( ProjectServiceProvider serviceProvider, ExecutionScenario executionScenario )
         : base( serviceProvider, executionScenario ) { }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -626,7 +626,7 @@ public sealed partial class ContextualSyntaxGenerator
             typeSyntax = (TypeSyntax) new RemoveReferenceNullableAnnotationsRewriter( type ).Visit( typeSyntax ).AssertNotNull();
         }
 
-        if ( this.Options.TriviaMatters )
+        if ( this.Options.WillBeTextualized )
         {
             // Just calling NormalizeWhitespaceIfNecessary here produces ugly whitespace, e.g. "typeof(global::System.Int32[, ])".
             typeSyntax = (TypeSyntax) new NormalizeSpaceRewriter( this.SyntaxGenerationContext.EndOfLine ).Visit( typeSyntax ).AssertNotNull();
@@ -644,7 +644,7 @@ public sealed partial class ContextualSyntaxGenerator
             typeSyntax = (ExpressionSyntax) new RemoveReferenceNullableAnnotationsRewriter( type ).Visit( typeSyntax ).AssertNotNull();
         }
 
-        if ( this.Options.TriviaMatters )
+        if ( this.Options.WillBeTextualized )
         {
             // Just calling NormalizeWhitespaceIfNecessary here produces ugly whitespace, e.g. "typeof(global::System.Int32[, ])".
             typeSyntax = (ExpressionSyntax) new NormalizeSpaceRewriter( this.SyntaxGenerationContext.EndOfLine ).Visit( typeSyntax ).AssertNotNull();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGenerationContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGenerationContext.cs
@@ -63,7 +63,7 @@ public sealed class SyntaxGenerationContext
     internal SyntaxTrivia ElasticEndOfLineTrivia => SyntaxFactory.ElasticEndOfLine( this.EndOfLine );
 
     [Memo]
-    public SyntaxTriviaList OptionalElasticEndOfLineTriviaList => this.Options.TriviaMatters ? new SyntaxTriviaList( this.ElasticEndOfLineTrivia ) : default;
+    public SyntaxTriviaList OptionalElasticEndOfLineTriviaList => this.Options.WillBeTextualized ? new SyntaxTriviaList( this.ElasticEndOfLineTrivia ) : default;
 
     [Memo]
     public SyntaxTriviaList ElasticEndOfLineTriviaList => new( this.ElasticEndOfLineTrivia );
@@ -73,7 +73,7 @@ public sealed class SyntaxGenerationContext
 
     [Memo]
     internal SyntaxTriviaList TwoElasticEndOfLinesTriviaList
-        => this.Options.TriviaMatters ? new SyntaxTriviaList( this.ElasticEndOfLineTrivia, this.ElasticEndOfLineTrivia ) : default;
+        => this.Options.WillBeTextualized ? new SyntaxTriviaList( this.ElasticEndOfLineTrivia, this.ElasticEndOfLineTrivia ) : default;
 
     private SyntaxGenerationContext(
         bool isNullOblivious,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGenerationOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGenerationOptions.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.Engine.Formatting;
 using Metalama.Framework.Services;
+using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.SyntaxGeneration;
 
@@ -11,12 +12,35 @@ public sealed record SyntaxGenerationOptions : IProjectService
 {
     private readonly CodeFormattingOptions _codeFormattingOptions;
 
-    // We must normalize whitespace even if we later run the formatter because the formatter requires existing whitespace.
-    internal bool NormalizeWhitespace => this._codeFormattingOptions != CodeFormattingOptions.None;
+    /// <summary>
+    /// Gets a value indicating whether the syntax tree produced under these options is
+    /// intended to be textualized to C# source. When <c>false</c> (i.e.
+    /// <see cref="CodeFormattingOptions.None"/>), the generator skips emission of elastic
+    /// spacing trivia and <c>NormalizeWhitespace</c> calls; the resulting tree is
+    /// therefore not safe to <see cref="SyntaxNode.ToFullString"/>, because tokens may be
+    /// left adjacent with no separator. Directive trivia is always preserved regardless
+    /// of this flag.
+    /// </summary>
+    /// <remarks>
+    /// This predicate also gates whether <c>NormalizeWhitespace(elasticTrivia: true)</c>
+    /// is run during generation. Normalization is required whenever the tree will be
+    /// textualized (including in <see cref="CodeFormattingOptions.Formatted"/> mode),
+    /// because Roslyn's <c>Formatter</c> reflows only elastic trivia and preserves
+    /// non-elastic trivia verbatim — it does not synthesize new trivia between tokens
+    /// that have none. <c>NormalizeWhitespace(elasticTrivia: true)</c> is what sprays
+    /// those elastic markers through the tree.
+    /// </remarks>
+    internal bool WillBeTextualized => this._codeFormattingOptions != CodeFormattingOptions.None;
 
-    internal bool TriviaMatters => this._codeFormattingOptions != CodeFormattingOptions.None;
-
-    internal bool AddFormattingAnnotations => this._codeFormattingOptions == CodeFormattingOptions.Formatted;
+    /// <summary>
+    /// Gets a value indicating whether the syntax tree produced under these options will
+    /// be post-processed by the <c>CodeFormatter</c> (simplification + reformat).
+    /// When <c>true</c>, generation attaches <c>Simplifier.Annotation</c> to candidate
+    /// nodes so the post-pass can reduce redundant namespace qualifications, casts, and
+    /// similar over-specifications. Only <c>true</c> for
+    /// <see cref="CodeFormattingOptions.Formatted"/>.
+    /// </summary>
+    internal bool WillBeFormatted => this._codeFormattingOptions == CodeFormattingOptions.Formatted;
 
     internal SyntaxGenerationOptions( CodeFormattingOptions options )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.AbstractGeneratorVisitor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/SyntaxGeneratorForIType.AbstractGeneratorVisitor.cs
@@ -29,14 +29,14 @@ internal sealed partial class SyntaxGeneratorForIType
         {
             var generationOptions = this.SyntaxGenerator._generationOptions;
 
-            if ( generationOptions.TriviaMatters )
+            if ( generationOptions.WillBeTextualized )
             {
                 syntax = syntax
                     .WithRequiredLeadingTrivia( syntax.GetLeadingTrivia().Insert( 0, SyntaxFactory.ElasticMarker ) )
                     .WithRequiredTrailingTrivia( syntax.GetTrailingTrivia().Add( SyntaxFactory.ElasticMarker ) );
             }
 
-            if ( generationOptions.AddFormattingAnnotations )
+            if ( generationOptions.WillBeFormatted )
             {
                 syntax = syntax.WithAdditionalAnnotations( SymbolAnnotation.Create( symbol ) );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxExtensions.cs
@@ -156,7 +156,7 @@ public static class SyntaxExtensions
     internal static TNode NormalizeWhitespaceIfNecessary<TNode>( this TNode node, SyntaxGenerationContext context )
         where TNode : SyntaxNode
     {
-        if ( !context.Options.NormalizeWhitespace )
+        if ( !context.Options.WillBeTextualized )
         {
             return node;
         }
@@ -173,7 +173,7 @@ public static class SyntaxExtensions
     internal static TNode WithSimplifierAnnotationIfNecessary<TNode>( this TNode node, SyntaxGenerationOptions options )
         where TNode : SyntaxNode
     {
-        if ( !options.AddFormattingAnnotations )
+        if ( !options.WillBeFormatted )
         {
             return node;
         }
@@ -183,7 +183,9 @@ public static class SyntaxExtensions
 
     private static bool ContainsDirectives( this SyntaxTriviaList trivias )
     {
-        // PERF: Using trivias.Any( t => t.IsDirective ) would allocate, since SyntaxTriviaList is a struct.
+        // PERF: `trivias.Any(t => t.IsDirective)` would allocate — the predicate materializes
+        // a delegate, and calling `Any` via IEnumerable<T> boxes the struct enumerator.
+        // A hand-rolled foreach over `SyntaxTriviaList` uses its struct enumerator directly.
 
         foreach ( var trivia in trivias )
         {
@@ -201,7 +203,7 @@ public static class SyntaxExtensions
     internal static TNode WithOptionalLeadingTrivia<TNode>( this TNode node, SyntaxTriviaList leadingTrivia, SyntaxGenerationOptions options )
         where TNode : SyntaxNode
     {
-        if ( !options.TriviaMatters && !leadingTrivia.ContainsDirectives() )
+        if ( !options.WillBeTextualized && !leadingTrivia.ContainsDirectives() )
         {
             return node;
         }
@@ -231,7 +233,7 @@ public static class SyntaxExtensions
         SyntaxGenerationContext context )
         where TNode : SyntaxNode
     {
-        if ( !context.Options.TriviaMatters )
+        if ( !context.Options.WillBeTextualized )
         {
             return node;
         }
@@ -250,7 +252,7 @@ public static class SyntaxExtensions
         SyntaxGenerationContext context )
         where TNode : SyntaxNode
     {
-        if ( !context.Options.TriviaMatters )
+        if ( !context.Options.WillBeTextualized )
         {
             return node;
         }
@@ -264,7 +266,7 @@ public static class SyntaxExtensions
         SyntaxGenerationContext context )
         where TNode : SyntaxNode
     {
-        if ( !context.Options.TriviaMatters )
+        if ( !context.Options.WillBeTextualized )
         {
             return node;
         }
@@ -276,7 +278,7 @@ public static class SyntaxExtensions
         this SyntaxToken node,
         SyntaxGenerationContext context )
     {
-        if ( !context.Options.TriviaMatters )
+        if ( !context.Options.WillBeTextualized )
         {
             return node;
         }
@@ -310,7 +312,7 @@ public static class SyntaxExtensions
         this SyntaxTriviaList list,
         SyntaxGenerationContext context )
     {
-        if ( !context.Options.NormalizeWhitespace )
+        if ( !context.Options.WillBeTextualized )
         {
             return list;
         }
@@ -325,7 +327,7 @@ public static class SyntaxExtensions
     internal static TNode WithOptionalTrailingTrivia<TNode>( this TNode node, SyntaxTriviaList trailingTrivia, SyntaxGenerationOptions options )
         where TNode : SyntaxNode
     {
-        if ( !options.TriviaMatters && !trailingTrivia.ContainsDirectives() )
+        if ( !options.WillBeTextualized && !trailingTrivia.ContainsDirectives() )
         {
             return node;
         }
@@ -340,7 +342,7 @@ public static class SyntaxExtensions
     // Resharper disable once UnusedMember.Global
     internal static SyntaxToken WithOptionalTrailingTrivia( this SyntaxToken token, SyntaxTriviaList trailingTrivia, SyntaxGenerationOptions options )
     {
-        if ( !options.TriviaMatters && !trailingTrivia.ContainsDirectives() )
+        if ( !options.WillBeTextualized && !trailingTrivia.ContainsDirectives() )
         {
             return token;
         }
@@ -380,7 +382,7 @@ public static class SyntaxExtensions
         SyntaxGenerationOptions options )
         where TNode : SyntaxNode
     {
-        if ( !options.TriviaMatters && !leadingTrivia.ContainsDirectives() && !trailingTrivia.ContainsDirectives() )
+        if ( !options.WillBeTextualized && !leadingTrivia.ContainsDirectives() && !trailingTrivia.ContainsDirectives() )
         {
             return node;
         }
@@ -397,13 +399,13 @@ public static class SyntaxExtensions
         => node.WithTriviaFromIfNecessary( fromNode, context.Options );
 
     internal static bool ShouldBePreserved( this SyntaxTriviaList trivia, SyntaxGenerationOptions options )
-        => options.TriviaMatters || trivia.ContainsDirectives();
+        => options.WillBeTextualized || trivia.ContainsDirectives();
 
     internal static bool ShouldBePreserved( this IEnumerable<SyntaxTrivia> trivia, SyntaxGenerationOptions options )
-        => options.TriviaMatters || trivia.Any( t => t.IsDirective );
+        => options.WillBeTextualized || trivia.Any( t => t.IsDirective );
 
     internal static bool ShouldTriviaBePreserved( this SyntaxNodeOrToken nodeOrToken, SyntaxGenerationOptions options )
-        => options.TriviaMatters || nodeOrToken.ContainsDirectives;
+        => options.WillBeTextualized || nodeOrToken.ContainsDirectives;
 
     internal static TNode AddTriviaFromIfNecessary<TNode>( this TNode node, SyntaxNode fromNode, SyntaxGenerationOptions options )
         where TNode : SyntaxNode
@@ -411,7 +413,7 @@ public static class SyntaxExtensions
         var fromLeading = fromNode.GetLeadingTrivia();
         var fromTrailing = fromNode.GetTrailingTrivia();
 
-        if ( !options.TriviaMatters && !fromLeading.ContainsDirectives() && !fromTrailing.ContainsDirectives() )
+        if ( !options.WillBeTextualized && !fromLeading.ContainsDirectives() && !fromTrailing.ContainsDirectives() )
         {
             return node;
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SyntaxTreeVerifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SyntaxTreeVerifier.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.Utilities.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Metalama.Framework.Engine.Utilities;
+
+/// <summary>
+/// Provides utilities for verifying syntax trees.
+/// </summary>
+internal sealed class SyntaxTreeVerifier
+{
+    private readonly IConcurrentTaskRunner _concurrentTaskRunner;
+
+    public SyntaxTreeVerifier( ProjectServiceProvider serviceProvider )
+    {
+        this._concurrentTaskRunner = serviceProvider.GetRequiredService<IConcurrentTaskRunner>();
+    }
+
+    /// <summary>
+    /// Verifies that a compilation's syntax trees can be round-trip parsed without errors.
+    /// This checks for "hidden" problems where the text of the source code appears valid,
+    /// but reparsing it reveals syntax errors (e.g., missing whitespace).
+    /// </summary>
+    /// <param name="compilation">The compilation to verify.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A tuple containing a success flag and any diagnostics found. If successful, diagnostics will be null.</returns>
+    public async Task<(bool isSuccessful, DiagnosticBag? diagnostics)> VerifyAsync(
+        Compilation compilation,
+        CancellationToken cancellationToken )
+    {
+        var diagnosticBag = new DiagnosticBag();
+
+        // Process all syntax trees in parallel
+        await this._concurrentTaskRunner.RunConcurrentlyAsync(
+            compilation.SyntaxTrees,
+            syntaxTree => VerifySyntaxTree( syntaxTree, diagnosticBag ),
+            cancellationToken );
+
+        if ( diagnosticBag.Count == 0 )
+        {
+            return (true, null);
+        }
+        else
+        {
+            return (false, diagnosticBag);
+        }
+    }
+
+    private static void VerifySyntaxTree( SyntaxTree syntaxTree, DiagnosticBag diagnostics )
+    {
+        SyntaxNode parsedFromText;
+
+        try
+        {
+            // Parse the syntax tree's text representation back into a syntax tree
+            parsedFromText = CSharpSyntaxTree.ParseText(
+                    syntaxTree.GetRoot().ToString(),
+                    path: syntaxTree.FilePath,
+                    encoding: Encoding.UTF8,
+                    options: (CSharpParseOptions) syntaxTree.Options )
+                .GetRoot();
+        }
+        catch ( Exception ex )
+        {
+            // If parsing throws an exception, create a diagnostic with detailed information
+            var message =
+                $"Failed to parse generated code for file '{syntaxTree.FilePath}'. " +
+                $"This indicates a code generation issue where the generated syntax tree produces invalid text. " +
+                $"Exception: {ex.GetType().Name}: {ex.Message}";
+
+            var diagnostic = Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "LAMA9999",
+                    "Generated code parse error",
+                    message,
+                    "Metalama.Framework",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true ),
+                Location.None );
+
+            diagnostics.Report( diagnostic );
+
+            return;
+        }
+
+        // Check for syntax errors in the parsed tree
+        foreach ( var diagnostic in parsedFromText.GetDiagnostics() )
+        {
+            if ( diagnostic.Severity == DiagnosticSeverity.Error )
+            {
+                // Find the problematic node for debugging
+                var node = parsedFromText.FindNode( diagnostic.Location.SourceSpan );
+                var nodeText = node.ToString();
+
+                // Truncate the problematic code if too long
+                if ( nodeText.Length > 100 )
+                {
+                    nodeText = nodeText.Substring( 0, 97 ) + "...";
+                }
+
+                // Create an enhanced diagnostic with context
+                var enhancedMessage =
+                    $"Syntax error in generated code for file '{syntaxTree.FilePath}': {diagnostic.GetMessage( System.Globalization.CultureInfo.InvariantCulture )}. " +
+                    $"Location: Line {diagnostic.Location.GetLineSpan().StartLinePosition.Line + 1}, " +
+                    $"Column {diagnostic.Location.GetLineSpan().StartLinePosition.Character + 1}. " +
+                    $"Problematic code: '{nodeText}'";
+
+                var enhancedDiagnostic = Diagnostic.Create(
+                    new DiagnosticDescriptor(
+                        diagnostic.Id,
+                        "Syntax error in generated code",
+                        enhancedMessage,
+                        diagnostic.Descriptor.Category,
+                        DiagnosticSeverity.Error,
+                        isEnabledByDefault: true ),
+                    diagnostic.Location );
+
+                diagnostics.Report( enhancedDiagnostic );
+            }
+        }
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SyntaxTreeVerifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SyntaxTreeVerifier.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Engine.Utilities.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,23 +80,10 @@ internal sealed class SyntaxTreeVerifier
         }
         catch ( Exception ex )
         {
-            // If parsing throws an exception, create a diagnostic with detailed information
-            var message =
-                $"Failed to parse generated code for file '{syntaxTree.FilePath}'. " +
-                $"This indicates a code generation issue where the generated syntax tree produces invalid text. " +
-                $"Exception: {ex.GetType().Name}: {ex.Message}";
-
-            var diagnostic = Diagnostic.Create(
-                new DiagnosticDescriptor(
-                    "LAMA9999",
-                    "Generated code parse error",
-                    message,
-                    "Metalama.Framework",
-                    DiagnosticSeverity.Error,
-                    isEnabledByDefault: true ),
-                Location.None );
-
-            diagnostics.Report( diagnostic );
+            diagnostics.Report(
+                GeneralDiagnosticDescriptors.GeneratedCodeParseFailed.CreateRoslynDiagnostic(
+                    null,
+                    (syntaxTree.FilePath, ex.GetType().Name, ex.Message) ) );
 
             return;
         }
@@ -115,24 +103,16 @@ internal sealed class SyntaxTreeVerifier
                     nodeText = nodeText.Substring( 0, 97 ) + "...";
                 }
 
-                // Create an enhanced diagnostic with context
-                var enhancedMessage =
-                    $"Syntax error in generated code for file '{syntaxTree.FilePath}': {diagnostic.GetMessage( System.Globalization.CultureInfo.InvariantCulture )}. " +
-                    $"Location: Line {diagnostic.Location.GetLineSpan().StartLinePosition.Line + 1}, " +
-                    $"Column {diagnostic.Location.GetLineSpan().StartLinePosition.Character + 1}. " +
-                    $"Problematic code: '{nodeText}'.";
+                var lineSpan = diagnostic.Location.GetLineSpan();
 
-                var enhancedDiagnostic = Diagnostic.Create(
-                    new DiagnosticDescriptor(
-                        diagnostic.Id,
-                        "Syntax error in generated code",
-                        enhancedMessage,
-                        diagnostic.Descriptor.Category,
-                        DiagnosticSeverity.Error,
-                        isEnabledByDefault: true ),
-                    diagnostic.Location );
-
-                diagnostics.Report( enhancedDiagnostic );
+                diagnostics.Report(
+                    GeneralDiagnosticDescriptors.GeneratedCodeSyntaxError.CreateRoslynDiagnostic(
+                        diagnostic.Location,
+                        (syntaxTree.FilePath,
+                         diagnostic.GetMessage( CultureInfo.InvariantCulture ),
+                         lineSpan.StartLinePosition.Line + 1,
+                         lineSpan.StartLinePosition.Character + 1,
+                         nodeText) ) );
             }
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SyntaxTreeVerifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/SyntaxTreeVerifier.cs
@@ -60,11 +60,18 @@ internal sealed class SyntaxTreeVerifier
     {
         SyntaxNode parsedFromText;
 
+        // Use ToFullString(), not ToString(): ToString() drops the leading trivia of the first token
+        // and the trailing trivia of the last token. For a source file that starts with a directive
+        // like '#if BENCHMARK' (held as leading trivia of the first 'using' token), ToString() would
+        // strip the opening directive while leaving the closing '#endif' (which lives as leading trivia
+        // of the EOF token), producing a spurious CS1028 'Unexpected preprocessor directive' on reparse.
+        var sourceText = syntaxTree.GetRoot().ToFullString();
+
         try
         {
             // Parse the syntax tree's text representation back into a syntax tree
             parsedFromText = CSharpSyntaxTree.ParseText(
-                    syntaxTree.GetRoot().ToString(),
+                    sourceText,
                     path: syntaxTree.FilePath,
                     encoding: Encoding.UTF8,
                     options: (CSharpParseOptions) syntaxTree.Options )
@@ -113,7 +120,7 @@ internal sealed class SyntaxTreeVerifier
                     $"Syntax error in generated code for file '{syntaxTree.FilePath}': {diagnostic.GetMessage( System.Globalization.CultureInfo.InvariantCulture )}. " +
                     $"Location: Line {diagnostic.Location.GetLineSpan().StartLinePosition.Line + 1}, " +
                     $"Column {diagnostic.Location.GetLineSpan().StartLinePosition.Character + 1}. " +
-                    $"Problematic code: '{nodeText}'";
+                    $"Problematic code: '{nodeText}'.";
 
                 var enhancedDiagnostic = Diagnostic.Create(
                     new DiagnosticDescriptor(

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
@@ -41,6 +41,7 @@
         <CompilerVisibleProperty Include="MetalamaAssemblyLocatorSalt"/>
         <CompilerVisibleProperty Include="MetalamaValidateRunTimeCode"/>
         <CompilerVisibleProperty Include="TargetFrameworks"/>
+        <CompilerVisibleProperty Include="MetalamaVerifyOutputCode"/>
     </ItemGroup>
 
     <!-- More properties are already exported by Metalama.Compiler and don't need to be exported a second time. -->

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/Formatting/CodeFormattingOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/Formatting/CodeFormattingOptions.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.Formatting;
 
@@ -18,7 +19,11 @@ public enum CodeFormattingOptions
     Default,
 
     /// <summary>
-    /// No text output is required, only a syntax tree.
+    /// The resulting tree is not safe to textualize. Only a syntax tree is produced:
+    /// tokens may be left adjacent with no separator trivia, so
+    /// <see cref="SyntaxNode.ToFullString"/> generally will not round-trip through the
+    /// parser. Use this only for AST-level analysis (for example, test validation of
+    /// well-formedness).
     /// </summary>
     None,
 

--- a/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestContextOptions.cs
+++ b/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestContextOptions.cs
@@ -98,6 +98,13 @@ public record TestContextOptions
     internal bool ValidateRunTimeCode { get; init; } = true;
 
     /// <summary>
+    /// Gets a value indicating whether generated output code should be verified for syntax correctness.
+    /// When <c>true</c>, the output code will be parsed as a syntax tree and checked for errors.
+    /// This helps detect issues like missing whitespace that can cause syntax errors.
+    /// </summary>
+    internal bool VerifyOutputCode { get; init; }
+
+    /// <summary>
     /// Gets the list of extension types given explicitly as types using <see cref="ITestExtensionCollector"/>,
     /// typically through the unit test framework.
     /// </summary>

--- a/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestProjectOptions.cs
@@ -115,6 +115,8 @@ internal sealed class TestProjectOptions : DefaultProjectOptions, IDisposable
 
     public override bool ValidateRunTimeCode => this.TestContextOptions.ValidateRunTimeCode;
 
+    public override bool VerifyOutputCode => this.TestContextOptions.VerifyOutputCode;
+
     public override ImmutableArray<TargetedAssemblyReference> CompileTimeAssemblies
         => this.TestContextOptions.CompileTimeAssemblies.Select( TargetedAssemblyReference.FromPath ).ToImmutableArray();
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/MethodOverride.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/MethodOverride.t.cs
@@ -5,6 +5,7 @@ public class Target
   [Aspect2]
   public void Foo()
   {
+    // Comment after Foo opening brace.
     // Comment before Foo opening brace.
     // Comment before Aspect1.
     Console.WriteLine("Aspect1");
@@ -17,12 +18,14 @@ public class Target
   // Comment after Aspect1.
   // Comment after Foo closing brace.
   // Comment after Aspect2.
+  // Comment before Foo closing brace.
   } // Comment after Foo.
   // Comment before Bar.
   [Aspect1]
   [Aspect2]
   public int Bar()
   {
+    // Comment after Bar opening brace.
     // Comment before Bar opening brace.
     // Comment before Aspect1.
     Console.WriteLine("Aspect1");
@@ -37,5 +40,6 @@ public class Target
   // Comment after Aspect2.
   // Comment after Aspect1.
   // Comment after Bar closing brace.
+  // Comment before Bar closing brace.
   } // Comment after Bar.
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/PropertyAccessorOverride.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/PropertyAccessorOverride.t.cs
@@ -8,6 +8,7 @@ public class Target
     // Before Foo.get.
     get // After Foo.get keyword.
     {
+      // After Foo.get opening brace.
       // Before Foo.get opening brace.
       // Comment before Aspect1.
       Console.WriteLine("Aspect1");
@@ -20,9 +21,11 @@ public class Target
     // Comment after Aspect2.
     // Comment after Aspect1.
     // After Foo.get closing brace.
+    // Before Foo.get closing brace.
     } // After Foo.get and before Foo.set.
     set // After Foo.set keyword.
     {
+      // After Foo.set opening brace.
       // Before Foo.set opening brace.
       // Comment before Aspect1.
       Console.WriteLine("Aspect1");
@@ -34,6 +37,7 @@ public class Target
     // Comment after Aspect1.
     // After Foo.set closing brace.
     // Comment after Aspect2.
+    // Before Foo.set closing brace.
     } // Before Foo closing brace.
   } // After Foo closing brace.
   private int _bar;
@@ -94,7 +98,7 @@ public class Target
       // Comment mid Aspect2.
       // Before Baz.get expression.
       return // Before Baz.get expression.
- 42 // After Baz.get expression.
+      42 // After Baz.get expression.
       ; // After Baz.get expression.
     // Comment after Aspect2.
     // Comment after Aspect1.
@@ -139,7 +143,7 @@ public class Target
       // Comment mid Aspect2.
       // Before Qux.get expression.
       return // Before Qux.get expression.
- 42 // After Qux.get expression.
+      42 // After Qux.get expression.
       ; // After Qux.get expression.
     // Comment after Aspect2.
     // Comment after Aspect1.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/PropertyOverride.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Formatting/PropertyOverride.t.cs
@@ -8,6 +8,7 @@ public class Target
     // Before Foo.get.
     get // After Foo.get keyword.
     {
+      // After Foo.get opening brace.
       // Before Foo.get opening brace.
       // Comment before Aspect1.
       Console.WriteLine("Aspect1");
@@ -20,9 +21,11 @@ public class Target
     // Comment after Aspect2.
     // Comment after Aspect1.
     // After Foo.get closing brace.
+    // Before Foo.get closing brace.
     } // After Foo.get and before Foo.set.
     set // After Foo.set keyword.
     {
+      // After Foo.set opening brace.
       // Before Foo.set opening brace.
       // Comment before Aspect1.
       Console.WriteLine("Aspect1");
@@ -34,6 +37,7 @@ public class Target
     // Comment after Aspect2.
     // Comment after Aspect1.
     // After Foo.set closing brace.
+    // Before Foo.set closing brace.
     } // Before Foo closing brace.
   } // After Foo closing brace.
   private int _bar;
@@ -94,7 +98,7 @@ public class Target
       // Comment mid Aspect2.
       // Before Baz.get expression.
       return // Before Baz.get expression.
- 42 // After Baz.get expression.
+      42 // After Baz.get expression.
       ; // After Baz.get expression.
     // Comment after Aspect2.
     // Comment after Aspect1.
@@ -139,7 +143,7 @@ public class Target
       // Comment mid Aspect2.
       // Before Qux.get expression.
       return // Before Qux.get expression.
- 42 // After Qux.get expression.
+      42 // After Qux.get expression.
       ; // After Qux.get expression.
     // Comment after Aspect2.
     // Comment after Aspect1.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/VerifyOutputCodeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/VerifyOutputCodeTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Pipeline.CompileTime;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Tests for the VerifyOutputCode option that validates generated syntax trees.
+/// </summary>
+public sealed class VerifyOutputCodeTests : UnitTestClass
+{
+    [Fact]
+    public async Task VerifyOutputCode_WithValidCode_Succeeds()
+    {
+        const string code = """
+            using Metalama.Framework.Aspects;
+            using Metalama.Framework.Code;
+
+            class TestAspect : TypeAspect
+            {
+                public override void BuildAspect(IAspectBuilder<INamedType> builder)
+                {
+                    builder.Advice.IntroduceMethod(builder.Target, nameof(IntroducedMethod));
+                }
+
+                [Template]
+                public void IntroducedMethod()
+                {
+                    System.Console.WriteLine("Hello");
+                }
+            }
+
+            [TestAspect]
+            class TargetClass { }
+            """;
+
+        var testOptions = new TestContextOptions { VerifyOutputCode = true };
+        using var testContext = this.CreateTestContext( testOptions );
+        var compilation = testContext.CreateCSharpCompilation( code );
+        var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
+        var result = await pipeline.ExecuteAsync( null, null, compilation, default, default );
+
+        Assert.True( result.IsSuccessful, "Pipeline should succeed with valid code" );
+    }
+
+    [Fact]
+    public async Task VerifyOutputCode_Disabled_DoesNotValidate()
+    {
+        const string code = """
+            using Metalama.Framework.Aspects;
+            using Metalama.Framework.Code;
+
+            class TestAspect : TypeAspect
+            {
+                public override void BuildAspect(IAspectBuilder<INamedType> builder)
+                {
+                    builder.Advice.IntroduceMethod(builder.Target, nameof(IntroducedMethod));
+                }
+
+                [Template]
+                public void IntroducedMethod()
+                {
+                    System.Console.WriteLine("Hello");
+                }
+            }
+
+            [TestAspect]
+            class TargetClass { }
+            """;
+
+        var testOptions = new TestContextOptions { VerifyOutputCode = false };
+        using var testContext = this.CreateTestContext( testOptions );
+        var compilation = testContext.CreateCSharpCompilation( code );
+        var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
+        var result = await pipeline.ExecuteAsync( null, null, compilation, default, default );
+
+        // With VerifyOutputCode disabled, even if there were syntax issues in output,
+        // the pipeline would not fail due to syntax validation
+        Assert.True( result.IsSuccessful, "Pipeline should succeed when validation is disabled" );
+    }
+
+    [Fact]
+    public async Task VerifyOutputCode_WithInvalidGeneratedCode_Fails()
+    {
+        const string code = """
+            using Metalama.Framework.Aspects;
+            using Metalama.Framework.Engine;
+            using Metalama.Framework.Engine.AspectWeavers;
+            using Metalama.Framework.Engine.Utilities.Roslyn;
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.CSharp;
+            using Microsoft.CodeAnalysis.CSharp.Syntax;
+            using System.Linq;
+            using System.Threading.Tasks;
+
+            [RequireAspectWeaver("InvalidCodeWeaver")]
+            class TestAspect : MethodAspect { }
+
+            [MetalamaPlugIn]
+            class InvalidCodeWeaver : IAspectWeaver
+            {
+                public Task TransformAsync(AspectWeaverContext context)
+                {
+                    return context.RewriteAspectTargetsAsync(new Rewriter());
+                }
+
+                private class Rewriter : SafeSyntaxRewriter
+                {
+                    public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+                    {
+                        // Generate invalid syntax by parsing malformed code
+                        // ")(" is definitely invalid syntax
+                        var invalidCodeText = ")(";
+                        var parsedStatement = SyntaxFactory.ParseStatement(invalidCodeText);
+
+                        var newBody = SyntaxFactory.Block(parsedStatement);
+                        return node.WithBody(newBody);
+                    }
+                }
+            }
+
+            class TargetClass
+            {
+                [TestAspect]
+                public void TestMethod() { }
+            }
+            """;
+
+        var testOptions = new TestContextOptions { VerifyOutputCode = true };
+        using var testContext = this.CreateTestContext( testOptions );
+        var compilation = testContext.CreateCSharpCompilation(
+            code,
+            additionalReferences: new[]
+            {
+                MetadataReference.CreateFromFile( typeof(Microsoft.CodeAnalysis.Compilation).Assembly.Location ),
+                MetadataReference.CreateFromFile( typeof(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree).Assembly.Location )
+            } );
+        var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
+        var result = await pipeline.ExecuteAsync( null, null, compilation, default, default );
+
+        // The pipeline should fail because the generated code has syntax errors
+        Assert.False( result.IsSuccessful, "Pipeline should fail when generated code has syntax errors" );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/VerifyOutputCodeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/VerifyOutputCodeTests.cs
@@ -52,37 +52,66 @@ public sealed class VerifyOutputCodeTests : UnitTestClass
     [Fact]
     public async Task VerifyOutputCode_Disabled_DoesNotValidate()
     {
+        // Use the same invalid-output weaver as VerifyOutputCode_WithInvalidGeneratedCode_Fails;
+        // when VerifyOutputCode = false, the pipeline must still succeed even though the generated
+        // syntax tree contains errors, proving that validation is genuinely skipped.
         const string code = """
             using Metalama.Framework.Aspects;
-            using Metalama.Framework.Code;
+            using Metalama.Framework.Engine;
+            using Metalama.Framework.Engine.AspectWeavers;
+            using Metalama.Framework.Engine.Utilities.Roslyn;
+            using Microsoft.CodeAnalysis;
+            using Microsoft.CodeAnalysis.CSharp;
+            using Microsoft.CodeAnalysis.CSharp.Syntax;
+            using System.Linq;
+            using System.Threading.Tasks;
 
-            class TestAspect : TypeAspect
+            [RequireAspectWeaver("InvalidCodeWeaver")]
+            class TestAspect : MethodAspect { }
+
+            [MetalamaPlugIn]
+            class InvalidCodeWeaver : IAspectWeaver
             {
-                public override void BuildAspect(IAspectBuilder<INamedType> builder)
+                public Task TransformAsync(AspectWeaverContext context)
                 {
-                    builder.Advice.IntroduceMethod(builder.Target, nameof(IntroducedMethod));
+                    return context.RewriteAspectTargetsAsync(new Rewriter());
                 }
 
-                [Template]
-                public void IntroducedMethod()
+                private class Rewriter : SafeSyntaxRewriter
                 {
-                    System.Console.WriteLine("Hello");
+                    public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+                    {
+                        var invalidCodeText = ")(";
+                        var parsedStatement = SyntaxFactory.ParseStatement(invalidCodeText);
+
+                        var newBody = SyntaxFactory.Block(parsedStatement);
+                        return node.WithBody(newBody);
+                    }
                 }
             }
 
-            [TestAspect]
-            class TargetClass { }
+            class TargetClass
+            {
+                [TestAspect]
+                public void TestMethod() { }
+            }
             """;
 
         var testOptions = new TestContextOptions { VerifyOutputCode = false };
         using var testContext = this.CreateTestContext( testOptions );
-        var compilation = testContext.CreateCSharpCompilation( code );
+        var compilation = testContext.CreateCSharpCompilation(
+            code,
+            additionalReferences: new[]
+            {
+                MetadataReference.CreateFromFile( typeof(Microsoft.CodeAnalysis.Compilation).Assembly.Location ),
+                MetadataReference.CreateFromFile( typeof(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree).Assembly.Location )
+            } );
         var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
         var result = await pipeline.ExecuteAsync( null, null, compilation, default, default );
 
-        // With VerifyOutputCode disabled, even if there were syntax issues in output,
-        // the pipeline would not fail due to syntax validation
-        Assert.True( result.IsSuccessful, "Pipeline should succeed when validation is disabled" );
+        // With VerifyOutputCode disabled, the pipeline does not run the round-trip parse check,
+        // so generated syntax errors do not cause failure here.
+        Assert.True( result.IsSuccessful, "Pipeline should succeed when validation is disabled, even with invalid generated code" );
     }
 
     [Fact]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Linker/LinkerTriviaPreservationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Linker/LinkerTriviaPreservationTests.cs
@@ -129,7 +129,7 @@ public sealed class LinkerTriviaPreservationTests : UnitTestClass
     }
 
     /// <summary>
-    /// Enumerates byte offsets in <paramref name="source"/> where injecting a <c>#warning</c>
+    /// Enumerates character offsets in <paramref name="source"/> where injecting a <c>#warning</c>
     /// directive must round-trip through the linker. Only positions on members carrying an
     /// attribute list (i.e., aspect targets) are considered, since untargeted members go
     /// through the linker's pass-through path which trivially preserves trivia.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Linker/LinkerTriviaPreservationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Linker/LinkerTriviaPreservationTests.cs
@@ -1,0 +1,510 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Pipeline;
+using Metalama.Framework.Engine.Pipeline.DesignTime;
+using Metalama.Framework.Engine.Services;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.Linker;
+
+/// <summary>
+/// Property-style regression test for the linker's directive-trivia preservation invariant.
+/// <para>
+/// For each (member kind × rewrite path) seed snippet, this test injects a uniquely-tagged
+/// <c>#warning probe_*</c> at every "must-survive" trivia position in the target source,
+/// re-runs the pipeline, and asserts that each probe appears <em>exactly once</em> in the
+/// linker's output.
+/// </para>
+/// <para>
+/// Equality (count == 1), not just presence, is the assertion — that catches both drop and
+/// duplication bugs (e.g., a misguided fix to <c>GetIndentationTrivia</c> that emits
+/// preserved directives at multiple brace positions where its output is shared).
+/// </para>
+/// <para>
+/// The pipeline configuration (compile-time aspect compilation) is built once per corpus
+/// entry and reused across all probe variants, since only the target source is mutated —
+/// the aspect source is invariant per entry.
+/// </para>
+/// </summary>
+public sealed class LinkerTriviaPreservationTests : UnitTestClass
+{
+    public LinkerTriviaPreservationTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    public static IEnumerable<object[]> Corpus()
+    {
+        yield return new object[] { "Method_BlockBody", _overrideMethodAspect, _methodBlockBodyTarget };
+        yield return new object[] { "Method_ExpressionBody", _overrideMethodAspect, _methodExpressionBodyTarget };
+        yield return new object[] { "Method_Async", _overrideMethodAspect, _methodAsyncTarget };
+        yield return new object[] { "Property_AutoProperty", _overridePropertyAspect, _propertyAutoTarget };
+        yield return new object[] { "Property_BlockAccessors", _overridePropertyAspect, _propertyBlockAccessorsTarget };
+        yield return new object[] { "Property_ExpressionBodyAccessors", _overridePropertyAspect, _propertyExpressionBodyAccessorsTarget };
+        yield return new object[] { "Property_WholeExpressionBody", _overridePropertyAspect, _propertyWholeExpressionBodyTarget };
+        yield return new object[] { "Event_FieldLike", _overrideEventAspect, _eventFieldLikeTarget };
+        yield return new object[] { "Event_BlockAccessors", _overrideEventAspect, _eventBlockAccessorsTarget };
+        yield return new object[] { "Constructor_BlockBody", _initializerAspect, _constructorTarget };
+        yield return new object[] { "Constructor_ExpressionBody", _initializerAspect, _constructorExpressionBodyTarget };
+    }
+
+    [Theory]
+    [MemberData( nameof(Corpus) )]
+    public async Task DirectivesArePreservedAsync( string label, string aspectSource, string targetSource )
+    {
+        using var testContext = this.CreateTestContext();
+
+        var sources = new Dictionary<string, string> { ["Aspect.cs"] = aspectSource, ["Target.cs"] = targetSource };
+        var seedCompilation = testContext.CreateCSharpCompilation( sources );
+
+        // Sanity check: the unmodified seed must compile cleanly through the pipeline before
+        // we can blame the linker for any per-probe failure.
+        var pipeline = new TestablePreviewAspectPipeline( testContext.ServiceProvider );
+        var initDiagnostics = new DiagnosticBag();
+
+        Assert.True(
+            pipeline.InvokeTryInitialize( initDiagnostics, seedCompilation, default, out var configuration ),
+            $"{label}: pipeline initialization failed.\n{FormatDiagnostics( initDiagnostics )}" );
+
+        var seedDiagnostics = new DiagnosticBag();
+        var seedResult = await pipeline.ExecutePreviewAsync( seedDiagnostics, PartialCompilation.CreateComplete( seedCompilation ), configuration!, default );
+
+        Assert.True(
+            seedResult.IsSuccessful,
+            $"{label}: seed (no probes) pipeline run failed.\n{FormatDiagnostics( seedDiagnostics )}" );
+
+        // Enumerate the must-survive insertion sites on aspect-target members.
+        var insertionSites = EnumerateInsertionSites( targetSource ).ToList();
+        Assert.NotEmpty( insertionSites );
+
+        var failures = new List<string>();
+
+        for ( var i = 0; i < insertionSites.Count; i++ )
+        {
+            var probeId = $"probe_{label}_{i}";
+            var modifiedTarget = targetSource.Insert( insertionSites[i], $"\n#warning {probeId}\n" );
+
+            var modifiedSources = new Dictionary<string, string> { ["Aspect.cs"] = aspectSource, ["Target.cs"] = modifiedTarget };
+            var modifiedCompilation = testContext.CreateCSharpCompilation( modifiedSources );
+
+            var iterDiagnostics = new DiagnosticBag();
+
+            var result = await pipeline.ExecutePreviewAsync(
+                iterDiagnostics,
+                PartialCompilation.CreateComplete( modifiedCompilation ),
+                configuration!,
+                default );
+
+            if ( !result.IsSuccessful )
+            {
+                failures.Add( $"  site #{i} (offset {insertionSites[i]}): pipeline failed — {FormatDiagnostics( iterDiagnostics )}" );
+
+                continue;
+            }
+
+            var outputText = string.Concat( result.Value.SyntaxTrees.Values.Select( t => t.GetRoot().ToFullString() ) );
+            var occurrences = CountOccurrences( outputText, probeId );
+
+            if ( occurrences != 1 )
+            {
+                failures.Add( $"  site #{i} (offset {insertionSites[i]}): expected 1 occurrence of '{probeId}', got {occurrences}" );
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            $"{label}: {failures.Count}/{insertionSites.Count} insertion sites failed:\n{string.Join( "\n", failures )}" );
+    }
+
+    /// <summary>
+    /// Enumerates byte offsets in <paramref name="source"/> where injecting a <c>#warning</c>
+    /// directive must round-trip through the linker. Only positions on members carrying an
+    /// attribute list (i.e., aspect targets) are considered, since untargeted members go
+    /// through the linker's pass-through path which trivially preserves trivia.
+    /// </summary>
+    private static IEnumerable<int> EnumerateInsertionSites( string source )
+    {
+        var root = CSharpSyntaxTree.ParseText( source ).GetRoot();
+
+        foreach ( var member in root.DescendantNodes().OfType<MemberDeclarationSyntax>() )
+        {
+            if ( !member.AttributeLists.Any() )
+            {
+                continue;
+            }
+
+            // (a) Just after the closing ']' of the last attribute list — between attributes
+            //     and the modifier/return-type. The linker rewrites the modifier list, so this
+            //     trivia slot is exposed to its rewriter.
+            yield return member.AttributeLists.Last().CloseBracketToken.Span.End;
+
+            // (b) Inside method/constructor/destructor/operator block bodies,
+            //     OR around the arrow and semicolon of expression-bodied ones.
+            switch ( member )
+            {
+                case BaseMethodDeclarationSyntax { Body: { } body }:
+                    foreach ( var site in EnumerateBraceBodySites( body ) )
+                    {
+                        yield return site;
+                    }
+
+                    break;
+
+                case BaseMethodDeclarationSyntax { ExpressionBody: { } bmdExpr } bmd:
+                    foreach ( var site in EnumerateArrowSemicolonSites( bmdExpr, bmd.SemicolonToken ) )
+                    {
+                        yield return site;
+                    }
+
+                    break;
+            }
+
+            // (c) Around the arrow/semicolon of a property/indexer whose whole declaration is
+            //     expression-bodied (e.g. `int Value => 42;`). Accessor-level expression bodies
+            //     are handled below via the accessor list.
+            switch ( member )
+            {
+                case PropertyDeclarationSyntax { ExpressionBody: { } pExpr } pd:
+                    foreach ( var site in EnumerateArrowSemicolonSites( pExpr, pd.SemicolonToken ) )
+                    {
+                        yield return site;
+                    }
+
+                    break;
+
+                case IndexerDeclarationSyntax { ExpressionBody: { } iExpr } id:
+                    foreach ( var site in EnumerateArrowSemicolonSites( iExpr, id.SemicolonToken ) )
+                    {
+                        yield return site;
+                    }
+
+                    break;
+            }
+
+            // (d) Inside accessor bodies of property/indexer/event declarations.
+            var accessors = member switch
+            {
+                PropertyDeclarationSyntax p => p.AccessorList,
+                IndexerDeclarationSyntax i => i.AccessorList,
+                EventDeclarationSyntax e => e.AccessorList,
+                _ => null
+            };
+
+            if ( accessors != null )
+            {
+                // Accessor-list opening brace: leading (before {) and trailing (after {) slots.
+                yield return accessors.OpenBraceToken.SpanStart;
+                yield return accessors.OpenBraceToken.Span.End;
+
+                foreach ( var accessor in accessors.Accessors )
+                {
+                    if ( accessor.Body is { } accBody )
+                    {
+                        foreach ( var site in EnumerateBraceBodySites( accBody ) )
+                        {
+                            yield return site;
+                        }
+                    }
+                    else if ( accessor.ExpressionBody is { } accExpr )
+                    {
+                        // Expression-bodied accessor: `get => expr;` / `set => expr;`.
+                        foreach ( var site in EnumerateArrowSemicolonSites( accExpr, accessor.SemicolonToken ) )
+                        {
+                            yield return site;
+                        }
+                    }
+                    else if ( !accessor.SemicolonToken.IsKind( SyntaxKind.None ) )
+                    {
+                        // Auto-accessor: `get;` / `set;` — only the semicolon slot is user-visible.
+                        yield return accessor.SemicolonToken.SpanStart;
+                        yield return accessor.SemicolonToken.Span.End;
+                    }
+                }
+
+                // Accessor-list closing brace: leading (before }) and trailing (after }) slots.
+                yield return accessors.CloseBraceToken.SpanStart;
+                yield return accessors.CloseBraceToken.Span.End;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Yields offsets for the four trivia slots of an expression-bodied member: leading and
+    /// trailing of the <c>=&gt;</c> arrow, and leading and trailing of the terminating <c>;</c>.
+    /// The semicolon slots are skipped when the member has no explicit semicolon (shouldn't
+    /// happen for the expression-bodied shapes we test, but guarded for safety).
+    /// </summary>
+    private static IEnumerable<int> EnumerateArrowSemicolonSites(
+        ArrowExpressionClauseSyntax expressionBody,
+        SyntaxToken semicolonToken )
+    {
+        yield return expressionBody.ArrowToken.SpanStart;
+        yield return expressionBody.ArrowToken.Span.End;
+
+        if ( !semicolonToken.IsKind( SyntaxKind.None ) )
+        {
+            yield return semicolonToken.SpanStart;
+            yield return semicolonToken.Span.End;
+        }
+    }
+
+    /// <summary>
+    /// Yields offsets for all four brace-trivia slots: leading and trailing of both open and close
+    /// brace, plus the positions between statements inside the body. Leading-of-open goes BEFORE
+    /// <c>{</c>, trailing-of-open goes AFTER <c>{</c> (before the first statement), leading-of-close
+    /// goes BEFORE <c>}</c> (after the last statement), trailing-of-close goes AFTER <c>}</c>.
+    /// </summary>
+    private static IEnumerable<int> EnumerateBraceBodySites( BlockSyntax body )
+    {
+        yield return body.OpenBraceToken.SpanStart;
+        yield return body.OpenBraceToken.Span.End;
+
+        foreach ( var stmt in body.Statements )
+        {
+            yield return stmt.SpanStart;
+        }
+
+        yield return body.CloseBraceToken.SpanStart;
+        yield return body.CloseBraceToken.Span.End;
+    }
+
+    private static int CountOccurrences( string haystack, string needle )
+    {
+        var count = 0;
+        var idx = 0;
+
+        while ( ( idx = haystack.IndexOf( needle, idx, StringComparison.Ordinal ) ) >= 0 )
+        {
+            count++;
+            idx += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static string FormatDiagnostics( DiagnosticBag bag )
+        => string.Join( "\n  ", bag.SelectAsArray( d => d.GetMessage( CultureInfo.InvariantCulture ) ) );
+
+    /// <summary>
+    /// Test-only subclass that exposes the <c>protected</c> <see cref="AspectPipeline.TryInitialize"/>
+    /// so the test can perform compile-time aspect compilation once and reuse the result.
+    /// </summary>
+    private sealed class TestablePreviewAspectPipeline : PreviewAspectPipeline
+    {
+        public TestablePreviewAspectPipeline( ProjectServiceProvider serviceProvider )
+            : base( serviceProvider, ExecutionScenario.Preview ) { }
+
+        public bool InvokeTryInitialize(
+            IDiagnosticAdder diagnosticAdder,
+            Compilation compilation,
+            CancellationToken cancellationToken,
+            out AspectPipelineConfiguration? configuration )
+            => this.TryInitialize( diagnosticAdder, compilation, null, cancellationToken, out configuration );
+    }
+
+    // ---------------- Aspects ----------------
+
+    private const string _overrideMethodAspect = @"
+using Metalama.Framework.Aspects;
+
+public class OverrideAttribute : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod() => meta.Proceed();
+}
+";
+
+    private const string _overridePropertyAspect = @"
+using Metalama.Framework.Aspects;
+
+public class OverrideAttribute : OverrideFieldOrPropertyAspect
+{
+    public override dynamic? OverrideProperty
+    {
+        get => meta.Proceed();
+        set => meta.Proceed();
+    }
+}
+";
+
+    private const string _overrideEventAspect = @"
+using Metalama.Framework.Aspects;
+
+public class OverrideAttribute : OverrideEventAspect
+{
+    public override void OverrideAdd( dynamic value ) => meta.Proceed();
+    public override void OverrideRemove( dynamic value ) => meta.Proceed();
+}
+";
+
+    private const string _initializerAspect = @"
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+public class OverrideAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        foreach ( var ctor in builder.Target.Constructors )
+        {
+            builder.With( ctor ).AddInitializer( nameof(Initialize) );
+        }
+    }
+
+    [Template]
+    private void Initialize() { }
+}
+";
+
+    // ---------------- Targets ----------------
+
+    private const string _methodBlockBodyTarget = @"
+public class Target
+{
+    [Override]
+    public int Compute( int x )
+    {
+        return x + 1;
+    }
+}
+";
+
+    private const string _methodExpressionBodyTarget = @"
+public class Target
+{
+    [Override]
+    public int Compute( int x ) => x + 1;
+}
+";
+
+    private const string _methodAsyncTarget = @"
+using System.Threading.Tasks;
+
+public class Target
+{
+    [Override]
+    public async Task<int> ComputeAsync( int x )
+    {
+        await Task.Yield();
+        return x + 1;
+    }
+}
+";
+
+    private const string _propertyAutoTarget = @"
+public class Target
+{
+    [Override]
+    public int Value { get; set; }
+}
+";
+
+    private const string _propertyBlockAccessorsTarget = @"
+public class Target
+{
+    private int _value;
+
+    [Override]
+    public int Value
+    {
+        get
+        {
+            return this._value;
+        }
+        set
+        {
+            this._value = value;
+        }
+    }
+}
+";
+
+    private const string _propertyExpressionBodyAccessorsTarget = @"
+public class Target
+{
+    private int _value;
+
+    [Override]
+    public int Value
+    {
+        get => this._value;
+        set => this._value = value;
+    }
+}
+";
+
+    private const string _eventFieldLikeTarget = @"
+using System;
+
+public class Target
+{
+    [Override]
+    public event EventHandler? Changed;
+}
+";
+
+    private const string _eventBlockAccessorsTarget = @"
+using System;
+
+public class Target
+{
+    private EventHandler? _changed;
+
+    [Override]
+    public event EventHandler? Changed
+    {
+        add
+        {
+            this._changed += value;
+        }
+        remove
+        {
+            this._changed -= value;
+        }
+    }
+}
+";
+
+    private const string _constructorTarget = @"
+[Override]
+public class Target
+{
+    public Target( int x )
+    {
+        this.X = x;
+    }
+
+    public int X { get; }
+}
+";
+
+    private const string _propertyWholeExpressionBodyTarget = @"
+public class Target
+{
+    [Override]
+    public int Value => 42;
+}
+";
+
+    private const string _constructorExpressionBodyTarget = @"
+[Override]
+public class Target
+{
+    public int X;
+
+    public Target( int x ) => this.X = x;
+}
+";
+}


### PR DESCRIPTION
## Summary
- Broaden the linker's brace-trivia handling to keep directives and ordinary comments from all four brace trivia slots (open-leading, open-trailing, close-leading, close-trailing) across every rewritten member kind (methods, properties, indexers, events, constructors, destructors, operators, conversion operators).
- New helper `StripVerticalWhitespaceAndDocComments` strips vertical whitespace and XML documentation comments while re-framing kept trivia with linker-owned EOLs plus the original brace indentation.
- Expression-bodied members route arrow/semicolon trivia into the same slot model via `.AddOptionalLineFeed`.
- Add property-style `LinkerTriviaPreservationTests` that injects a uniquely-tagged probe directive at every must-survive position (brace slots, `=>`/`;` slots, auto-accessor semicolons) and asserts each probe appears exactly once in the linker output — catches both drop and duplication regressions.

## Issues Fixed
- #1173 - Verify linker output code via round-trip parsing
