### PR TITLE
Fix AfterLastInstanceConstructor derived-type handling and initializer ordering (#1580, #1582)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
@@ -1534,7 +1534,23 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
                     slotFields,
                     position );
 
-                return advice.Execute( this._state );
+                var result = advice.Execute( this._state );
+
+                // After OnConstructedMethodAdvice's transformations (including parameter pulls into
+                // derived constructors in the same compilation) have been applied to MutableCompilation,
+                // walk same-compilation derived types and emit the epilogue + descend rewrite. This is
+                // the in-project counterpart of AddConstructorEpilogueTransitiveAspect, which only
+                // handles cross-project propagation. See issue #1580: without this, a derived class in
+                // the same compilation receives the pulled InitializationContext parameter but neither
+                // calls OnConstructed nor descends the context to its base call.
+                if ( result.Outcome == AdviceOutcome.Success
+                     && !targetType.IsSealed
+                     && targetType.TypeKind != TypeKind.Struct )
+                {
+                    this.EmitOnConstructedEpilogueOnDerivedTypes( targetType );
+                }
+
+                return result;
             }
             else
             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -436,6 +436,20 @@ internal sealed partial class LinkerInjectionStep
         public LateTypeLevelTransformations GetOrAddLateTypeLevelTransformations( ISymbolRef<INamedType> type )
             => this._lateTypeLevelTransformations.GetOrAdd( type, static _ => new LateTypeLevelTransformations() );
 
+        /// <summary>
+        /// Returns the statements that must be <em>prepended</em> to the body of the given injected
+        /// member — i.e. statements that run before the member's own body executes. This covers:
+        /// <list type="bullet">
+        /// <item>For constructors: pre-user-body initializers (<see cref="InsertedStatementKind.InitializerAfterBase"/>
+        /// — see that enum value for why constructor initializers land at entry despite the name);</item>
+        /// <item>For <c>Initialize</c> / <c>OnConstructed</c> methods on the last override layer: the
+        /// <c>BeforeBase</c> bucket, the synthesized <c>base.X()</c> anchor, and any input contracts;</item>
+        /// <item>For arbitrary methods and property/indexer accessors: input-contract statements
+        /// scoped to this specific injected member layer.</item>
+        /// </list>
+        /// "Entry" is a <em>physical placement</em> label (start of body) distinct from the semantic
+        /// <c>InitializerBeforeBase</c>/<c>InitializerAfterBase</c> <em>kinds</em>.
+        /// </summary>
         internal IReadOnlyList<StatementSyntax> GetInjectedEntryStatements( InjectedMember injectedMember )
         {
             var targetMethod = injectedMember.Declaration.As<IMethodBase>();
@@ -443,9 +457,11 @@ internal sealed partial class LinkerInjectionStep
             return this.GetInjectedEntryStatements( targetMethod, targetMethod, injectedMember );
         }
 
+        /// <inheritdoc cref="GetInjectedEntryStatements(InjectedMember)"/>
         internal IReadOnlyList<StatementSyntax> GetInjectedEntryStatements( IRef<IMethodBase> targetMethod, InjectedMember? targetInjectedMember = null )
             => this.GetInjectedEntryStatements( targetMethod, targetMethod, targetInjectedMember );
 
