### PR TITLE
Fix typeof(TSelf) collapses to open generic definition (#1579)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateTypeArgumentFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateTypeArgumentFactory.cs
@@ -26,9 +26,10 @@ internal sealed class TemplateTypeArgumentFactory
     {
         var syntax = context.SyntaxGenerator.TypeSyntax( type ).AssertNotNull();
 
-        // When the template argument is a canonical self-instance of a generic type (e.g. Handler<TMessage> for target Handler<TMessage>),
-        // we want 'typeof(TSelf)' to emit the bound form 'typeof(Handler<TMessage>)', not the open form 'typeof(Handler<>)'. See #1579.
-        var syntaxForTypeOf = context.SyntaxGenerator.TypeOfExpression( type, preferClosedType: true ).Type;
+        // When the template argument is a generic type whose type arguments are its own type parameters (e.g. Handler<TMessage>
+        // for target Handler<TMessage>), the enclosing type parameters are in scope at the template expansion site, so we emit
+        // the constructed form 'typeof(Handler<TMessage>)' rather than the unbound generic type 'typeof(Handler<>)'. See #1579.
+        var syntaxForTypeOf = context.SyntaxGenerator.TypeOfExpression( type, preferConstructedType: true ).Type;
 
         return new TemplateTypeArgument( name, type, syntax, syntaxForTypeOf );
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateTypeArgumentFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/TemplateTypeArgumentFactory.cs
@@ -25,7 +25,10 @@ internal sealed class TemplateTypeArgumentFactory
     public static TemplateTypeArgument Create( IType type, string name, SyntaxGenerationContext context )
     {
         var syntax = context.SyntaxGenerator.TypeSyntax( type ).AssertNotNull();
-        var syntaxForTypeOf = context.SyntaxGenerator.TypeOfExpression( type ).Type;
+
+        // When the template argument is a canonical self-instance of a generic type (e.g. Handler<TMessage> for target Handler<TMessage>),
+        // we want 'typeof(TSelf)' to emit the bound form 'typeof(Handler<TMessage>)', not the open form 'typeof(Handler<>)'. See #1579.
+        var syntaxForTypeOf = context.SyntaxGenerator.TypeOfExpression( type, preferClosedType: true ).Type;
 
         return new TemplateTypeArgument( name, type, syntax, syntaxForTypeOf );
     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/CompilationHelpers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/CompilationHelpers.cs
@@ -47,7 +47,7 @@ internal sealed class CompilationHelpers : ICompilationHelpers
 
     public SerializableTypeId GetSerializableId( IType type ) => type.GetSerializableTypeId();
 
-    public IExpression ToTypeOfExpression( IType type, bool preferClosedType = false ) => new TypeOfUserExpression( type, preferClosedType );
+    public IExpression ToTypeOfExpression( IType type, bool preferConstructedType = false ) => new TypeOfUserExpression( type, preferConstructedType );
 
     public bool DerivesFrom( INamedType left, INamedType right, DerivedTypesOptions options = DerivedTypesOptions.Default )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/CompilationHelpers.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/CompilationHelpers.cs
@@ -47,7 +47,7 @@ internal sealed class CompilationHelpers : ICompilationHelpers
 
     public SerializableTypeId GetSerializableId( IType type ) => type.GetSerializableTypeId();
 
-    public IExpression ToTypeOfExpression( IType type ) => new TypeOfUserExpression( type );
+    public IExpression ToTypeOfExpression( IType type, bool preferClosedType = false ) => new TypeOfUserExpression( type, preferClosedType );
 
     public bool DerivesFrom( INamedType left, INamedType right, DerivedTypesOptions options = DerivedTypesOptions.Default )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -72,16 +72,17 @@ public sealed partial class ContextualSyntaxGenerator
         ITypeSymbol type,
         IReadOnlyDictionary<string, TypeSyntax>? substitutions = null,
         bool keepNullableAnnotations = false,
-        bool preferClosedType = false )
+        bool preferConstructedType = false )
     {
         var typeSyntax = this.TypeSyntax( type );
 
-        // A type is considered an open generic definition only when its type arguments are bound to the type's own type parameters.
-        // When preferClosedType is true, we keep the bound form (useful for canonical self-instances produced by templates).
+        // By default, a generic type whose type arguments are its own type parameters is emitted as the unbound generic type
+        // (e.g. 'List<>'). When preferConstructedType is true, we keep the constructed form (e.g. 'List<T>'), which is what
+        // callers want when the type parameters are in scope at the emission site (e.g. for a template's canonical self-instance).
         var shouldRemoveTypeArguments = type.Kind == SymbolKind.NamedType
                                         && type is INamedTypeSymbol { IsGenericType: true } namedTypeSymbol
                                         && namedTypeSymbol.IsGenericTypeDefinition()
-                                        && !preferClosedType;
+                                        && !preferConstructedType;
 
         if ( shouldRemoveTypeArguments )
         {
@@ -125,21 +126,22 @@ public sealed partial class ContextualSyntaxGenerator
         IReadOnlyDictionary<string, TypeSyntax>? substitutions = null,
         bool keepNullableAnnotations = false,
         bool bypassSymbols = false,
-        bool preferClosedType = false )
+        bool preferConstructedType = false )
     {
         if ( type.GetSymbol() is { } symbol && !bypassSymbols )
         {
-            return this.TypeOfExpression( symbol, substitutions, keepNullableAnnotations, preferClosedType );
+            return this.TypeOfExpression( symbol, substitutions, keepNullableAnnotations, preferConstructedType );
         }
 
         var typeSyntax = this.TypeSyntax( type );
 
-        // A type is considered an open generic definition only when its type parameters are bound to themselves (canonical generic instance).
-        // When preferClosedType is true, we keep the bound form (useful for canonical self-instances produced by templates).
+        // By default, a generic type whose type arguments are its own type parameters is emitted as the unbound generic type
+        // (e.g. 'List<>'). When preferConstructedType is true, we keep the constructed form (e.g. 'List<T>'), which is what
+        // callers want when the type parameters are in scope at the emission site (e.g. for a template's canonical self-instance).
         var shouldRemoveTypeArguments =
             type.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Extension
             && type is INamedType { TypeParameters.Count: > 0, IsCanonicalGenericInstance: true }
-            && !preferClosedType;
+            && !preferConstructedType;
 
         if ( shouldRemoveTypeArguments )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/SyntaxGeneration/ContextualSyntaxGenerator.cs
@@ -71,17 +71,22 @@ public sealed partial class ContextualSyntaxGenerator
     internal TypeOfExpressionSyntax TypeOfExpression(
         ITypeSymbol type,
         IReadOnlyDictionary<string, TypeSyntax>? substitutions = null,
-        bool keepNullableAnnotations = false )
+        bool keepNullableAnnotations = false,
+        bool preferClosedType = false )
     {
         var typeSyntax = this.TypeSyntax( type );
 
-        if ( type.Kind == SymbolKind.NamedType && type is INamedTypeSymbol { IsGenericType: true } namedType )
+        // A type is considered an open generic definition only when its type arguments are bound to the type's own type parameters.
+        // When preferClosedType is true, we keep the bound form (useful for canonical self-instances produced by templates).
+        var shouldRemoveTypeArguments = type.Kind == SymbolKind.NamedType
+                                        && type is INamedTypeSymbol { IsGenericType: true } namedTypeSymbol
+                                        && namedTypeSymbol.IsGenericTypeDefinition()
+                                        && !preferClosedType;
+
+        if ( shouldRemoveTypeArguments )
         {
-            if ( namedType.IsGenericTypeDefinition() )
-            {
-                // In generic definitions, we must remove type arguments.
-                typeSyntax = (TypeSyntax) new RemoveTypeArgumentsRewriter().Visit( typeSyntax ).AssertNotNull();
-            }
+            // In generic definitions, we must remove type arguments.
+            typeSyntax = (TypeSyntax) new RemoveTypeArgumentsRewriter().Visit( typeSyntax ).AssertNotNull();
         }
 
         if ( !keepNullableAnnotations )
@@ -95,13 +100,13 @@ public sealed partial class ContextualSyntaxGenerator
         // In any typeof, we must change dynamic to object.
         typeSyntax = (TypeSyntax) dynamicToVarRewriter.Visit( typeSyntax ).AssertNotNull();
 
-        SafeSyntaxRewriter rewriter = type.Kind switch
-        {
-            SymbolKind.NamedType when type is INamedTypeSymbol { IsGenericType: true } genericType && genericType.IsGenericTypeDefinition() =>
-                new RemoveTypeArgumentsRewriter(),
-            SymbolKind.NamedType when type is INamedTypeSymbol { IsGenericType: true } => new RemoveReferenceNullableAnnotationsRewriterForSymbol( type ),
-            _ => dynamicToVarRewriter
-        };
+        SafeSyntaxRewriter rewriter = shouldRemoveTypeArguments
+            ? new RemoveTypeArgumentsRewriter()
+            : type.Kind switch
+            {
+                SymbolKind.NamedType when type is INamedTypeSymbol { IsGenericType: true } => new RemoveReferenceNullableAnnotationsRewriterForSymbol( type ),
+                _ => dynamicToVarRewriter
+            };
 
         var rewrittenTypeSyntax = rewriter.Visit( typeSyntax ).AssertNotNull();
 
@@ -119,17 +124,24 @@ public sealed partial class ContextualSyntaxGenerator
         IType type,
         IReadOnlyDictionary<string, TypeSyntax>? substitutions = null,
         bool keepNullableAnnotations = false,
-        bool bypassSymbols = false )
+        bool bypassSymbols = false,
+        bool preferClosedType = false )
     {
         if ( type.GetSymbol() is { } symbol && !bypassSymbols )
         {
-            return this.TypeOfExpression( symbol, substitutions, keepNullableAnnotations );
+            return this.TypeOfExpression( symbol, substitutions, keepNullableAnnotations, preferClosedType );
         }
 
         var typeSyntax = this.TypeSyntax( type );
 
-        if ( type.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Extension
-             && type is INamedType { TypeParameters.Count: > 0, IsCanonicalGenericInstance: true } )
+        // A type is considered an open generic definition only when its type parameters are bound to themselves (canonical generic instance).
+        // When preferClosedType is true, we keep the bound form (useful for canonical self-instances produced by templates).
+        var shouldRemoveTypeArguments =
+            type.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Extension
+            && type is INamedType { TypeParameters.Count: > 0, IsCanonicalGenericInstance: true }
+            && !preferClosedType;
+
+        if ( shouldRemoveTypeArguments )
         {
             // In generic definitions, we must remove type arguments.
             typeSyntax = (TypeSyntax) new RemoveTypeArgumentsRewriter().Visit( typeSyntax ).AssertNotNull();
@@ -146,14 +158,14 @@ public sealed partial class ContextualSyntaxGenerator
         // In any typeof, we must change dynamic to object.
         typeSyntax = (TypeSyntax) dynamicToVarRewriter.Visit( typeSyntax ).AssertNotNull();
 
-        SafeSyntaxRewriter rewriter = type.TypeKind switch
-        {
-            TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Extension
-                when type is INamedType { TypeParameters.Count: > 0, IsCanonicalGenericInstance: true } => new RemoveTypeArgumentsRewriter(),
-            TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Extension
-                when type is INamedType { TypeParameters.Count: > 0 } => new RemoveReferenceNullableAnnotationsRewriter( type ),
-            _ => dynamicToVarRewriter
-        };
+        SafeSyntaxRewriter rewriter = shouldRemoveTypeArguments
+            ? new RemoveTypeArgumentsRewriter()
+            : type.TypeKind switch
+            {
+                TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Delegate or TypeKind.Enum or TypeKind.Extension
+                    when type is INamedType { TypeParameters.Count: > 0 } => new RemoveReferenceNullableAnnotationsRewriter( type ),
+                _ => dynamicToVarRewriter
+            };
 
         var rewrittenTypeSyntax = rewriter.Visit( typeSyntax ).AssertNotNull();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/TypeOfUserExpression.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/TypeOfUserExpression.cs
@@ -12,16 +12,16 @@ namespace Metalama.Framework.Engine.Templating.Expressions
     internal sealed class TypeOfUserExpression : UserExpression
     {
         private readonly IType _type;
-        private readonly bool _preferClosedType;
+        private readonly bool _preferConstructedType;
 
-        public TypeOfUserExpression( IType type, bool preferClosedType = false )
+        public TypeOfUserExpression( IType type, bool preferConstructedType = false )
         {
             this._type = type;
-            this._preferClosedType = preferClosedType;
+            this._preferConstructedType = preferConstructedType;
         }
 
         protected override ExpressionSyntax ToSyntax( SyntaxSerializationContext syntaxSerializationContext, IType? targetType = null )
-            => syntaxSerializationContext.SyntaxGenerator.TypeOfExpression( this._type, preferClosedType: this._preferClosedType );
+            => syntaxSerializationContext.SyntaxGenerator.TypeOfExpression( this._type, preferConstructedType: this._preferConstructedType );
 
         protected override bool CanBeNull => false;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/TypeOfUserExpression.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/Expressions/TypeOfUserExpression.cs
@@ -12,14 +12,16 @@ namespace Metalama.Framework.Engine.Templating.Expressions
     internal sealed class TypeOfUserExpression : UserExpression
     {
         private readonly IType _type;
+        private readonly bool _preferClosedType;
 
-        public TypeOfUserExpression( IType type )
+        public TypeOfUserExpression( IType type, bool preferClosedType = false )
         {
             this._type = type;
+            this._preferClosedType = preferClosedType;
         }
 
         protected override ExpressionSyntax ToSyntax( SyntaxSerializationContext syntaxSerializationContext, IType? targetType = null )
-            => syntaxSerializationContext.SyntaxGenerator.TypeOfExpression( this._type );
+            => syntaxSerializationContext.SyntaxGenerator.TypeOfExpression( this._type, preferClosedType: this._preferClosedType );
 
         protected override bool CanBeNull => false;
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/ICompilationHelpers.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/ICompilationHelpers.cs
@@ -22,7 +22,7 @@ namespace Metalama.Framework.Code
 
         SerializableTypeId GetSerializableId( IType type );
 
-        IExpression ToTypeOfExpression( IType type, bool preferClosedType = false );
+        IExpression ToTypeOfExpression( IType type, bool preferConstructedType = false );
 
         bool DerivesFrom( INamedType left, INamedType right, DerivedTypesOptions options = DerivedTypesOptions.Default );
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/ICompilationHelpers.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/ICompilationHelpers.cs
@@ -22,7 +22,7 @@ namespace Metalama.Framework.Code
 
         SerializableTypeId GetSerializableId( IType type );
 
-        IExpression ToTypeOfExpression( IType type );
+        IExpression ToTypeOfExpression( IType type, bool preferClosedType = false );
 
         bool DerivesFrom( INamedType left, INamedType right, DerivedTypesOptions options = DerivedTypesOptions.Default );
 

--- a/Metalama.Framework/src/Metalama.Framework/Code/TypeExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/TypeExtensions.cs
@@ -125,7 +125,14 @@ namespace Metalama.Framework.Code
         /// Gets an <see cref="IExpression"/> representing 'typeof' expression for the given type.
         /// </summary>
         /// <param name="type">The type.</param>
+        /// <param name="preferClosedType">
+        /// When <c>true</c> and <paramref name="type"/> is a canonical generic instance (i.e. its type parameters
+        /// are bound to themselves), the generated <c>typeof</c> expression keeps the bound form (e.g. <c>typeof(List&lt;T&gt;)</c>)
+        /// instead of collapsing to the open generic definition (e.g. <c>typeof(List&lt;&gt;)</c>). The default is <c>false</c>,
+        /// which preserves the legacy behavior of emitting the open generic form for canonical instances.
+        /// </param>
         /// <returns>An <see cref="IExpression"/> representing <c>typeof(type)</c>.</returns>
-        public static IExpression ToTypeOfExpression( this IType type ) => ((ICompilationInternal) type.Compilation).Helpers.ToTypeOfExpression( type );
+        public static IExpression ToTypeOfExpression( this IType type, bool preferClosedType = false )
+            => ((ICompilationInternal) type.Compilation).Helpers.ToTypeOfExpression( type, preferClosedType );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Code/TypeExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Code/TypeExtensions.cs
@@ -125,14 +125,16 @@ namespace Metalama.Framework.Code
         /// Gets an <see cref="IExpression"/> representing 'typeof' expression for the given type.
         /// </summary>
         /// <param name="type">The type.</param>
-        /// <param name="preferClosedType">
-        /// When <c>true</c> and <paramref name="type"/> is a canonical generic instance (i.e. its type parameters
-        /// are bound to themselves), the generated <c>typeof</c> expression keeps the bound form (e.g. <c>typeof(List&lt;T&gt;)</c>)
-        /// instead of collapsing to the open generic definition (e.g. <c>typeof(List&lt;&gt;)</c>). The default is <c>false</c>,
-        /// which preserves the legacy behavior of emitting the open generic form for canonical instances.
+        /// <param name="preferConstructedType">
+        /// When <c>true</c> and <paramref name="type"/> is a generic type whose type arguments are its own type
+        /// parameters (e.g. <c>List&lt;T&gt;</c> where <c>T</c> is <c>List</c>'s type parameter), the generated
+        /// <c>typeof</c> expression keeps the constructed form (e.g. <c>typeof(List&lt;T&gt;)</c>) instead of
+        /// emitting the unbound generic type (e.g. <c>typeof(List&lt;&gt;)</c>). Use this only when the type
+        /// parameters are in scope at the emission site. The default is <c>false</c>, which emits the unbound
+        /// generic type for such inputs.
         /// </param>
         /// <returns>An <see cref="IExpression"/> representing <c>typeof(type)</c>.</returns>
-        public static IExpression ToTypeOfExpression( this IType type, bool preferClosedType = false )
-            => ((ICompilationInternal) type.Compilation).Helpers.ToTypeOfExpression( type, preferClosedType );
+        public static IExpression ToTypeOfExpression( this IType type, bool preferConstructedType = false )
+            => ((ICompilationInternal) type.Compilation).Helpers.ToTypeOfExpression( type, preferConstructedType );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Linq;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+#pragma warning disable CS8618, CS0169, CS0649
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1579;
+
+public interface IMessage { }
+
+public static class MessageRouter
+{
+    public static void Register( Type handlerType, Type messageType ) { }
+}
+
+public class RegisterMessageHandlerAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var selfType = builder.Target.MakeGenericInstance(
+            builder.Target.TypeParameters.ToArray<IType>() );
+
+        builder.AddInitializer(
+            nameof(RegisterHandler),
+            InitializerKind.BeforeTypeConstructor,
+            args: new
+            {
+                TSelf = selfType,
+                TMessage = builder.Target.TypeParameters[0]
+            } );
+    }
+
+    [Template]
+    private static void RegisterHandler<[CompileTime] TSelf, [CompileTime] TMessage>()
+    {
+        MessageRouter.Register( typeof(TSelf), typeof(TMessage) );
+    }
+}
+
+// <target>
+[RegisterMessageHandler]
+public partial class Handler<TMessage> where TMessage : IMessage { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579.t.cs
@@ -1,0 +1,9 @@
+[RegisterMessageHandler]
+public partial class Handler<TMessage>
+  where TMessage : IMessage
+{
+  static Handler()
+  {
+    global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1579.MessageRouter.Register(typeof(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1579.Handler<TMessage>), typeof(TMessage));
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579_ToTypeOfExpression.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579_ToTypeOfExpression.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1579_ToTypeOfExpression;
+
+internal class TestAspect : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceMethod( nameof(GetTypes) );
+    }
+
+    [Template]
+    private object?[] GetTypes()
+    {
+        var openDefinition = (INamedType) TypeFactory.GetType( typeof(List<>) );
+        var canonicalSelfInstance = meta.Target.Type.MakeGenericInstance( meta.Target.Type.TypeParameters.ToArray<IType>() );
+
+        return new object?[]
+        {
+            // Default behavior: open generic definition stays open.
+            openDefinition.ToTypeOfExpression().Value,
+
+            // preferClosedType=true on a canonical self-instance keeps the bound form.
+            canonicalSelfInstance.ToTypeOfExpression( preferClosedType: true ).Value,
+
+            // Default behavior: a canonical self-instance is still collapsed to the open form (backward-compatible).
+            canonicalSelfInstance.ToTypeOfExpression().Value
+        };
+    }
+}
+
+// <target>
+[TestAspect]
+internal partial class Target<T> { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579_ToTypeOfExpression.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579_ToTypeOfExpression.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Metalama.Framework.Advising;
@@ -26,13 +25,13 @@ internal class TestAspect : TypeAspect
 
         return new object?[]
         {
-            // Default behavior: open generic definition stays open.
+            // Default behavior: unbound generic type stays unbound.
             openDefinition.ToTypeOfExpression().Value,
 
-            // preferClosedType=true on a canonical self-instance keeps the bound form.
-            canonicalSelfInstance.ToTypeOfExpression( preferClosedType: true ).Value,
+            // preferConstructedType=true on a generic instance bound to its own type parameters emits the constructed form.
+            canonicalSelfInstance.ToTypeOfExpression( preferConstructedType: true ).Value,
 
-            // Default behavior: a canonical self-instance is still collapsed to the open form (backward-compatible).
+            // Default behavior: the generic instance bound to its own type parameters is emitted as the unbound generic type (backward-compatible).
             canonicalSelfInstance.ToTypeOfExpression().Value
         };
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579_ToTypeOfExpression.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Bugs/Bug1579_ToTypeOfExpression.t.cs
@@ -1,0 +1,13 @@
+[TestAspect]
+internal partial class Target<T>
+{
+  private global::System.Object? [] GetTypes()
+  {
+    return (global::System.Object? [])new object? []
+    {
+      typeof(global::System.Collections.Generic.List<>),
+      typeof(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1579_ToTypeOfExpression.Target<T>),
+      typeof(global::Metalama.Framework.Tests.AspectTests.Tests.Aspects.Bugs.Bug1579_ToTypeOfExpression.Target<>)
+    };
+  }
+}


### PR DESCRIPTION
Fixes #1579.

## Progress

- [x] Phase 1: Understand the issue
- [x] Phase 2: Reproduce with a failing regression test
- [x] Phase 3: Implement the fix
- [x] Phase 4: Build and test (zero warnings, all 2262 aspect tests + 1841 unit tests pass)
- [x] Phase 5: Finalize
- [x] Address review feedback (rename per C# spec terminology)

## Summary

When a template emitted `typeof(TSelf)` and the aspect passed a canonical self-instantiation of the target generic type (e.g. `builder.Target.MakeGenericInstance(builder.Target.TypeParameters)`), the emitted syntax was collapsed to the unbound generic type (e.g. `typeof(Handler<>)` instead of `typeof(Handler<TMessage>)`).

Root cause: in `ContextualSyntaxGenerator.TypeOfExpression`, the check `IsCanonicalGenericInstance` (or `IsGenericTypeDefinition()` on the symbol path) treats canonical self-instances the same as unbound generic types and strips the type arguments.

## Fix

Added an optional `preferConstructedType` parameter (per @gfraiteur's guidance) to:

- `IType.ToTypeOfExpression( preferConstructedType: ... )` (public API, default `false`, backward compatible)
- `ICompilationHelpers.ToTypeOfExpression` (internal interface)
- `TypeOfUserExpression` (internal)
- `ContextualSyntaxGenerator.TypeOfExpression` (internal)

When `preferConstructedType` is `true`, the constructed form (type arguments kept) is preserved instead of emitting the unbound generic type. Use this only when the type parameters are in scope at the emission site.

In `TemplateTypeArgumentFactory.Create`, the template pipeline now passes `preferConstructedType: true` when producing the `SyntaxForTypeOf` used to rewrite `typeof(T)` expressions inside templates. This is the primary bug fix path.

## Tests

- `Bug1579` — regression test from the issue report (template `typeof(TSelf)` where `TSelf` is the canonical self-instance of the target generic type).
- `Bug1579_ToTypeOfExpression` — exercises the new public API parameter directly, including the backward-compatible default behavior.
- `TypeofGenericTypeDefinition` (existing) — verifies that `typeof(List<>)` still emits the unbound form when using the default.

— Claude for @PostSharpAgent