### PR TITLE
Fix AfterLastInstanceConstructor derived class context descent and epilogue (#1580)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedEpilogueEmitter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedEpilogueEmitter.cs
@@ -256,6 +256,116 @@ internal static class OnConstructedEpilogueEmitter
     }
 
     /// <summary>
+    /// Emits the epilogue and descend override for all constructors of a same-project derived type.
+    /// Unlike <see cref="EmitForType"/>, this method does not need to resolve the <see cref="InitializationContext"/>
+    /// parameter from the code model — it uses the known default parameter name, because the parameter
+    /// was introduced by the recursive pull in <see cref="OnConstructedMethodAdvice"/> and may not yet
+    /// be visible in the code model for the derived constructors (the source model doesn't reflect
+    /// transformations from the same advice execution).
+    /// </summary>
+    internal static void EmitForDerivedType(
+        INamedType derivedType,
+        IType initContextType,
+        AspectLayerInstance aspectLayerInstance,
+        AdviceImplementationContext context )
+    {
+        var allConstructors = derivedType.Constructors
+            .Where( c => !c.IsRecordCopyConstructor() )
+            .ToList();
+
+        // Pass 1: non-:this(...) constructors.
+        foreach ( var ctor in allConstructors.Where( c => c.InitializerKind != ConstructorInitializerKind.This ) )
+        {
+            context.AddTransformation(
+                new OnConstructedEpilogueTransformation(
+                    aspectLayerInstance,
+                    derivedType.ToRef(),
+                    ctor.ToFullRef(),
+                    _defaultContextParameterName,
+                    guarded: true ) );
+
+            EmitDescendOverrideForChainedInitializerWithFallback(
+                ctor,
+                initContextType,
+                _defaultContextParameterName,
+                aspectLayerInstance,
+                context );
+        }
+
+        // Pass 2: :this(...) constructors — same treatment, guarded epilogue prevents double-fire.
+        foreach ( var ctor in allConstructors.Where( c => c.InitializerKind == ConstructorInitializerKind.This ) )
+        {
+            context.AddTransformation(
+                new OnConstructedEpilogueTransformation(
+                    aspectLayerInstance,
+                    derivedType.ToRef(),
+                    ctor.ToFullRef(),
+                    _defaultContextParameterName,
+                    guarded: true ) );
+
+            EmitDescendOverrideForChainedInitializerWithFallback(
+                ctor,
+                initContextType,
+                _defaultContextParameterName,
+                aspectLayerInstance,
+                context );
+        }
+    }
+
+    /// <summary>
+    /// Like <see cref="EmitDescendOverrideForChainedInitializer"/> but with a fallback for same-project
+    /// <c>:base(...)</c> chains where the chained constructor's <see cref="InitializationContext"/>
+    /// parameter was introduced by the pull and is not yet visible in the code model.
+    /// </summary>
+    private static void EmitDescendOverrideForChainedInitializerWithFallback(
+        IConstructor derivedConstructor,
+        IType initContextType,
+        string contextParameterName,
+        AspectLayerInstance aspectLayerInstance,
+        AdviceImplementationContext context )
+    {
+        var chainedConstructor = ((IConstructorImpl) derivedConstructor).GetBaseConstructor()?.Definition;
+
+        if ( chainedConstructor == null )
+        {
+            return;
+        }
+
+        var chainedContextParameter = chainedConstructor.Parameters.FirstOrDefault( p => p.Type.Equals( initContextType ) );
+
+        int parameterIndex;
+        string parameterName;
+
+        if ( chainedContextParameter != null )
+        {
+            parameterIndex = chainedContextParameter.Index;
+            parameterName = chainedContextParameter.Name;
+        }
+        else
+        {
+            // Same-project path: the chained constructor's InitializationContext parameter was
+            // introduced by the parameter pull and appended at the end. Since it isn't visible
+            // in the source model yet, compute the index from the original parameter count.
+            // This mirrors the :this() handling in EmitDescendOverrideForChainedInitializer.
+            parameterIndex = chainedConstructor.Parameters.Count;
+            parameterName = _defaultContextParameterName;
+        }
+
+        var requiresParameterName = chainedConstructor.Parameters.Any(
+            p => p.DefaultValue != null && p.Index < parameterIndex );
+
+        context.AddTransformation(
+            new IntroduceConstructorInitializerArgumentTransformation(
+                aspectLayerInstance,
+                derivedConstructor.ToFullRef(),
+                parameterIndex,
+                parameterName,
+                BuildDescendExpression( contextParameterName ),
+                requiresParameterName,
+                isOverride: true ) );
+    }
+
+    /// <summary>
     /// Locates the <see cref="InitializationContext"/> parameter on the constructor reached by
     /// <paramref name="derivedConstructor"/>'s <c>:base(...)</c> or <c>:this(...)</c> initializer
     /// and, if found, emits an <c>IsOverride=true</c>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedMethodAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedMethodAdvice.cs