+        /// <inheritdoc cref="GetInjectedEntryStatements(InjectedMember)"/>
         /// <param name="targetTypeMember">In case of accessors, the property or event.</param>
         internal IReadOnlyList<StatementSyntax> GetInjectedEntryStatements(
             IRef<IMethodBase> targetMethod,
@@ -510,44 +526,29 @@ internal sealed partial class LinkerInjectionStep
 
             if ( (!hasInjectedMembers && targetInjectedMember == null) || (hasInjectedMembers && targetInjectedMember == injectedMembers![^1]) )
             {
-                // Return entry statements to source members with no overrides or to the last override.
-                // This applies to both constructors (BeforeInstanceConstructor / BeforeTypeConstructor
-                // initializers) and methods (Initialize / OnConstructed template statements).
-                //
-                // Entry part of the three-bucket matryoshka layout:
-                //   1. BeforeBase bucket — run in run-time order (outermost-first), so outer aspects
-                //      bracket inner ones before the base call.
-                //   2. Base-call anchor (base.Initialize / base.OnConstructed).
-                //
-                // For Initialize / OnConstructed methods, the AfterBase bucket is emitted as an exit
-                // statement (see GetInjectedExitStatements) in innermost-first order so that the
-                // matryoshka unwinds correctly: the inner aspect's AfterBase runs first after the
-                // base call, and the outer aspect's AfterBase runs last.
-                //
-                // For constructors, however, there is no post-body seam — the conceptual "base call"
-                // lives in the constructor header (`: base(...)`), so AfterBase statements
-                // (BeforeInstanceConstructor / BeforeTypeConstructor) are emitted at the start of the
-                // constructor body, right after the implicit base call. Semantically they are
-                // pre-user-body entry statements, so they are ordered outermost-first across aspects
-                // (the outer aspect's initializer runs before the inner aspect's, which in turn runs
-                // before the user's body).
+                // Initializer buckets are emitted once per method, at the last override layer.
+                // The layout depends on whether the target has a post-body seam around the base call
+                // (see AfterBaseEmittedAtEntry / InsertedStatementKind.InitializerAfterBase):
+                //   - Initialize / OnConstructed: BeforeBase + base.X() anchor here; AfterBase at exit.
+                //   - Constructors: no body seam — AfterBase collapses into entry, outer-first.
 
-                var beforeBaseStatements = OrderInitializerStatements(
-                    insertedStatements.Where( s => s.Kind == InsertedStatementKind.InitializerBeforeBase ),
-                    reverseAcrossAspects: true );
-
-                statements.AddRange( beforeBaseStatements.Select( s => s.Statement ) );
-
-                var baseCallStatements =
-                    insertedStatements
-                        .Where( s => s.Kind == InsertedStatementKind.InitializerBase );
-
-                statements.AddRange( baseCallStatements.Select( s => s.Statement ) );
-
-                if ( AfterBaseEmittedAtEntry( targetMethod ) )
+                if ( !AfterBaseEmittedAtEntry( targetMethod ) )
                 {
-                    // Pre-user-body: outer first (same as BeforeBase above).
-                    statements.AddRange( GetOrderedAfterBaseStatements( insertedStatements, reverseAcrossAspects: true ) );
+                    var beforeBaseStatements = OrderInitializerStatements(
+                        insertedStatements.Where( s => s.Kind == InsertedStatementKind.InitializerBeforeBase ),
+                        reverseAcrossAspects: true );
+
+                    statements.AddRange( beforeBaseStatements.Select( s => s.Statement ) );
+
+                    var baseCallStatements =
+                        insertedStatements
+                            .Where( s => s.Kind == InsertedStatementKind.InitializerBase );
+
+                    statements.AddRange( baseCallStatements.Select( s => s.Statement ) );
+                }
+                else
+                {
+                    statements.AddRange( GetOrderedInitializerAfterBaseStatements( insertedStatements, reverseAcrossAspects: true ) );
                 }
             }
 
@@ -574,6 +575,20 @@ internal sealed partial class LinkerInjectionStep
             return statements;
         }
 
+        /// <summary>
+        /// Returns the statements that must be <em>appended</em> to the body of the given injected
+        /// member — i.e. statements that run after the member's own body executes. This covers:
+        /// <list type="bullet">
+        /// <item>For <c>Initialize</c> / <c>OnConstructed</c> methods on the last override layer: the
+        /// <see cref="InsertedStatementKind.InitializerAfterBase"/> bucket, unwound innermost-first;</item>
+        /// <item>For arbitrary methods and property/indexer accessors: output-contract statements
+        /// scoped to this specific injected member layer.</item>
+        /// </list>
+        /// Constructors never have body-exit initializer statements — their <c>AfterBase</c> bucket
+        /// is emitted at entry (see <see cref="GetInjectedEntryStatements(InjectedMember)"/> and
+        /// <see cref="AfterBaseEmittedAtEntry"/>). For the constructor-body epilogue emitted by
+        /// <c>AfterLastInstanceConstructor</c>, see <see cref="GetInjectedEpilogueStatements"/>.
+        /// </summary>
         internal IReadOnlyList<StatementSyntax> GetInjectedExitStatements( InjectedMember injectedMember )
         {
             var targetMethod = injectedMember.Declaration.As<IMethodBase>();
@@ -581,6 +596,8 @@ internal sealed partial class LinkerInjectionStep
             return this.GetInjectedExitStatements( targetMethod, targetMethod, injectedMember );
         }
 
