### PR TITLE
Add WpfPrecompile pipeline mode for MarkupCompilePass1 (#1590)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/ExecutionScenario.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/ExecutionScenario.cs
@@ -31,6 +31,10 @@ namespace Metalama.Framework.Engine.CodeModel
 
         public static ExecutionScenario CompileTime { get; } = new( nameof(CompileTime), false, true, false, false );
 
+        // Real batch compile, but emits design-time-style signature stubs instead of running the linker.
+        // Used by the WPF MarkupCompilePass1 temporary assembly, whose only consumer is the XAML type resolver.
+        public static ExecutionScenario WpfPrecompile { get; } = new( nameof(WpfPrecompile), false, false, false, false );
+
         public static ExecutionScenario CodeFix { get; } = new( nameof(CodeFix), true, false, true, true );
 
         public static ExecutionScenario Introspection { get; } = new( nameof(Introspection), false, true, true, false );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/CompilationScenario.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/CompilationScenario.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Metalama.Framework.Engine.Options;
+
+/// <summary>
+/// Identifies the kind of compilation Metalama is participating in. Settable via the
+/// <c>MetalamaCompilationScenario</c> MSBuild property and exposed as <see cref="IProjectOptions.CompilationScenario"/>.
+/// Most builds use <see cref="Default"/>; specific values exist for build contexts that need a tailored pipeline.
+/// </summary>
+public enum CompilationScenario
+{
+    /// <summary>
+    /// The standard compile-time pipeline: front-end + linker, producing a fully transformed assembly.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// The temporary assembly produced by WPF's <c>MarkupCompilePass1</c> (project name suffix <c>_wpftmp</c>).
+    /// The pipeline emits aspect-introduced member signatures only; the linker is skipped because the assembly
+    /// is consumed only by the XAML compiler for type resolution and then discarded.
+    /// </summary>
+    WpfPrecompile = 1,
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/DefaultProjectOptions.cs
@@ -132,6 +132,8 @@ public class DefaultProjectOptions : IProjectOptions
 
     public virtual bool VerifyOutputCode => false;
 
+    public virtual CompilationScenario CompilationScenario => CompilationScenario.Default;
+
     // IProjectOptions is currently not used as a dictionary key, so we can throw here.
     public sealed override int GetHashCode() => throw new NotImplementedException();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
@@ -249,4 +249,11 @@ public interface IProjectOptions : IProjectService, IEquatable<IProjectOptions>
     /// This helps detect issues like missing whitespace that can cause syntax errors.
     /// </summary>
     bool VerifyOutputCode { get; }
+
+    /// <summary>
+    /// Gets the kind of compilation Metalama is participating in. Defaults to <see cref="Options.CompilationScenario.Default"/>.
+    /// Specific values trigger tailored pipelines (e.g. <see cref="Options.CompilationScenario.WpfPrecompile"/> for the
+    /// WPF MarkupCompilePass1 temporary assembly).
+    /// </summary>
+    CompilationScenario CompilationScenario { get; }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/IProjectOptions.cs
@@ -251,8 +251,8 @@ public interface IProjectOptions : IProjectService, IEquatable<IProjectOptions>
     bool VerifyOutputCode { get; }
 
     /// <summary>
-    /// Gets the kind of compilation Metalama is participating in. Defaults to <see cref="Options.CompilationScenario.Default"/>.
-    /// Specific values trigger tailored pipelines (e.g. <see cref="Options.CompilationScenario.WpfPrecompile"/> for the
+    /// Gets the kind of compilation Metalama is participating in. Defaults to <see cref="CompilationScenario.Default"/>.
+    /// Specific values trigger tailored pipelines (e.g. <see cref="CompilationScenario.WpfPrecompile"/> for the
     /// WPF MarkupCompilePass1 temporary assembly).
     /// </summary>
     CompilationScenario CompilationScenario { get; }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
@@ -255,7 +255,10 @@ public partial class MSBuildProjectOptions : DefaultProjectOptions
     private T GetEnumOption<T>( string name, T defaultValue = default )
         where T : struct, Enum
     {
-        if ( this._source.TryGetValue( name, out var s ) && Enum.TryParse<T>( s, ignoreCase: true, out var value ) )
+        if ( this._source.TryGetValue( name, out var s )
+             && !string.IsNullOrWhiteSpace( s )
+             && Enum.TryParse<T>( s, ignoreCase: true, out var value )
+             && Enum.IsDefined( typeof(T), value ) )
         {
             return value;
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildProjectOptions.cs
@@ -190,6 +190,9 @@ public partial class MSBuildProjectOptions : DefaultProjectOptions
     public override bool VerifyOutputCode => this.GetBooleanOption( MSBuildPropertyNames.MetalamaVerifyOutputCode );
 
     [Memo]
+    public override CompilationScenario CompilationScenario => this.GetEnumOption<CompilationScenario>( MSBuildPropertyNames.MetalamaCompilationScenario );
+
+    [Memo]
     public override ImmutableArray<string> SourceGeneratorAttributes => this.GetListOption( MSBuildPropertyNames.MetalamaSourceGeneratorAttributes );
 
     public override bool AvoidLockingExtensionAssemblies => this.GetBooleanOption( MSBuildPropertyNames.MetalamaAvoidLockingExtensionAssemblies );
@@ -247,6 +250,17 @@ public partial class MSBuildProjectOptions : DefaultProjectOptions
         }
 
         return null;
+    }
+
+    private T GetEnumOption<T>( string name, T defaultValue = default )
+        where T : struct, Enum
+    {
+        if ( this._source.TryGetValue( name, out var s ) && Enum.TryParse<T>( s, ignoreCase: true, out var value ) )
+        {
+            return value;
+        }
+
+        return defaultValue;
     }
 
     [return: NotNullIfNotNull( nameof(defaultValue) )]

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/MSBuildPropertyNames.cs
@@ -56,6 +56,7 @@ public static class MSBuildPropertyNames
     public const string MetalamaValidateRunTimeCode = nameof(MetalamaValidateRunTimeCode);
     public const string TargetFrameworks = nameof(TargetFrameworks);
     public const string MetalamaVerifyOutputCode = nameof(MetalamaVerifyOutputCode);
+    public const string MetalamaCompilationScenario = nameof(MetalamaCompilationScenario);
 
     public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
         MetalamaBuildTouchFile,
@@ -98,5 +99,6 @@ public static class MSBuildPropertyNames
         MetalamaAssemblyLocatorSalt,
         MetalamaValidateRunTimeCode,
         TargetFrameworks,
-        MetalamaVerifyOutputCode );
+        MetalamaVerifyOutputCode,
+        MetalamaCompilationScenario );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Options/ProjectOptionsWrapper.cs
@@ -118,6 +118,8 @@ public abstract class ProjectOptionsWrapper : IProjectOptions
 
     public virtual bool VerifyOutputCode => this.Wrapped.VerifyOutputCode;
 
