### PR TITLE
Fix parallel multi-TFM build collision on MetalamaSourceGenerator.touch (#1597)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
@@ -78,21 +78,25 @@
         </PropertyGroup>
     </Target>
 
-    <Target Name="ExportMetalamaFrameworkProperties" BeforeTargets="PrepareForBuild">
-        <Error Text="The BaseIntermediateOutputPath property is not defined." Condition="'$(BaseIntermediateOutputPath)'==''"/>
+    <!-- Both touch files live under $(IntermediateOutputPath) so they are TFM-specific. Multi-targeted
+         projects build their TFMs in parallel; sharing a single file across TFMs (as we briefly did under
+         $(BaseIntermediateOutputPath) for the source-generator touch file) causes MSB3371 file-lock
+         collisions. See https://github.com/metalama/Metalama/issues/1597.
+         If $(IntermediateOutputPath) is undefined (e.g. when the .NET SDK has not yet resolved), the
+         path properties stay empty and CreateMetalamaTouchFiles is skipped — IProjectOptions
+         tolerates a null SourceGeneratorTouchFile/BuildTouchFile. -->
+    <Target Name="ExportMetalamaFrameworkProperties" BeforeTargets="PrepareForBuild" Condition="'$(IntermediateOutputPath)'!=''">
         <PropertyGroup>
             <MetalamaBuildTouchFile>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),$(IntermediateOutputPath),'MetalamaBuild.touch'))</MetalamaBuildTouchFile>
-            <MetalamaSourceGeneratorTouchFile>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),$(BaseIntermediateOutputPath),'MetalamaSourceGenerator.touch'))</MetalamaSourceGeneratorTouchFile>
+            <MetalamaSourceGeneratorTouchFile>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),$(IntermediateOutputPath),'MetalamaSourceGenerator.touch'))</MetalamaSourceGeneratorTouchFile>
         </PropertyGroup>
     </Target>
 
-    <Target Name="CreateMetalamaTouchFiles" BeforeTargets="BeforeCompile">
+    <Target Name="CreateMetalamaTouchFiles" BeforeTargets="BeforeCompile" Condition="'$(MetalamaBuildTouchFile)'!='' AND '$(MetalamaSourceGeneratorTouchFile)'!=''">
         <!-- We create a touch file every time that the file is absent. This file is used to signal
              the design-time Metalama pipeline that a build has started. When the design-time pipeline needs this information again, it will
              delete the file. It should do that only when the source code has changed (even if it is not saved). We don't overwrite an existing
-             file because this would break incremental build.
-             We use Touch with AlwaysCreate=true which handles concurrent access gracefully when
-             multiple TFMs build in parallel since they share the same obj directory. -->
+             file because this would break incremental build. -->
         <Touch Files="$(MetalamaBuildTouchFile)" AlwaysCreate="true"/>
         <Touch Files="$(MetalamaSourceGeneratorTouchFile)" AlwaysCreate="true"/>
         <ItemGroup>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/MSBuildProjectOptionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Options/MSBuildProjectOptionsTests.cs
@@ -54,6 +54,19 @@ public sealed class MSBuildProjectOptionsTests
         Assert.Equal( touchFilePath, options.SourceGeneratorTouchFile );
     }
 
+    [Fact]
+    public void MissingSourceGeneratorTouchFile_ReturnsNull()
+    {
+        // When IntermediateOutputPath is undefined (e.g. SDK not yet resolved), the targets file skips
+        // ExportMetalamaFrameworkProperties and the property is never exposed to the compiler. See #1597.
+        var source = new DictionaryOptionsSource( new Dictionary<string, string>() );
+
+        var options = new TestableMSBuildProjectOptions( source );
+
+        Assert.Null( options.SourceGeneratorTouchFile );
+        Assert.Null( options.BuildTouchFile );
+    }
+
     private sealed class TestableMSBuildProjectOptions : MSBuildProjectOptions
     {
         public TestableMSBuildProjectOptions( IProjectOptionsSource source ) : base( source ) { }


### PR DESCRIPTION
## Summary

Fixes #1597 — multi-TFM projects (e.g. `Metalama.Patterns.Wpf`) were intermittently failing with **MSB3371** because all TFMs wrote to the same `obj\MetalamaSourceGenerator.touch` file in parallel.

## Root cause

PR #1478 (issue #670) moved `MetalamaSourceGeneratorTouchFile` from `$(IntermediateOutputPath)` (per-TFM, e.g. `obj\Debug\net8.0-windows\`) to `$(BaseIntermediateOutputPath)` (the shared `obj\` root) to work around a different problem: the property could end up empty when the .NET SDK had not yet resolved (typical in some IDE / restore scenarios). The shared path then made the parallel `Touch` task collide on a single file lock.

## Fix

- Revert the touch-file path back to `$(IntermediateOutputPath)` so it is TFM-specific and parallel TFMs no longer race.
- Address the original empty-string concern at the right layer: gate `ExportMetalamaFrameworkProperties` on `'$(IntermediateOutputPath)'!=''` and gate `CreateMetalamaTouchFiles` on the touch-file properties being non-empty. When the SDK has not resolved, no touch file is written and the properties stay empty. Downstream consumers (`MSBuildProjectOptions.SourceGeneratorTouchFile`, `AnalysisProcessProjectSourceGenerator.TryGetTouchFilePath`, `BaseSourceGenerator.GetTouchId`, `TouchFileHelper.GetTouchId`) already tolerate a null/empty path.
- Drop the `<Error Text="The BaseIntermediateOutputPath property is not defined." />` guard since the empty case is now handled by skipping the targets instead of failing the build.
- Add a regression unit test (`MissingSourceGeneratorTouchFile_ReturnsNull`) to lock in the "property absent → null" contract that the new targets-file conditions rely on.

## Test plan

- [x] `MSBuildProjectOptionsTests` — 5 / 5 pass (4 existing + 1 new).
- [ ] CI multi-TFM pack of `Metalama.Patterns` no longer hits MSB3371 on `MetalamaSourceGenerator.touch`.
- [ ] Smoke-test design-time scenario where `IntermediateOutputPath` resolves correctly: touch file is created and source generator re-runs as expected.

— Claude for @gfraiteur