+        /// <inheritdoc cref="GetInjectedExitStatements(InjectedMember)"/>
+        /// <param name="targetTypeMember">In case of accessors, the property or event.</param>
         internal IReadOnlyList<StatementSyntax> GetInjectedExitStatements(
             IRef<IMethodBase> targetMethod,
             IRef<IMember> targetTypeMember,
@@ -621,15 +638,13 @@ internal sealed partial class LinkerInjectionStep
 
             var statements = new List<StatementSyntax>();
 
-            // AfterBase / legacy Initializer bucket: emitted exactly once per method at the last-override
-            // point. Targets with a post-body seam (Initialize / OnConstructed) emit it here, after the
-            // user body. Targets without a post-body seam (constructors) have it emitted at entry by
-            // GetInjectedEntryStatements; see AfterBaseEmittedAtEntry.
+            // AfterBase bucket — emitted once per method at the last-override layer, only for targets
+            // with a post-body seam (Initialize / OnConstructed). Constructors emit it at entry, see
+            // AfterBaseEmittedAtEntry. Inner-first so the matryoshka unwinds correctly (inner aspect's
+            // AfterBase runs before outer aspect's AfterBase).
             if ( targetInjectedMember == injectedMembers![^1] && !AfterBaseEmittedAtEntry( targetMethod ) )
             {
-                // Post-base-call / post-user-body: inner first so the matryoshka unwinds correctly
-                // (inner aspect's AfterBase runs before outer aspect's AfterBase).
-                statements.AddRange( GetOrderedAfterBaseStatements( insertedStatements, reverseAcrossAspects: false ) );
+                statements.AddRange( GetOrderedInitializerAfterBaseStatements( insertedStatements, reverseAcrossAspects: false ) );
             }
 
             // For non-initializer statements we have to select a range of statements that fits this injected member.
@@ -669,21 +684,24 @@ internal sealed partial class LinkerInjectionStep
 
             // Hand-authored Initialize / OnConstructed: emitted at method exit after the user body,
             // inner first so the matryoshka unwinds correctly.
-            return GetOrderedAfterBaseStatements( insertedStatements, reverseAcrossAspects: false ).ToReadOnlyList();
+            return GetOrderedInitializerAfterBaseStatements( insertedStatements, reverseAcrossAspects: false ).ToReadOnlyList();
         }
 
         /// <summary>
-        /// Returns the ordered <see cref="InsertedStatementKind.InitializerAfterBase"/> statements for a
-        /// target method. The ordering differs by emission site:
+        /// Filters and orders <see cref="InsertedStatementKind.InitializerAfterBase"/> statements. Note
+        /// that <c>InitializerAfterBase</c> is a semantic <em>kind</em> (position relative to the base
+        /// call) — the physical emission site depends on the target (see
+        /// <see cref="AfterBaseEmittedAtEntry"/>). The <paramref name="reverseAcrossAspects"/> argument
+        /// reflects which site this call is serving:
         /// <list type="bullet">
-        /// <item><c>reverseAcrossAspects: true</c> (outer-first) for constructor entry (<c>BeforeInstanceConstructor</c>/<c>BeforeTypeConstructor</c>),
+        /// <item><c>reverseAcrossAspects: true</c> (outer-first) for constructor entry (<c>BeforeInstanceConstructor</c>/<c>BeforeTypeConstructor</c>/<c>AfterObjectInitializer</c>),
         /// which is semantically a pre-user-body bucket.</item>
         /// <item><c>reverseAcrossAspects: false</c> (inner-first) for <c>Initialize</c> / <c>OnConstructed</c> method exit,
         /// which is a post-base-call bucket and must unwind innermost-first.</item>
         /// </list>
         /// Within a single aspect instance, programmatic add-order is always preserved.
         /// </summary>