+    public virtual CompilationScenario CompilationScenario => this.Wrapped.CompilationScenario;
+
     public sealed override int GetHashCode() => throw new NotImplementedException();
 
     public sealed override bool Equals( object? obj ) => this.Equals( obj as IProjectOptions );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
@@ -41,6 +41,16 @@ public class CompileTimeAspectPipeline : AspectPipeline
         serviceProvider,
         executionScenario ?? ExecutionScenario.CompileTime ) { }
 
+    /// <summary>
+    /// Creates the right <see cref="CompileTimeAspectPipeline"/> for the project's <see cref="IProjectOptions.CompilationScenario"/>.
+    /// </summary>
+    public static CompileTimeAspectPipeline Create( ProjectServiceProvider serviceProvider )
+        => serviceProvider.GetRequiredService<IProjectOptions>().CompilationScenario switch
+        {
+            CompilationScenario.WpfPrecompile => new WpfPrecompileAspectPipeline( serviceProvider ),
+            _ => new CompileTimeAspectPipeline( serviceProvider )
+        };
+
     protected override SyntaxGenerationOptions GetSyntaxGenerationOptions()
     {
         var projectOptions = this.ServiceProvider.GetRequiredService<IProjectOptions>();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompileAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompileAspectPipeline.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.Services;
+
+namespace Metalama.Framework.Engine.Pipeline.CompileTime;
+
+/// <summary>
+/// A <see cref="CompileTimeAspectPipeline"/> for the WPF MarkupCompilePass1 temporary assembly. Reuses the full
+/// compile-time front-end but emits aspect-introduced member signatures only — the linker is skipped because the
+/// temp assembly is consumed only by the XAML compiler for type resolution and then discarded.
+/// </summary>
+public sealed class WpfPrecompileAspectPipeline : CompileTimeAspectPipeline
+{
+    public WpfPrecompileAspectPipeline( ProjectServiceProvider serviceProvider )
+        : base( serviceProvider, ExecutionScenario.WpfPrecompile ) { }
+
+    private protected override HighLevelPipelineStage CreateHighLevelStage(
+        PipelineStageConfiguration configuration,
+        CompileTimeProject compileTimeProject )
+        => new WpfPrecompilePipelineStage( configuration.AspectLayers );
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompilePipelineStage.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompilePipelineStage.cs
@@ -44,7 +44,22 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
                 diagnosticSink,
                 cancellationToken );
 
-            var addTransformations = introducedSyntaxTrees.SelectAsArray( t => SyntaxTreeTransformation.AddTree( t.GeneratedSyntaxTree.WithFilePath( t.Name ) ) );
+            // Generated trees default to C# 1 parse options; copy the project's options so the new trees share the
+            // same LangVersion, preprocessor symbols and nullable context as the original sources.
+            var projectParseOptions = input.LastCompilation.SyntaxTrees.Values.FirstOrDefault()?.Options;
+
+            var addTransformations = introducedSyntaxTrees.SelectAsArray(
+                t =>
+                {
+                    var tree = t.GeneratedSyntaxTree.WithFilePath( t.Name );
+
+                    if ( projectParseOptions != null )
+                    {
+                        tree = tree.WithRootAndOptions( tree.GetRoot( cancellationToken ), projectParseOptions );
+                    }
+
+                    return SyntaxTreeTransformation.AddTree( tree );
+                } );
 
             var compilationWithStubs = input.LastCompilation.Update( addTransformations );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompilePipelineStage.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompilePipelineStage.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Compiler;
+using Metalama.Framework.Engine.AspectOrdering;
+using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Pipeline.DesignTime;
+using Metalama.Framework.Engine.Transformations;
+using Metalama.Framework.Engine.Utilities.Threading;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metalama.Framework.Engine.Pipeline.CompileTime
+{
+    /// <summary>
+    /// A <see cref="HighLevelPipelineStage"/> for the WPF MarkupCompilePass1 temporary assembly. Reuses the full compile-time
+    /// front-end (aspect discovery, eligibility, advice, template expansion of observable members) but skips the linker —
+    /// the temp assembly only needs aspect-introduced member signatures so the XAML compiler can resolve type references.
+    /// Emits the same partial-class stubs the design-time source generator produces.
+    /// </summary>
+    internal sealed class WpfPrecompilePipelineStage : HighLevelPipelineStage
+    {
+        public WpfPrecompilePipelineStage( IReadOnlyList<OrderedAspectLayer> aspectLayers )
+            : base( aspectLayers ) { }
+
+        protected override async Task<AspectPipelineResult> GetStageResultAsync(
+            AspectPipelineConfiguration pipelineConfiguration,
+            AspectPipelineResult input,
+            PipelineStepsResult pipelineStepsResult,
+            TestableCancellationToken cancellationToken )
+        {
+            var diagnosticSink = new UserDiagnosticSink( pipelineConfiguration.ServiceProvider );
+
+            var introducedSyntaxTrees = await DesignTimeSyntaxTreeGenerator.GenerateDesignTimeSyntaxTreesAsync(
+                pipelineConfiguration.ServiceProvider,
+                input.LastCompilation,
+                pipelineStepsResult.FirstCompilation,
+                pipelineStepsResult.LastCompilation,
+                pipelineStepsResult.Transformations,
+                diagnosticSink,
+                cancellationToken );
+
+            var addTransformations = introducedSyntaxTrees.SelectAsArray( t => SyntaxTreeTransformation.AddTree( t.GeneratedSyntaxTree.WithFilePath( t.Name ) ) );
+
+            var compilationWithStubs = input.LastCompilation.Update( addTransformations );
+
+            return new AspectPipelineResult(
+                compilationWithStubs,
+                input.Project,
+                input.AspectLayers,
+                input.FirstCompilationModel.AssertNotNull(),
+                null,
+                input.Configuration,
+                input.Diagnostics
+                    .Concat( pipelineStepsResult.Diagnostics )
+                    .Concat( diagnosticSink.ToImmutable() ),
+                new PipelineContributorSources( input.ContributorSources.Contributors.Add( pipelineStepsResult.OverflowAspectSource ) ),
+                input.ExternallyInheritableAspects.AddRange(
+                    pipelineStepsResult.InheritableAspectInstances.SelectAsReadOnlyCollection( i => new InheritableAspectInstance( i ) ) ),
+                pipelineStepsResult.LastCompilation.Annotations,
+                input.TransitiveContributors,
+                additionalSyntaxTrees: input.AdditionalSyntaxTrees,
+                aspectInstanceResults: input.AspectInstanceResults.AddRange( pipelineStepsResult.AspectInstanceResults ),
+                additionalCompilationOutputFiles: input.AdditionalCompilationOutputFiles,
+                transformations: pipelineStepsResult.Transformations.ToImmutableArray<ITransformationBase>() );
+        }
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
@@ -91,11 +91,7 @@ public sealed partial class SourceTransformer : ISourceTransformerWithServices
             var projectServiceProvider = globalServices
                 .WithProjectScopedServices( projectOptions, context.Compilation );
 
-            using var pipeline = projectOptions.CompilationScenario switch
-            {
-                CompilationScenario.WpfPrecompile => (CompileTimeAspectPipeline) new WpfPrecompileAspectPipeline( projectServiceProvider ),
-                _ => new CompileTimeAspectPipeline( projectServiceProvider )
-            };
+            using var pipeline = CompileTimeAspectPipeline.Create( projectServiceProvider );
 
             var taskRunner = globalServices.GetRequiredService<ITaskRunner>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
@@ -91,7 +91,11 @@ public sealed partial class SourceTransformer : ISourceTransformerWithServices
             var projectServiceProvider = globalServices
                 .WithProjectScopedServices( projectOptions, context.Compilation );
 
-            using CompileTimeAspectPipeline pipeline = new( projectServiceProvider );
+            using var pipeline = projectOptions.CompilationScenario switch
+            {
+                CompilationScenario.WpfPrecompile => (CompileTimeAspectPipeline) new WpfPrecompileAspectPipeline( projectServiceProvider ),
+                _ => new CompileTimeAspectPipeline( projectServiceProvider )
+            };
 
             var taskRunner = globalServices.GetRequiredService<ITaskRunner>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.CompilerVisibleProperties.props
@@ -42,6 +42,7 @@
         <CompilerVisibleProperty Include="MetalamaValidateRunTimeCode"/>
         <CompilerVisibleProperty Include="TargetFrameworks"/>
         <CompilerVisibleProperty Include="MetalamaVerifyOutputCode"/>
+        <CompilerVisibleProperty Include="MetalamaCompilationScenario"/>
     </ItemGroup>
 
     <!-- More properties are already exported by Metalama.Compiler and don't need to be exported a second time. -->

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
@@ -52,6 +52,15 @@
         <IncludePackageReferencesDuringMarkupCompilation Condition="'$(IncludePackageReferencesDuringMarkupCompilation)'==''">true</IncludePackageReferencesDuringMarkupCompilation>
     </PropertyGroup>
 
+    <!-- Inside the WPF MarkupCompilePass1 temporary assembly (project name suffix _wpftmp), switch Metalama
+         to the WpfPrecompile compilation scenario. The pipeline then emits aspect-introduced member signatures
+         only and skips the linker, since the temp assembly is consumed only by the XAML compiler for type
+         resolution and then discarded. The full linker still runs in the real compile pass that follows.
+         The user can override by setting MetalamaCompilationScenario explicitly. See https://github.com/metalama/Metalama/issues/1590. -->
+    <PropertyGroup Condition="'$(UseWPF)'=='true' AND '$(MetalamaEnabled)'!='False' AND '$(MetalamaCompilationScenario)'==''">
+        <MetalamaCompilationScenario Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">WpfPrecompile</MetalamaCompilationScenario>
+    </PropertyGroup>
+
       <!-- The LangVersionImplicitlySet property is set by Metalama.Compiler when LangVersion is not defined, according to the current target framework.
          We change this value to our own lowest supported version. 
         -->

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/WpfPrecompileTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/WpfPrecompileTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Pipeline.CompileTime;
+using Metalama.Testing.UnitTesting;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Tests for the WPF precompile pipeline mode that emits aspect-introduced member signatures only,
+/// without running the linker. Used by WPF's MarkupCompilePass1 temporary assembly.
+/// </summary>
+public sealed class WpfPrecompileTests : UnitTestClass
+{
+    private const string _aspectThatIntroducesAMemberAndOverridesAMethod = """
+                                                                          using Metalama.Framework.Aspects;
+                                                                          using Metalama.Framework.Code;
+
+                                                                          class TrackChanges : TypeAspect
+                                                                          {
+                                                                              [Introduce]
+                                                                              public bool IsChanged { get; private set; }
+
+                                                                              [Introduce]
+                                                                              public void AcceptChanges() => this.IsChanged = false;
+                                                                          }
+
+                                                                          class LoggingAspect : OverrideMethodAspect
+                                                                          {
+                                                                              public override dynamic? OverrideMethod()
+                                                                              {
+                                                                                  System.Console.WriteLine("entering " + meta.Target.Method.Name);
+                                                                                  return meta.Proceed();
+                                                                              }
+                                                                          }
+
+                                                                          [TrackChanges]
+                                                                          partial class Document
+                                                                          {
+                                                                              public string? Name { get; set; }
+
+                                                                              [LoggingAspect]
+                                                                              public void Save() { }
+                                                                          }
+                                                                          """;
+
+    [Fact]
+    public async Task WpfPrecompile_EmitsIntroducedMemberSignatures()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCSharpCompilation( _aspectThatIntroducesAMemberAndOverridesAMethod );
+        var pipeline = new WpfPrecompileAspectPipeline( testContext.ServiceProvider );
+
+        var result = await pipeline.ExecuteAsync( null, null, compilation, default, testContext.CancellationToken );
+
+        Assert.True( result.IsSuccessful );
+
+        var addedTrees = result.Value.SyntaxTreeTransformations
+            .Where( t => t.OldTree == null )
+            .ToArray();
+
+        Assert.NotEmpty( addedTrees );
+
+        var introducedCode = string.Join( "\n", addedTrees.SelectAsArray( t => t.NewTree!.ToString() ) );
+
+        // Introduced members appear as signatures.
+        Assert.Contains( "IsChanged", introducedCode );
+        Assert.Contains( "AcceptChanges", introducedCode );
+
+        // The override aspect's body rewriting (the Console.WriteLine wrapping) does not.
+        Assert.DoesNotContain( "entering", introducedCode );
+    }
+
+    [Fact]
+    public async Task DefaultScenario_EmitsLinkedBodies()
+    {
+        // Negative control: same input under the default scenario produces transformed bodies (linker output),
+        // proving the WpfPrecompile assertions above are not vacuous.
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCSharpCompilation( _aspectThatIntroducesAMemberAndOverridesAMethod );
+        var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider );
+
+        var result = await pipeline.ExecuteAsync( null, null, compilation, default, testContext.CancellationToken );
+
+        Assert.True( result.IsSuccessful );
+
+        var allOutputCode = string.Join(
+            "\n",
+            result.Value.SyntaxTreeTransformations
+                .Select( t => (t.NewTree ?? t.OldTree)!.ToString() ) );
+
+        Assert.Contains( "entering", allOutputCode );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/MSBuildProjectOptionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/MSBuildProjectOptionsTests.cs
@@ -54,6 +54,39 @@ public sealed class MSBuildProjectOptionsTests
         Assert.Equal( touchFilePath, options.SourceGeneratorTouchFile );
     }
 
+    [Fact]
+    public void CompilationScenario_Unset_ReturnsDefault()
+    {
+        var options = new TestableMSBuildProjectOptions( new DictionaryOptionsSource( new() ) );
+
+        Assert.Equal( CompilationScenario.Default, options.CompilationScenario );
+    }
+
+    [Theory]
+    [InlineData( "WpfPrecompile" )]
+    [InlineData( "wpfprecompile" )]
+    [InlineData( "WPFPRECOMPILE" )]
+    public void CompilationScenario_KnownValue_IsParsedCaseInsensitively( string value )
+    {
+        var source = new DictionaryOptionsSource( new() { [MSBuildPropertyNames.MetalamaCompilationScenario] = value } );
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Equal( CompilationScenario.WpfPrecompile, options.CompilationScenario );
+    }
+
+    [Theory]
+    [InlineData( "" )]
+    [InlineData( "   " )]
+    [InlineData( "NotARealValue" )]
+    [InlineData( "999" )]
+    public void CompilationScenario_InvalidOrEmptyValue_FallsBackToDefault( string value )
+    {
+        var source = new DictionaryOptionsSource( new() { [MSBuildPropertyNames.MetalamaCompilationScenario] = value } );
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Equal( CompilationScenario.Default, options.CompilationScenario );
+    }
+
     private sealed class TestableMSBuildProjectOptions : MSBuildProjectOptions
     {
         public TestableMSBuildProjectOptions( IProjectOptionsSource source ) : base( source ) { }

--- a/Metalama.Framework/src/tests/Standalone/Issue1585/Issue1585.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585/Issue1585.csproj
@@ -2,20 +2,36 @@
 
     <!--
         Regression test for https://github.com/metalama/Metalama/issues/1588 (originally
-        reported as #1585).
+        reported as #1585) and for https://github.com/metalama/Metalama/issues/1590.
 
-        When a WPF project references aspect-introduced members from its XAML code-behind,
-        WPF's MarkupCompilePass1 target generates a temporary target assembly used to
-        resolve types referenced in XAML. That temp compile only includes PackageReferences
-        when IncludePackageReferencesDuringMarkupCompilation is true. If it is false,
-        Metalama (delivered as a PackageReference) does not run during the temp compile,
-        aspect-introduced members do not exist, and the temp compile fails with
-        CS0117/CS1061 - which then cascades into MC3074 for types referenced from XAML.
+        When a WPF project references aspect-introduced members from its XAML or its XAML
+        code-behind, WPF's MarkupCompilePass1 target generates a temporary target assembly
+        used to resolve types and members referenced in XAML. Two pieces of plumbing make
+        this work end-to-end:
 
-        Metalama.Framework.targets defaults IncludePackageReferencesDuringMarkupCompilation
-        to true when UseWPF is set, so the temp compile picks up the Metalama analyzer/targets
-        and the aspect-introduced members are seen by both the markup pre-pass and the real
-        compile. This project relies on that default (no explicit value).
+        1. IncludePackageReferencesDuringMarkupCompilation defaults to true so that Metalama
+           (delivered as a PackageReference) runs during the temp compile. Without this the
+           temp compile fails with CS0117/CS1061, cascading into MC3074. Tracked by #1588.
+
+        2. MetalamaCompilationScenario auto-defaults to WpfPrecompile when MSBuildProjectName
+           ends with _wpftmp (the WPF SDK's naming convention for the temp project). In that
+           mode Metalama runs the full front-end (aspect discovery, advice, template
+           expansion) but emits aspect-introduced member signatures only and skips the
+           linker, since the temp assembly is consumed only by the XAML compiler for type
+           resolution and then discarded. Tracked by #1590.
+
+        Both defaults are user-overridable. An explicit IncludePackageReferencesDuringMarkupCompilation=false
+        is rejected by MetalamaCheckMarkupCompilation since it is incompatible with Metalama
+        in a WPF project.
+
+        Coverage in this project:
+        - SelectSettingsWindowControl.xaml.cs references aspect-introduced *properties* and
+          *methods* on a referenced data type ([TrackChanges] on SwapTransformPackage).
+        - SelectSettingsWindowControl.xaml.cs has [WithButtonHandler] applied to the Window
+          itself, introducing an event handler method that is bound from XAML via Click=...,
+          which exercises XAML's compile-time event handler resolution.
+        - SelectSettingsWindowControl.xaml references a hand-written IValueConverter, which
+          fails with MC3074 if the temp compile fails for any reason.
     -->
     <PropertyGroup>
         <OutputType>WinExe</OutputType>

--- a/Metalama.Framework/src/tests/Standalone/Issue1585/SelectSettingsWindowControl.xaml
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585/SelectSettingsWindowControl.xaml
@@ -9,5 +9,8 @@
     </Window.Resources>
     <Grid>
         <TextBlock Text="{Binding Name, Converter={StaticResource EnumToStringConverter}}" />
+        <!-- Click="OnButtonClicked" binds to an aspect-introduced method on the code-behind class.
+             Resolved at MarkupCompilePass1, so the temp assembly must contain that signature. -->
+        <Button Content="OK" Click="OnButtonClicked" />
     </Grid>
 </Window>

--- a/Metalama.Framework/src/tests/Standalone/Issue1585/SelectSettingsWindowControl.xaml.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585/SelectSettingsWindowControl.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 
 namespace Issue1585;
 
+[WithButtonHandler]
 public partial class SelectSettingsWindowControl : Window
 {
     private readonly SwapTransformPackage _package = new();

--- a/Metalama.Framework/src/tests/Standalone/Issue1585/SwapTransformPackage.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585/SwapTransformPackage.cs
@@ -1,7 +1,7 @@
 namespace Issue1585;
 
 [TrackChanges]
-public class SwapTransformPackage
+public partial class SwapTransformPackage
 {
     public string? Name { get; set; }
 }

--- a/Metalama.Framework/src/tests/Standalone/Issue1585/WithButtonHandlerAttribute.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585/WithButtonHandlerAttribute.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using Metalama.Framework.Aspects;
+
+namespace Issue1585;
+
+// Introduces an event handler method whose signature matches WPF's RoutedEventHandler.
+// XAML's Click="OnButtonClicked" binding is resolved at MarkupCompilePass1 against the
+// code-behind class, so this aspect-introduced method must exist in the temp assembly
+// for the XAML compile to succeed.
+public class WithButtonHandlerAttribute : TypeAspect
+{
+    [Introduce]
+    public void OnButtonClicked( object sender, RoutedEventArgs e ) { }
+}


### PR DESCRIPTION
## Summary

Closes #1590.

Introduces a purpose-built pipeline mode for the WPF `MarkupCompilePass1` temporary assembly. The temp assembly only exists so the XAML compiler can resolve type references — it is then thrown away. Today the full Metalama linker runs anyway, doubling the work per WPF build.

The new mode reuses the full compile-time front-end (aspect discovery, eligibility, advice, template expansion of observable members) but emits aspect-introduced member *signatures* via the design-time emitter and skips the linker entirely.

## Changes

- `ExecutionScenario.WpfPrecompile` (`IsDesignTime=false`, `CapturesNonObservableTransformations=false`).
- `WpfPrecompilePipelineStage` — new `HighLevelPipelineStage` that calls `DesignTimeSyntaxTreeGenerator` and feeds the partial-class stubs into `LastCompilation` so they flow back to `Metalama.Compiler` as added syntax trees.
- `WpfPrecompileAspectPipeline : CompileTimeAspectPipeline` — derived class that wires the scenario in its constructor and returns the new stage from `CreateHighLevelStage`. Keeps `CompileTimeAspectPipeline` itself unbranched.
- New `CompilationScenario` enum (`Default`, `WpfPrecompile`) on `IProjectOptions`, settable via the `MetalamaCompilationScenario` MSBuild property.
- `MSBuildProjectOptions.GetEnumOption<T>` helper, used for the new property.
- `Metalama.Framework.targets` auto-defaults `MetalamaCompilationScenario=WpfPrecompile` when `UseWPF=true` and `MSBuildProjectName.EndsWith('_wpftmp')` (the WPF SDK's own naming convention for `GenerateTemporaryTargetAssembly`).
- `SourceTransformer` constructs the right pipeline based on the project option.

## Test plan

- [x] `WpfPrecompileTests` — asserts introduced signatures are emitted and linker output is absent under `WpfPrecompile`; negative control under `Default` proves the assertion is not vacuous.
- [x] `Metalama.Framework.Tests.UnitTests` `CompileTime` suite (154 tests) passes — no regressions in the linker path.
- [x] `tests/Standalone/Issue1585` expanded: `[WithButtonHandler]` aspect introduces a `Click` event handler signature on the Window itself, XAML binds `Click="OnButtonClicked"` — exercises XAML's compile-time event-handler resolution against an aspect-introduced method.
- [ ] User to run `Build.ps1 build` to validate the standalone test against the local package and to surface the change to cross-solution consumers.