### PR TITLE
Fix AfterObjectInitializer multi-slot Descend on derived types (#1584)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/InitializeMethodAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/InitializeMethodAdvice.cs
@@ -97,7 +97,7 @@ internal sealed class InitializeMethodAdvice : Advice<AddInitializerAdviceResult
                         new Dictionary<IMember, IMember> { { interfaceMethod, ownInitializeMethod } } ) );
             }
 
-            return Succeed( ownInitializeMethod, baseMethod: null );
+            return Succeed( ownInitializeMethod, GetBaseMethodForAggregation( ownInitializeMethod ) );
         }
 
         // Resolves or introduces the Initialize method and returns it along with the base method (if overriding).
@@ -120,7 +120,7 @@ internal sealed class InitializeMethodAdvice : Advice<AddInitializerAdviceResult
                             this ) );
                 }
 
-                return Succeed( existingMethod, baseMethod: null );
+                return Succeed( existingMethod, GetBaseMethodForAggregation( existingMethod ) );
             }
 
             // Inherited from a base type — override it if possible.
@@ -131,6 +131,16 @@ internal sealed class InitializeMethodAdvice : Advice<AddInitializerAdviceResult
         }
 
         return Succeed( IntroduceMethod( null ), baseMethod: null );
+
+        // When the target type already exposes a peer-aspect-introduced Initialize override, we still
+        // need to emit the aggregatable base-call transformation so that this aspect's slot fields
+        // combine with peer aspects' into a single `base.Initialize(context.Descend(slotA | slotB))`.
+        // User-authored methods are excluded: they are assumed to forward to base already in source,
+        // and injecting another base call would duplicate it.
+        static IMethod? GetBaseMethodForAggregation( IMethod existing )
+            => existing.Origin.Kind == DeclarationOriginKind.Aspect && existing.IsOverride
+                ? existing.OverriddenMethod
+                : null;
 
         IMethod IntroduceMethod( IMethod? baseMethodToOverride )
         {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_SlotFields_TwoLevel_TwoAspects.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_SlotFields_TwoLevel_TwoAspects.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.RunTime.Initialization;
+using System;
+using System.Linq;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_SlotFields_TwoLevel_TwoAspects;
+
+[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(FirstAspect), typeof(SecondAspect) )]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Initialization.OnInitialized_SlotFields_TwoLevel_TwoAspects;
+
+// Two different aspects, each declaring its own user slot, are applied together to a base class
+// that is also inherited. The derived override must call `base.Initialize(...)` with BOTH slots
+// combined via the `|` operator, so that each aspect's guard in the base body (which checks
+// `context.IsHandled(ItsOwnSlot)`) correctly skips when the derived layer will re-run it.
+//
+// This is the AfterObjectInitializer / Initialize counterpart of
+// OnConstructed_SlotFields_TwoLevel_TwoAspects (which exercises AfterLastInstanceConstructor).
+public static class Slots
+{
+    public static readonly InitializationSlot FirstSlot = InitializationSlot.Allocate();
+    public static readonly InitializationSlot SecondSlot = InitializationSlot.Allocate();
+}
+
+[Inheritable]
+public class FirstAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var slotField = ((INamedType) builder.Target.Compilation.Factory
+                .GetTypeByReflectionType( typeof(Slots) ))
+            .Fields.OfName( nameof(Slots.FirstSlot) ).Single();
+
+        builder.AddInitializer(
+            nameof(Template),
+            InitializerKind.AfterObjectInitializer,
+            slotFields: new[] { slotField } );
+    }
+
+    [Template]
+    private void Template( InitializationContext context )
+    {
+        if ( !context.IsHandled( Slots.FirstSlot ) )
+        {
+            Console.WriteLine( $"First on {meta.Target.Type.Name}" );
+        }
+    }
+}
+
+[Inheritable]
+public class SecondAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var slotField = ((INamedType) builder.Target.Compilation.Factory
+                .GetTypeByReflectionType( typeof(Slots) ))
+            .Fields.OfName( nameof(Slots.SecondSlot) ).Single();
+
+        builder.AddInitializer(
+            nameof(Template),
+            InitializerKind.AfterObjectInitializer,
+            slotFields: new[] { slotField } );
+    }
+
+    [Template]
+    private void Template( InitializationContext context )
+    {
+        if ( !context.IsHandled( Slots.SecondSlot ) )
+        {
+            Console.WriteLine( $"Second on {meta.Target.Type.Name}" );
+        }
+    }
+}
+
+// <target>
+[FirstAspect]
+[SecondAspect]
+public class BaseClass
+{
+}
+
+// <target>
+public class DerivedClass : BaseClass
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_SlotFields_TwoLevel_TwoAspects.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Initialization/OnInitialized_SlotFields_TwoLevel_TwoAspects.t.cs
@@ -1,0 +1,31 @@
+[FirstAspect]
+[SecondAspect]
+public class BaseClass : IInitializable
+{
+  public virtual void Initialize(InitializationContext context = default)
+  {
+    if (!context.IsHandled(Slots.SecondSlot))
+    {
+      Console.WriteLine("Second on BaseClass");
+    }
+    if (!context.IsHandled(Slots.FirstSlot))
+    {
+      Console.WriteLine("First on BaseClass");
+    }
+  }
+}
+public class DerivedClass : BaseClass
+{
+  public override void Initialize(InitializationContext context = default)
+  {
+    base.Initialize(context.Descend(Slots.SecondSlot | Slots.FirstSlot));
+    if (!context.IsHandled(Slots.SecondSlot))
+    {
+      Console.WriteLine("Second on DerivedClass");
+    }
+    if (!context.IsHandled(Slots.FirstSlot))
+    {
+      Console.WriteLine("First on DerivedClass");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1584.

When two peer aspects on the same type each register an `AddInitializer` advice with `InitializerKind.AfterObjectInitializer` and their own `slotFields`, the first aspect introduces `DerivedClass.Initialize` as an override of `BaseClass.Initialize` and emits an aggregatable `InitializeBaseCallTransformation`. The second aspect then took the "ownInitializeMethod" early-return branch in `InitializeMethodAdvice.Implement` (because the override now exists on the target type) and passed `baseMethod: null`, so no transformation was emitted for it and its slot was never combined into the final `base.Initialize(context.Descend(...))` call.

The fix emits the aggregatable transformation for aspect-introduced overrides so that peer aspects'' slot fields are OR-combined into a single `Descend` argument. User-authored methods stay excluded — they are assumed to forward to base already in source, and injecting another base call would duplicate it.

This is the `AfterObjectInitializer` counterpart of the `AfterLastInstanceConstructor` fix from #1583.

## Test plan

- [x] New regression test `OnInitialized_SlotFields_TwoLevel_TwoAspects` (mirrors the existing `OnConstructed_SlotFields_TwoLevel_TwoAspects`) — fails before the fix, passes after.
- [x] Full `Aspects.Initialization` test family (138 tests) passes.