### PR TITLE
Fix XML doc for IntroduceExtensionBlock (#1587)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework/Advising/IAdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Advising/IAdviceFactory.cs
@@ -1036,7 +1036,7 @@ namespace Metalama.Framework.Advising
 
         /// <summary>
         /// Introduces a new extension block into a static class. Extension blocks allow adding
-        /// extension members (methods, properties, indexers) to a type (represented as an <see cref="IType"/>). Requires C# 14+ and Roslyn 5.0+.
+        /// extension members (methods, properties, operators) to a type (represented as an <see cref="IType"/>). Requires C# 14+ and Roslyn 5.0+.
         /// </summary>
         /// <param name="targetStaticClass">The static class into which the extension block must be introduced.
         ///     Only static classes can contain extension blocks.</param>
@@ -1058,7 +1058,7 @@ namespace Metalama.Framework.Advising
 
         /// <summary>
         /// Introduces a new extension block into a static class. Extension blocks allow adding
-        /// extension members (methods, properties, indexers) to a type  (represented as a <see cref="Type"/>). Requires C# 14+ and Roslyn 5.0+.
+        /// extension members (methods, properties, operators) to a type  (represented as a <see cref="Type"/>). Requires C# 14+ and Roslyn 5.0+.
         /// </summary>
         /// <param name="targetStaticClass">The static class into which the extension block must be introduced.</param>
         /// <param name="receiverType">The <see cref="Type"/> being extended.</param>


### PR DESCRIPTION
Fixes #1587.

## Summary

The XML summary on both overloads of `IAdviceFactory.IntroduceExtensionBlock` incorrectly listed `indexers` as a supported extension-member kind. Aspect tests (e.g. `ErrorIndexerIntoExtensionBlock.cs`) confirm that indexers are rejected with `LAMA0041`, while operators are supported. Replaced `indexers` with `operators` in both XML summaries.

## Checklist

- [x] Phase 1: Understand issue
- [x] Phase 2: Topic branch and draft PR created (doc-only change — no behavioral regression test applicable)
- [x] Phase 3: Fix applied
- [x] Phase 4: `Build.ps1 build` succeeded in Metalama with zero warnings across all solutions
- [x] Phase 5: Mark PR ready and request review

— Claude for @PostSharpAgent