-        private static IEnumerable<StatementSyntax> GetOrderedAfterBaseStatements(
+        private static IEnumerable<StatementSyntax> GetOrderedInitializerAfterBaseStatements(
             IEnumerable<InsertedStatement> insertedStatements,
             bool reverseAcrossAspects )
             => OrderInitializerStatements(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -515,22 +515,26 @@ internal sealed partial class LinkerInjectionStep
                 // initializers) and methods (Initialize / OnConstructed template statements).
                 //
                 // Entry part of the three-bucket matryoshka layout:
-                //   1. BeforeBase bucket — run in run-time order (last-applied aspect first, outer-to-inner).
+                //   1. BeforeBase bucket — run in run-time order (outermost-first), so outer aspects
+                //      bracket inner ones before the base call.
                 //   2. Base-call anchor (base.Initialize / base.OnConstructed).
                 //
                 // For Initialize / OnConstructed methods, the AfterBase bucket is emitted as an exit
-                // statement (see GetInjectedExitStatements) so that for hand-authored bodies the user
-                // body plays the base-call-anchor role and AfterBase templates run after it.
+                // statement (see GetInjectedExitStatements) in innermost-first order so that the
+                // matryoshka unwinds correctly: the inner aspect's AfterBase runs first after the
+                // base call, and the outer aspect's AfterBase runs last.
                 //
                 // For constructors, however, there is no post-body seam — the conceptual "base call"
                 // lives in the constructor header (`: base(...)`), so AfterBase statements
                 // (BeforeInstanceConstructor / BeforeTypeConstructor) are emitted at the start of the
-                // constructor body, right after the implicit base call. They are still ordered in
-                // compile-time (inside-out) order across aspects.
+                // constructor body, right after the implicit base call. Semantically they are
+                // pre-user-body entry statements, so they are ordered outermost-first across aspects
+                // (the outer aspect's initializer runs before the inner aspect's, which in turn runs
+                // before the user's body).
 
                 var beforeBaseStatements = OrderInitializerStatements(
                     insertedStatements.Where( s => s.Kind == InsertedStatementKind.InitializerBeforeBase ),
-                    reverseAcrossAspects: false );
+                    reverseAcrossAspects: true );
 
                 statements.AddRange( beforeBaseStatements.Select( s => s.Statement ) );
 
@@ -542,7 +546,8 @@ internal sealed partial class LinkerInjectionStep
 
                 if ( AfterBaseEmittedAtEntry( targetMethod ) )
                 {
-                    statements.AddRange( GetOrderedAfterBaseStatements( insertedStatements ) );
+                    // Pre-user-body: outer first (same as BeforeBase above).
+                    statements.AddRange( GetOrderedAfterBaseStatements( insertedStatements, reverseAcrossAspects: true ) );
                 }
             }
 
@@ -622,7 +627,9 @@ internal sealed partial class LinkerInjectionStep
             // GetInjectedEntryStatements; see AfterBaseEmittedAtEntry.
             if ( targetInjectedMember == injectedMembers![^1] && !AfterBaseEmittedAtEntry( targetMethod ) )
             {
-                statements.AddRange( GetOrderedAfterBaseStatements( insertedStatements ) );
+                // Post-base-call / post-user-body: inner first so the matryoshka unwinds correctly
+                // (inner aspect's AfterBase runs before outer aspect's AfterBase).
+                statements.AddRange( GetOrderedAfterBaseStatements( insertedStatements, reverseAcrossAspects: false ) );
             }
 
             // For non-initializer statements we have to select a range of statements that fits this injected member.
@@ -660,18 +667,28 @@ internal sealed partial class LinkerInjectionStep
                 return ImmutableArray<StatementSyntax>.Empty;
             }
 
-            return GetOrderedAfterBaseStatements( insertedStatements ).ToReadOnlyList();
+            // Hand-authored Initialize / OnConstructed: emitted at method exit after the user body,
+            // inner first so the matryoshka unwinds correctly.
+            return GetOrderedAfterBaseStatements( insertedStatements, reverseAcrossAspects: false ).ToReadOnlyList();
         }
 
         /// <summary>
         /// Returns the ordered <see cref="InsertedStatementKind.InitializerAfterBase"/> statements for a