@@ -152,6 +152,27 @@ internal sealed class OnConstructedMethodAdvice : Advice<AddInitializerAdviceRes
             context,
             registerPullFallback: true );
 
+        // Step 3b: emit the epilogue and descend override for all same-project derived types.
+        // The recursive parameter pull in Step 3 has already propagated the InitializationContext
+        // parameter to derived constructors, but the epilogue and descend rewrite were only emitted
+        // for the target type itself. When the aspect is [Inheritable], derived types get their own
+        // OnConstructedMethodAdvice, but when it is not, same-project derived constructors would
+        // otherwise only get the parameter without the epilogue/descend treatment. Using
+        // registerPullFallback: false because the parameter is already present from the recursive pull.
+        // The epilogue transformation is aggregatable, so duplicate emissions (when the aspect is
+        // inheritable and the derived type also gets its own advice) merge harmlessly.
+        if ( !targetType.IsSealed && targetType.TypeKind != Code.TypeKind.Struct )
+        {
+            foreach ( var derivedType in targetType.Compilation.GetDerivedTypes( targetType, DerivedTypesOptions.All ) )
+            {
+                OnConstructedEpilogueEmitter.EmitForDerivedType(
+                    derivedType,
+                    initContextType,
+                    this.AspectLayerInstance,
+                    context );
+            }
+        }
+
         // Step 4: cross-project propagation of the epilogue obligation. The transitive aspect runs
         // in dependent projects regardless of whether the user aspect is [Inheritable], so derived
         // classes in dependent projects also get the epilogue and the :base(context.Descend(...))

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnConstructed_TwoLevel_NonInheritable;
+
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterLastInstanceConstructor );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( $"OnConstructed on {meta.Target.Type.Name}!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public class BaseClass
+{
+    public string Value { get; }
+
+    public BaseClass( string value )
+    {
+        this.Value = value;
+    }
+}
+
+// <target>
+public class DerivedClass : BaseClass
+{
+    public int Extra { get; }
+
+    public DerivedClass( string value, int extra ) : base( value )
+    {
+        this.Extra = extra;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.t.cs
@@ -1,0 +1,29 @@
+[TheAspect]
+public class BaseClass
+{
+  public string Value { get; }
+  public BaseClass(string value, [AspectGenerated] InitializationContext context = default)
+  {
+    this.Value = value;
+    if (!context.IsHandled(InitializationSlot.OnConstructed))
+    {
+      this.OnConstructed(context);
+    }
+  }
+  protected virtual void OnConstructed(InitializationContext context = default)
+  {
+    Console.WriteLine("OnConstructed on BaseClass!");
+  }
+}
+public class DerivedClass : BaseClass
+{
+  public int Extra { get; }
+  public DerivedClass(string value, int extra, [AspectGenerated] InitializationContext context = default) : base(value, context.Descend(InitializationSlot.OnConstructed))
+  {
+    this.Extra = extra;
+    if (!context.IsHandled(InitializationSlot.OnConstructed))
+    {
+      this.OnConstructed(context);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1580. When `InitializerKind.AfterLastInstanceConstructor` is applied to a non-sealed type via a non-inheritable aspect, same-project derived class constructors only received the `InitializationContext` parameter (via the recursive pull) but not the epilogue and `Descend()` override. This caused `OnConstructed` to fire prematurely in the base constructor before the derived constructor body ran.

**Root cause**: `OnConstructedEpilogueEmitter.EmitForType()` only processed the target type's own constructors. For cross-project derived types, `AddConstructorEpilogueTransitiveAspect` handled this correctly. For same-project derived types with `[Inheritable]`, the aspect re-applies and each type gets its own advice. But same-project derived types without `[Inheritable]` were orphaned.

**Fix**: Added `OnConstructedEpilogueEmitter.EmitForDerivedType()` — emits the epilogue and descend override for derived constructors without relying on the code model to find the `InitializationContext` parameter (which isn't yet visible in the model because it was added as a transformation in the same advice execution). Called from `OnConstructedMethodAdvice.Implement()` after Step 3 for all same-project derived types.

## Checklist

- [x] Reproduce bug with a failing test (`OnConstructed_TwoLevel_NonInheritable`)
- [x] Implement fix
- [x] Run all tests in the solution (2258 aspect tests pass, 139 initialization tests pass)
- [x] Build with `Build.ps1 build` (0 warnings)
- [x] Run `Build.ps1 test` (all pass)
- [x] Finalize

— Claude for @gfraiteur