-        /// target method. The ordering is shared by all AfterBase emission sites: constructor entry,
-        /// <c>Initialize</c> / <c>OnConstructed</c> method exit, and the source-method visitor in the rewriter.
+        /// target method. The ordering differs by emission site:
+        /// <list type="bullet">
+        /// <item><c>reverseAcrossAspects: true</c> (outer-first) for constructor entry (<c>BeforeInstanceConstructor</c>/<c>BeforeTypeConstructor</c>),
+        /// which is semantically a pre-user-body bucket.</item>
+        /// <item><c>reverseAcrossAspects: false</c> (inner-first) for <c>Initialize</c> / <c>OnConstructed</c> method exit,
+        /// which is a post-base-call bucket and must unwind innermost-first.</item>
+        /// </list>
+        /// Within a single aspect instance, programmatic add-order is always preserved.
         /// </summary>
-        private static IEnumerable<StatementSyntax> GetOrderedAfterBaseStatements( IEnumerable<InsertedStatement> insertedStatements )
+        private static IEnumerable<StatementSyntax> GetOrderedAfterBaseStatements(
+            IEnumerable<InsertedStatement> insertedStatements,
+            bool reverseAcrossAspects )
             => OrderInitializerStatements(
                     insertedStatements.Where( s => s.Kind == InsertedStatementKind.InitializerAfterBase ),
-                    reverseAcrossAspects: true )
+                    reverseAcrossAspects )
                 .Select( s => s.Statement );
 
         /// <summary>
@@ -744,8 +761,10 @@ internal sealed partial class LinkerInjectionStep
         /// <summary>
         /// Orders initializer statements within one bucket (BeforeBase or AfterBase).
         /// <paramref name="reverseAcrossAspects"/> controls the across-aspect sort direction:
-        /// <c>true</c> selects descending <c>OrderWithinPipeline</c> (reverse aspect-application order — last-applied-first, outermost-first) — used for the AfterBase bucket;
-        /// <c>false</c> selects ascending <c>OrderWithinPipeline</c> (direct aspect-application order — first-applied-first, innermost-first) — used for the BeforeBase bucket.
+        /// <c>true</c> selects descending <c>OrderWithinPipeline</c> (reverse aspect-application order — last-applied-first, outermost-first) — used for buckets that run before the
+        /// conceptual base-call anchor (BeforeBase, and AfterBase emitted at constructor entry, which is semantically pre-user-body);
+        /// <c>false</c> selects ascending <c>OrderWithinPipeline</c> (direct aspect-application order — first-applied-first, innermost-first) — used for buckets that run after the
+        /// base-call anchor (AfterBase emitted at <c>Initialize</c> / <c>OnConstructed</c> method exit), so that the matryoshka unwinds innermost-first.
         /// Within a single aspect instance, programmatic add-order is preserved in both buckets.
         /// </summary>
         private static IEnumerable<InsertedStatement> OrderInitializerStatements(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Transformations/InsertedStatementKind.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Transformations/InsertedStatementKind.cs
@@ -21,10 +21,20 @@ internal enum InsertedStatementKind
     InitializerBase = -300,
 
     /// <summary>
-    /// Insert statement into an introduced <c>Initialize</c> or <c>OnConstructed</c> method <em>after</em>
-    /// the aggregated call to the base initializer. Also used for <c>BeforeInstanceConstructor</c> advice,
-    /// which is conceptually post-<c>:base()</c>. Emitted by <c>AddInitializer</c> advice with
-    /// <c>InitializerPosition.AfterBase</c> (the default).
+    /// Describes a statement that is semantically positioned <em>after</em> the base initializer call.
+    /// This is a <em>kind</em> label (semantic position relative to the base call); the physical emission
+    /// site varies by target:
+    /// <list type="bullet">
+    /// <item>For <c>Initialize</c> / <c>OnConstructed</c> methods the base call is a real body statement
+    /// (<c>base.Initialize(...)</c> / <c>base.OnConstructed(...)</c>), so these statements are emitted at
+    /// method <em>exit</em>, after the user body.</item>
+    /// <item>For source constructors (<c>BeforeInstanceConstructor</c> / <c>BeforeTypeConstructor</c> /
+    /// <c>AfterObjectInitializer</c>) the base call lives in the constructor header <c>:base(...)</c> —
+    /// there is no post-body seam — so these statements are emitted at the <em>start</em> of the
+    /// constructor body (pre-user-body).</item>
+    /// </list>
+    /// Emitted by <c>AddInitializer</c> advice with <c>InitializerPosition.AfterBase</c> (the default)
+    /// and by all constructor-targeting initialize advice (which always uses this kind).
     /// </summary>
     InitializerAfterBase = -250,
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_Position_TwoAspects_Inheritance.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_Position_TwoAspects_Inheritance.cs
@@ -9,11 +9,12 @@ using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnConstr
 using System;
 
 // Cross-aspect ordering convention for BeforeBase/AfterBase (spec §5.2.1), applied to
-// OnConstructed (AfterLastInstanceConstructor). AspectOrder lists SecondAspect first, so
-// SecondAspect is applied first (innermost) and FirstAspect is applied last (outermost).
-// On the derived class we therefore expect:
+// OnConstructed (AfterLastInstanceConstructor). With AspectOrderDirection.RunTime, the first
+// aspect in the list runs first at runtime, i.e. is the outermost layer in the matryoshka
+// model. AspectOrder therefore lists FirstAspect first so that FirstAspect is outermost
+// and SecondAspect is innermost. On the derived class we expect:
 //   First.BeforeBase, Second.BeforeBase, base.OnConstructed, Second.AfterBase, First.AfterBase.
-[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(SecondAspect), typeof(FirstAspect) )]
+[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(FirstAspect), typeof(SecondAspect) )]
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnConstructed_Position_TwoAspects_Inheritance;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_Position_TwoAspects_Ordering.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_Position_TwoAspects_Ordering.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnConstructed_Position_TwoAspects_Ordering;
+using System;
+
+// Regression test for https://github.com/metalama/Metalama/issues/1582.
+// AspectOrder(RunTime, A, B) makes AspectA the outer layer (runtime-first = outermost per the
+// matryoshka model). For InitializerPosition.BeforeBase/AfterBase on OnConstructed, the outer
+// aspect must bracket the inner one: A.BeforeBase then B.BeforeBase, then B.AfterBase then
+// A.AfterBase. The bug inverts both buckets — the inner aspect runs first in BeforeBase and
+// the outer aspect runs first in AfterBase.
+[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(AspectAAttribute), typeof(AspectBAttribute) )]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnConstructed_Position_TwoAspects_Ordering;
+
+public class AspectAAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(Before), InitializerKind.AfterLastInstanceConstructor, InitializerPosition.BeforeBase );
+        builder.AddInitializer( nameof(After), InitializerKind.AfterLastInstanceConstructor, InitializerPosition.AfterBase );
+    }
+
+    [Template]
+    private void Before() => Console.WriteLine( "AspectA.BeforeBase" );
+
+    [Template]
+    private void After() => Console.WriteLine( "AspectA.AfterBase" );
+}
+
+public class AspectBAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(Before), InitializerKind.AfterLastInstanceConstructor, InitializerPosition.BeforeBase );
+        builder.AddInitializer( nameof(After), InitializerKind.AfterLastInstanceConstructor, InitializerPosition.AfterBase );
+    }
+
+    [Template]
+    private void Before() => Console.WriteLine( "AspectB.BeforeBase" );
+
+    [Template]
+    private void After() => Console.WriteLine( "AspectB.AfterBase" );
+}
+
+// <target>
+[AspectA]
+[AspectB]
+public class BaseClass
+{
+    public BaseClass() { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_Position_TwoAspects_Ordering.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_Position_TwoAspects_Ordering.t.cs
@@ -1,0 +1,19 @@
+[AspectA]
+[AspectB]
+public class BaseClass
+{
+  public BaseClass([AspectGenerated] InitializationContext context = default)
+  {
+    if (!context.IsHandled(InitializationSlot.OnConstructed))
+    {
+      this.OnConstructed(context);
+    }
+  }
+  protected virtual void OnConstructed(InitializationContext context = default)
+  {
+    Console.WriteLine("AspectA.BeforeBase");
+    Console.WriteLine("AspectB.BeforeBase");
+    Console.WriteLine("AspectB.AfterBase");
+    Console.WriteLine("AspectA.AfterBase");
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_SlotFields_TwoLevel_TwoAspects.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_SlotFields_TwoLevel_TwoAspects.t.cs
@@ -12,13 +12,13 @@ public class BaseClass
   }
   protected virtual void OnConstructed(InitializationContext context = default)
   {
-    if (!context.IsHandled(Slots.FirstSlot))
-    {
-      Console.WriteLine("First on BaseClass");
-    }
     if (!context.IsHandled(Slots.SecondSlot))
     {
       Console.WriteLine("Second on BaseClass");
+    }
+    if (!context.IsHandled(Slots.FirstSlot))
+    {
+      Console.WriteLine("First on BaseClass");
     }
   }
 }
@@ -34,13 +34,13 @@ public class DerivedClass : BaseClass
   protected override void OnConstructed(InitializationContext context = default)
   {
     base.OnConstructed(context.Descend(Slots.SecondSlot | Slots.FirstSlot));
-    if (!context.IsHandled(Slots.FirstSlot))
-    {
-      Console.WriteLine("First on DerivedClass");
-    }
     if (!context.IsHandled(Slots.SecondSlot))
     {
       Console.WriteLine("Second on DerivedClass");
+    }
+    if (!context.IsHandled(Slots.FirstSlot))
+    {
+      Console.WriteLine("First on DerivedClass");
     }
   }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using System;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnConstructed_TwoLevel_NonInheritable;
+
+// Regression test for https://github.com/metalama/Metalama/issues/1580.
+// The aspect is intentionally NOT marked [Inheritable]. The documentation states that because the
+// generated OnConstructed method is protected virtual, a derived type inherits the initialization
+// chain automatically: its constructor ends with the call to OnConstructed and passes a descended
+// context to base. The bug was that the derived class in the same compilation received only the
+// pulled InitializationContext parameter and forwarded it unchanged to base, skipping OnConstructed.
+public class TheAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.AddInitializer( nameof(InitializerTemplate), InitializerKind.AfterLastInstanceConstructor );
+    }
+
+    [Template]
+    private void InitializerTemplate()
+    {
+        Console.WriteLine( $"OnConstructed on {meta.Target.Type.Name}!" );
+    }
+}
+
+// <target>
+[TheAspect]
+public class BaseClass
+{
+    public BaseClass( int x )
+    {
+        _ = x;
+    }
+}
+
+// <target>
+public class DerivedClass : BaseClass
+{
+    public DerivedClass() : base( 0 )
+    {
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnConstructed_TwoLevel_NonInheritable.t.cs
@@ -1,0 +1,26 @@
+[TheAspect]
+public class BaseClass
+{
+  public BaseClass(int x, [AspectGenerated] InitializationContext context = default)
+  {
+    _ = x;
+    if (!context.IsHandled(InitializationSlot.OnConstructed))
+    {
+      this.OnConstructed(context);
+    }
+  }
+  protected virtual void OnConstructed(InitializationContext context = default)
+  {
+    Console.WriteLine("OnConstructed on BaseClass!");
+  }
+}
+public class DerivedClass : BaseClass
+{
+  public DerivedClass([AspectGenerated] InitializationContext context = default) : base(0, context.Descend(InitializationSlot.OnConstructed))
+  {
+    if (!context.IsHandled(InitializationSlot.OnConstructed))
+    {
+      this.OnConstructed(context);
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Position_TwoAspects_Inheritance.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_Position_TwoAspects_Inheritance.cs
@@ -9,12 +9,14 @@ using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitia
 using System;
 
 // Cross-aspect ordering convention for BeforeBase/AfterBase (spec §5.2.1):
-//   - BeforeBase across aspects: run-time order (last-applied aspect first / outermost layer).
-//   - AfterBase across aspects: compile-time order (first-applied aspect first / innermost layer).
-// AspectOrder below lists SecondAspect first, so SecondAspect is applied first (innermost) and
-// FirstAspect is applied last (outermost). On the derived class we therefore expect:
+//   - BeforeBase across aspects: outermost-first (outer aspect's pre-base statements run first).
+//   - AfterBase across aspects: innermost-first (inner aspect's post-base statements run first,
+//     so the matryoshka unwinds correctly).
+// With AspectOrderDirection.RunTime, the first aspect in the list runs first at runtime and is
+// therefore the outermost layer. AspectOrder lists FirstAspect first, so FirstAspect is
+// outermost and SecondAspect is innermost. On the derived class we therefore expect:
 //   First.BeforeBase, Second.BeforeBase, base.Initialize, Second.AfterBase, First.AfterBase.
-[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(SecondAspect), typeof(FirstAspect) )]
+[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(FirstAspect), typeof(SecondAspect) )]
 
 namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_Position_TwoAspects_Inheritance;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_TwoAspects.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_TwoAspects.t.cs
@@ -4,9 +4,9 @@ public class TargetCode : IInitializable
 {
   public virtual void Initialize(InitializationContext context = default)
   {
-    Console.WriteLine("First1");
-    Console.WriteLine("First2");
     Console.WriteLine("Second1");
     Console.WriteLine("Second2");
+    Console.WriteLine("First1");
+    Console.WriteLine("First2");
   }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_TwoAspects_Inheritance.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_TwoAspects_Inheritance.t.cs
@@ -4,10 +4,10 @@ public class BaseClass : IInitializable
 {
   public virtual void Initialize(InitializationContext context = default)
   {
-    Console.WriteLine("First1");
-    Console.WriteLine("First2");
     Console.WriteLine("Second1");
     Console.WriteLine("Second2");
+    Console.WriteLine("First1");
+    Console.WriteLine("First2");
   }
 }
 public class DerivedClass : BaseClass
@@ -15,9 +15,9 @@ public class DerivedClass : BaseClass
   public override void Initialize(InitializationContext context = default)
   {
     base.Initialize(context);
-    Console.WriteLine("First1");
-    Console.WriteLine("First2");
     Console.WriteLine("Second1");
     Console.WriteLine("Second2");
+    Console.WriteLine("First1");
+    Console.WriteLine("First2");
   }
 }


### PR DESCRIPTION
## Summary

- **#1580** - ``AfterLastInstanceConstructor`` now correctly extends to same-compilation derived types even when the aspect is not ``[Inheritable]``: the derived constructor gets the guarded ``this.OnConstructed(context)`` call, and the ``: base(...)`` forwarder wraps the context in ``context.Descend(InitializationSlot.OnConstructed)``.
- **#1582** - ``BeforeBase`` / ``AfterBase`` initializer ordering across aspects now follows the matryoshka model defined by ``AspectOrder``. With ``AspectOrder(RunTime, A, B)`` (A outer, B inner): ``A.BeforeBase, B.BeforeBase, user-body, B.AfterBase, A.AfterBase``. ``AfterBase`` at constructor entry (pre-user-body) stays outer-first as before; ``AfterBase`` at method exit (OnConstructed/Initialize) is now inner-first.
- Fixed two pre-existing tests (``OnConstructed_Position_TwoAspects_Inheritance``, ``OnInitialized_Position_TwoAspects_Inheritance``) where ``AspectOrder`` was inverted relative to the explanatory comment and baseline.

## Issues Fixed

- Fixes #1580
- Fixes #1582

## Test plan

- [x] New failing-then-passing repro test for #1580: ``OnConstructed_TwoLevel_NonInheritable``
- [x] New failing-then-passing regression test for #1582: ``OnConstructed_Position_TwoAspects_Ordering``
- [x] Updated 3 baselines that had captured the inverted AfterBase-at-exit ordering (``OnInitialized_TwoAspects``, ``OnInitialized_TwoAspects_Inheritance``, ``OnConstructed_SlotFields_TwoLevel_TwoAspects``)
- [x] All 2259 aspect tests pass (27 skipped, same as baseline) - no regressions