### PR TITLE
Skip non-observable advice early in AdviceFactory (#1599)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/AddContractAdviceResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/AddContractAdviceResult.cs
@@ -30,5 +30,8 @@ internal sealed class AddContractAdviceResult<T> : AdviceResult, IAddContractAdv
 
     public static AddContractAdviceResult<T> Ignored( IAdviceFactoryImpl adviceFactory ) => new( AdviceOutcome.Ignore, adviceFactory );
 
-    public static AddContractAdviceResult<T> Skipped( IAdviceFactoryImpl adviceFactory ) => new( AdviceOutcome.Skipped, adviceFactory );
+    // Preserves the target declaration reference so user code reading `result.Declaration` after a
+    // pipeline-driven skip continues to see the original target.
+    public static AddContractAdviceResult<T> Skipped( IAdviceFactoryImpl adviceFactory, IRef<T>? declaration = null )
+        => new( AdviceOutcome.Skipped, adviceFactory, declaration );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/AddContractAdviceResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Contracts/AddContractAdviceResult.cs
@@ -29,4 +29,6 @@ internal sealed class AddContractAdviceResult<T> : AdviceResult, IAddContractAdv
     public T Declaration => this.Resolve( this._declaration );
 
     public static AddContractAdviceResult<T> Ignored( IAdviceFactoryImpl adviceFactory ) => new( AdviceOutcome.Ignore, adviceFactory );
+
+    public static AddContractAdviceResult<T> Skipped( IAdviceFactoryImpl adviceFactory ) => new( AdviceOutcome.Skipped, adviceFactory );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/AddInitializerAdviceResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/AddInitializerAdviceResult.cs
@@ -16,4 +16,6 @@ internal sealed class AddInitializerAdviceResult : AdviceResult, IAddInitializer
         outcome,
         adviceFactory,
         diagnostics ) { }
+
+    public static AddInitializerAdviceResult Skipped( IAdviceFactoryImpl adviceFactory ) => new( AdviceOutcome.Skipped, adviceFactory );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMemberAdviceResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMemberAdviceResult.cs
@@ -33,6 +33,9 @@ internal sealed class OverrideMemberAdviceResult<TMember> : AdviceResult, IOverr
 
     public OverrideAccessorAdviceResult<TMember> GetAccessor( Func<TMember, IMethod?> getAccessor ) => new( this, getAccessor );
 
-    public static OverrideMemberAdviceResult<TMember> Skipped( AdviceKind adviceKind, IAdviceFactoryImpl adviceFactory )
-        => new( adviceKind, AdviceOutcome.Skipped, adviceFactory );
+    // Preserves the target declaration reference so that user code reading `result.Declaration` after a
+    // pipeline-driven skip continues to see the original member (matching the success path which sets
+    // Declaration to the override target).
+    public static OverrideMemberAdviceResult<TMember> Skipped( AdviceKind adviceKind, IAdviceFactoryImpl adviceFactory, IRef<TMember>? declaration = null )
+        => new( adviceKind, AdviceOutcome.Skipped, adviceFactory, declaration );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMemberAdviceResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Override/OverrideMemberAdviceResult.cs
@@ -32,4 +32,7 @@ internal sealed class OverrideMemberAdviceResult<TMember> : AdviceResult, IOverr
     public TMember Declaration => this.Resolve( this._declaration );
 
     public OverrideAccessorAdviceResult<TMember> GetAccessor( Func<TMember, IMethod?> getAccessor ) => new( this, getAccessor );
+
+    public static OverrideMemberAdviceResult<TMember> Skipped( AdviceKind adviceKind, IAdviceFactoryImpl adviceFactory )
+        => new( adviceKind, AdviceOutcome.Skipped, adviceFactory );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
@@ -97,6 +97,39 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
 
     private DisposeAction WithNonUserCode() => this._state.ExecutionContext.WithoutDependencyCollection();
 
+    // True when the current scenario doesn't capture non-observable transformations (DesignTime, CodeFix)
+    // and the advice produces only Observability.None transformations (no CompileTimeOnly side effect).
+    private bool CanSkipNonObservableAdvice() => !this._state.ExecutionScenario.CapturesNonObservableTransformations;
+
+    // For non-void members (constructors, properties, events, indexers), Override on a partial member without
+    // implementation also emits SetHasImplementationTransformation (CompileTimeOnly), and a subsequent aspect
+    // may read member.HasImplementation expecting the post-override value (see PartialConstructor_HasImplementationAfterOverride).
+    // For Method targets, the only HasImplementation==false case is old-style partial void, where the flag flip
+    // has no observable effect at design time, so the IMethod overload doesn't need this guard.
+    private bool CanSkipNonObservableAdvice( IMember member ) => this.CanSkipNonObservableAdvice() && member.HasImplementation;
+
+    private bool TrySkipMethodOverride( IMethod targetMethod, [NotNullWhen( true )] out IOverrideAdviceResult<IMethod>? result )
+    {
+        if ( !this.CanSkipNonObservableAdvice() || targetMethod.MethodKind == MethodKind.EventRaise )
+        {
+            result = null;
+
+            return false;
+        }
+
+        var resultKind = targetMethod.MethodKind switch
+        {
+            MethodKind.EventAdd or MethodKind.EventRemove => AdviceKind.OverrideEvent,
+            MethodKind.PropertyGet or MethodKind.PropertySet => AdviceKind.OverrideFieldOrPropertyOrIndexer,
+            MethodKind.Finalizer => AdviceKind.OverrideFinalizer,
+            _ => AdviceKind.OverrideMethod
+        };
+
+        result = OverrideMemberAdviceResult<IMethod>.Skipped( resultKind, this );
+
+        return true;
+    }
+
     private AdviceFactory<T> WithTemplateClassInstance( TemplateClassInstance templateClassInstance )
         => new( this.Target, this._state, templateClassInstance, this._layerName, this._explicitlyImplementedInterfaceType, this._diagnostics );
 
@@ -487,6 +520,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetMethod, AdviceKind.OverrideMethod );
 
+            if ( this.TrySkipMethodOverride( targetMethod, out var skipped ) )
+            {
+                return skipped;
+            }
+
             var tagsReader = this.GetTagsReader( tags );
 
             switch ( targetMethod.MethodKind )
@@ -835,6 +873,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.OverrideConstructor );
 
+            if ( this.CanSkipNonObservableAdvice( targetConstructor ) && !targetConstructor.IsImplicitInstanceConstructor() )
+            {
+                return OverrideMemberAdviceResult<IConstructor>.Skipped( AdviceKind.OverrideConstructor, this );
+            }
+
             var boundTemplate =
                 this.ValidateTemplateName( template, TemplateKind.Default, true )
                     ?.GetTemplateMember<IMethod>( this._compilation, this._state.ServiceProvider, this.TemplateProvider, this.GetTagsReader( tags ) )
@@ -884,6 +927,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetFieldOrProperty, AdviceKind.OverrideFieldOrPropertyOrIndexer );
 
+            if ( this.CanSkipNonObservableAdvice( targetFieldOrProperty ) )
+            {
+                return OverrideMemberAdviceResult<IProperty>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this );
+            }
+
             // Set template represents both set and init accessors.
             var propertyTemplate = this.ValidateRequiredTemplateName( template, TemplateKind.Default )
                 .GetTemplateMember<IProperty>( this._compilation, this._state.ServiceProvider, this.TemplateProvider, this.GetTagsReader( tags ) );
@@ -924,6 +972,21 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
             }
 
             this.Validate( targetFieldOrPropertyOrIndexer, AdviceKind.OverrideFieldOrPropertyOrIndexer );
+
+            if ( this.CanSkipNonObservableAdvice( targetFieldOrPropertyOrIndexer ) )
+            {
+                // Return a result typed to the actual target (IProperty/IIndexer) so that the
+                // typed forwarder overloads can downcast via covariance.
+                return targetFieldOrPropertyOrIndexer.DeclarationKind switch
+                {
+                    DeclarationKind.Field or DeclarationKind.Property
+                        => OverrideMemberAdviceResult<IProperty>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this ),
+                    DeclarationKind.Indexer
+                        => OverrideMemberAdviceResult<IIndexer>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this ),
+                    _ => throw new AssertionFailedException( $"{targetFieldOrPropertyOrIndexer.GetType().Name} is not expected here." )
+                };
+            }
+
             var tagsReader = this.GetTagsReader( tags );
 
             // Set template represents both set and init accessors.
@@ -1589,6 +1652,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.AddInitializer );
 
+            if ( this.CanSkipNonObservableAdvice() )
+            {
+                return AddInitializerAdviceResult.Skipped( this );
+            }
+
             var templateMember = this.ValidateRequiredTemplateName( template, TemplateKind.Default )
                 .GetTemplateMember<IMethod>( this._compilation, this._state.ServiceProvider, this.TemplateProvider, this.GetTagsReader( tags ) );
 
@@ -1608,6 +1676,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.AddInitializer );
 
+            if ( this.CanSkipNonObservableAdvice() )
+            {
+                return AddInitializerAdviceResult.Skipped( this );
+            }
+
             var advice = new SyntaxBasedConstructorInitializeAdvice(
                 this.GetAdviceConstructorParameters<IMemberOrNamedType>( targetConstructor ),
                 statement,
@@ -1626,6 +1699,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
     {
         using ( this.WithNonUserCode() )
         {
+            if ( this.CanSkipNonObservableAdvice() )
+            {
+                return AddContractAdviceResult<IParameter>.Skipped( this );
+            }
+
             switch ( kind )
             {
                 case ContractDirection.Output when targetParameter.RefKind is not (RefKind.Ref or RefKind.Out) && !targetParameter.IsReturnParameter:
@@ -1669,6 +1747,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
     {
         using ( this.WithNonUserCode() )
         {
+            if ( this.CanSkipNonObservableAdvice() )
+            {
+                return AddContractAdviceResult<IFieldOrPropertyOrIndexer>.Skipped( this );
+            }
+
             if ( !this.TryPrepareContract( targetMember, template, ref direction, tags, out var boundTemplate ) )
             {
                 return AddContractAdviceResult<IFieldOrPropertyOrIndexer>.Ignored( this );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
@@ -97,33 +97,77 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
 
     private DisposeAction WithNonUserCode() => this._state.ExecutionContext.WithoutDependencyCollection();
 
-    // True when the current scenario doesn't capture non-observable transformations (DesignTime, CodeFix)
-    // and the advice produces only Observability.None transformations (no CompileTimeOnly side effect).
-    private bool CanSkipNonObservableAdvice() => !this._state.ExecutionScenario.CapturesNonObservableTransformations;
+    // Returns true when the advice can be safely short-circuited because the current scenario does not capture
+    // non-observable transformations (DesignTime, CodeFix). The skip avoids template binding and advice
+    // construction for advice that would otherwise produce only Observability.None transformations.
+    //
+    // The skip is unsafe when the advice would also produce a CompileTimeOnly transformation as a side effect:
+    //
+    //   - Override(...) on a partial member without implementation emits SetHasImplementationTransformation
+    //     (CompileTimeOnly). The transformation is filtered out of the design-time syntax tree by
+    //     DesignTimeSyntaxTreeGenerator, but it IS applied to MutableCompilation. A subsequent aspect that
+    //     reads member.HasImplementation observes the post-override value (see the existing
+    //     PartialConstructor_HasImplementationAfterOverride aspect-chain test). Skipping here would diverge
+    //     the model seen by the next aspect.
+    //
+    //   - Override(IField) emits PromoteFieldTransformation (CompileTimeOnly), which replaces the field with
+    //     a property in MutableCompilation. Same intra-pipeline observability as above.
+    //
+    // Both side effects are gated by the per-member predicates below, not by the scenario alone.
+    private bool CanSkipPureNonObservableAdvice() => !this._state.ExecutionScenario.CapturesNonObservableTransformations;
 
-    // For non-void members (constructors, properties, events, indexers), Override on a partial member without
-    // implementation also emits SetHasImplementationTransformation (CompileTimeOnly), and a subsequent aspect
-    // may read member.HasImplementation expecting the post-override value (see PartialConstructor_HasImplementationAfterOverride).
-    // For Method targets, the only HasImplementation==false case is old-style partial void, where the flag flip
-    // has no observable effect at design time, so the IMethod overload doesn't need this guard.
-    private bool CanSkipNonObservableAdvice( IMember member ) => this.CanSkipNonObservableAdvice() && member.HasImplementation;
+    private bool CanSkipPureNonObservableAdvice( IMember member )
+        => this.CanSkipPureNonObservableAdvice()
+           && member.HasImplementation
+           && member is not IField;
 
+    // For Override(IMethod) the relevant member for the HasImplementation gate is the parent event/property
+    // when the target is an accessor — SetHasImplementationTransformation tracks the parent member's flag.
     private bool TrySkipMethodOverride( IMethod targetMethod, [NotNullWhen( true )] out IOverrideAdviceResult<IMethod>? result )
     {
-        if ( !this.CanSkipNonObservableAdvice() || targetMethod.MethodKind == MethodKind.EventRaise )
+        if ( !this.CanSkipPureNonObservableAdvice() || targetMethod.MethodKind == MethodKind.EventRaise )
         {
             result = null;
 
             return false;
         }
 
-        var resultKind = targetMethod.MethodKind switch
+        IMember ownerMember;
+        AdviceKind resultKind;
+
+        switch ( targetMethod.MethodKind )
         {
-            MethodKind.EventAdd or MethodKind.EventRemove => AdviceKind.OverrideEvent,
-            MethodKind.PropertyGet or MethodKind.PropertySet => AdviceKind.OverrideFieldOrPropertyOrIndexer,
-            MethodKind.Finalizer => AdviceKind.OverrideFinalizer,
-            _ => AdviceKind.OverrideMethod
-        };
+            case MethodKind.EventAdd or MethodKind.EventRemove:
+                ownerMember = (IMember) targetMethod.ContainingDeclaration.AssertNotNull();
+                resultKind = AdviceKind.OverrideEvent;
+
+                break;
+
+            case MethodKind.PropertyGet or MethodKind.PropertySet:
+                ownerMember = (IMember) targetMethod.ContainingDeclaration.AssertNotNull();
+                resultKind = AdviceKind.OverrideFieldOrPropertyOrIndexer;
+
+                break;
+
+            case MethodKind.Finalizer:
+                ownerMember = targetMethod;
+                resultKind = AdviceKind.OverrideFinalizer;
+
+                break;
+
+            default:
+                ownerMember = targetMethod;
+                resultKind = AdviceKind.OverrideMethod;
+
+                break;
+        }
+
+        if ( !this.CanSkipPureNonObservableAdvice( ownerMember ) )
+        {
+            result = null;
+
+            return false;
+        }
 
         result = OverrideMemberAdviceResult<IMethod>.Skipped( resultKind, this );
 
@@ -873,7 +917,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.OverrideConstructor );
 
-            if ( this.CanSkipNonObservableAdvice( targetConstructor ) && !targetConstructor.IsImplicitInstanceConstructor() )
+            if ( this.CanSkipPureNonObservableAdvice( targetConstructor ) && !targetConstructor.IsImplicitInstanceConstructor() )
             {
                 return OverrideMemberAdviceResult<IConstructor>.Skipped( AdviceKind.OverrideConstructor, this );
             }
@@ -927,7 +971,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetFieldOrProperty, AdviceKind.OverrideFieldOrPropertyOrIndexer );
 
-            if ( this.CanSkipNonObservableAdvice( targetFieldOrProperty ) )
+            if ( this.CanSkipPureNonObservableAdvice( targetFieldOrProperty ) )
             {
                 return OverrideMemberAdviceResult<IProperty>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this );
             }
@@ -973,7 +1017,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
 
             this.Validate( targetFieldOrPropertyOrIndexer, AdviceKind.OverrideFieldOrPropertyOrIndexer );
 
-            if ( this.CanSkipNonObservableAdvice( targetFieldOrPropertyOrIndexer ) )
+            if ( this.CanSkipPureNonObservableAdvice( targetFieldOrPropertyOrIndexer ) )
             {
                 // Return a result typed to the actual target (IProperty/IIndexer) so that the
                 // typed forwarder overloads can downcast via covariance.
@@ -1652,7 +1696,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.AddInitializer );
 
-            if ( this.CanSkipNonObservableAdvice() )
+            if ( this.CanSkipPureNonObservableAdvice() )
             {
                 return AddInitializerAdviceResult.Skipped( this );
             }
@@ -1676,7 +1720,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.AddInitializer );
 
-            if ( this.CanSkipNonObservableAdvice() )
+            if ( this.CanSkipPureNonObservableAdvice() )
             {
                 return AddInitializerAdviceResult.Skipped( this );
             }
@@ -1699,7 +1743,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
     {
         using ( this.WithNonUserCode() )
         {
-            if ( this.CanSkipNonObservableAdvice() )
+            if ( this.CanSkipPureNonObservableAdvice() )
             {
                 return AddContractAdviceResult<IParameter>.Skipped( this );
             }
@@ -1747,7 +1791,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
     {
         using ( this.WithNonUserCode() )
         {
-            if ( this.CanSkipNonObservableAdvice() )
+            if ( this.CanSkipPureNonObservableAdvice() )
             {
                 return AddContractAdviceResult<IFieldOrPropertyOrIndexer>.Skipped( this );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactory.cs
@@ -135,6 +135,12 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         IMember ownerMember;
         AdviceKind resultKind;
 
+        // The successful Implement() of the underlying advice classes only sets Declaration for the
+        // regular-method case (OverrideMethodAdvice) — finalizer / event / property-accessor advice all
+        // call CreateSuccessResult() with no argument, leaving Declaration null. Match that contract
+        // here so a skipped result has the same Declaration shape as a successful one.
+        IRef<IMethod>? declaration = null;
+
         switch ( targetMethod.MethodKind )
         {
             case MethodKind.EventAdd or MethodKind.EventRemove:
@@ -158,6 +164,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
             default:
                 ownerMember = targetMethod;
                 resultKind = AdviceKind.OverrideMethod;
+                declaration = targetMethod.ToRef();
 
                 break;
         }
@@ -169,7 +176,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
             return false;
         }
 
-        result = OverrideMemberAdviceResult<IMethod>.Skipped( resultKind, this );
+        result = OverrideMemberAdviceResult<IMethod>.Skipped( resultKind, this, declaration );
 
         return true;
     }
@@ -919,7 +926,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
 
             if ( this.CanSkipPureNonObservableAdvice( targetConstructor ) && !targetConstructor.IsImplicitInstanceConstructor() )
             {
-                return OverrideMemberAdviceResult<IConstructor>.Skipped( AdviceKind.OverrideConstructor, this );
+                return OverrideMemberAdviceResult<IConstructor>.Skipped( AdviceKind.OverrideConstructor, this, targetConstructor.ToRef() );
             }
 
             var boundTemplate =
@@ -973,7 +980,11 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
 
             if ( this.CanSkipPureNonObservableAdvice( targetFieldOrProperty ) )
             {
-                return OverrideMemberAdviceResult<IProperty>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this );
+                // CanSkipPureNonObservableAdvice excludes IField, so the target is always IProperty here.
+                return OverrideMemberAdviceResult<IProperty>.Skipped(
+                    AdviceKind.OverrideFieldOrPropertyOrIndexer,
+                    this,
+                    ((IProperty) targetFieldOrProperty).ToRef() );
             }
 
             // Set template represents both set and init accessors.
@@ -1019,14 +1030,21 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
 
             if ( this.CanSkipPureNonObservableAdvice( targetFieldOrPropertyOrIndexer ) )
             {
-                // Return a result typed to the actual target (IProperty/IIndexer) so that the
-                // typed forwarder overloads can downcast via covariance.
+                // Return a result typed to the actual target (IProperty/IIndexer) so that the typed
+                // forwarder overloads can downcast via covariance, and pass the original target
+                // reference so user code can still read result.Declaration.
                 return targetFieldOrPropertyOrIndexer.DeclarationKind switch
                 {
                     DeclarationKind.Field or DeclarationKind.Property
-                        => OverrideMemberAdviceResult<IProperty>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this ),
+                        => OverrideMemberAdviceResult<IProperty>.Skipped(
+                            AdviceKind.OverrideFieldOrPropertyOrIndexer,
+                            this,
+                            ((IProperty) targetFieldOrPropertyOrIndexer).ToRef() ),
                     DeclarationKind.Indexer
-                        => OverrideMemberAdviceResult<IIndexer>.Skipped( AdviceKind.OverrideFieldOrPropertyOrIndexer, this ),
+                        => OverrideMemberAdviceResult<IIndexer>.Skipped(
+                            AdviceKind.OverrideFieldOrPropertyOrIndexer,
+                            this,
+                            ((IIndexer) targetFieldOrPropertyOrIndexer).ToRef() ),
                     _ => throw new AssertionFailedException( $"{targetFieldOrPropertyOrIndexer.GetType().Name} is not expected here." )
                 };
             }
@@ -1696,7 +1714,10 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.AddInitializer );
 
-            if ( this.CanSkipPureNonObservableAdvice() )
+            // ConstructorInitializeAdvice introduces an explicit ctor when the target is implicit
+            // (ConstructorInitializeAdvice.cs:82-91). That introduction is observable and changes the
+            // model seen by subsequent aspects, so don't skip in that case.
+            if ( this.CanSkipPureNonObservableAdvice() && !targetConstructor.IsImplicitInstanceConstructor() )
             {
                 return AddInitializerAdviceResult.Skipped( this );
             }
@@ -1720,7 +1741,8 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             this.Validate( targetConstructor, AdviceKind.AddInitializer );
 
-            if ( this.CanSkipPureNonObservableAdvice() )
+            // See AddInitializer(IConstructor, string, ...) for why implicit ctors aren't skipped.
+            if ( this.CanSkipPureNonObservableAdvice() && !targetConstructor.IsImplicitInstanceConstructor() )
             {
                 return AddInitializerAdviceResult.Skipped( this );
             }
@@ -1745,7 +1767,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             if ( this.CanSkipPureNonObservableAdvice() )
             {
-                return AddContractAdviceResult<IParameter>.Skipped( this );
+                return AddContractAdviceResult<IParameter>.Skipped( this, targetParameter.ToRef() );
             }
 
             switch ( kind )
@@ -1793,7 +1815,7 @@ internal sealed class AdviceFactory<T> : IAdviser<T>, IAdviceFactoryImpl, IDiagn
         {
             if ( this.CanSkipPureNonObservableAdvice() )
             {
-                return AddContractAdviceResult<IFieldOrPropertyOrIndexer>.Skipped( this );
+                return AddContractAdviceResult<IFieldOrPropertyOrIndexer>.Skipped( this, targetMember.ToRef() );
             }
 
             if ( !this.TryPrepareContract( targetMember, template, ref direction, tags, out var boundTemplate ) )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactoryState.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Advising/AdviceFactoryState.cs
@@ -27,6 +27,8 @@ internal sealed class AdviceFactoryState : IAdviceExecutionContext
 
     public ref readonly ProjectServiceProvider ServiceProvider => ref this._serviceProvider;
 
+    public ExecutionScenario ExecutionScenario { get; }
+
     public CompilationModel InitialCompilation => this.AspectLayerInstance.InitialCompilation;
 
     public IDiagnosticAdder Diagnostics { get; }
@@ -58,6 +60,7 @@ internal sealed class AdviceFactoryState : IAdviceExecutionContext
         this.IntrospectionListener = serviceProvider.GetService<IntrospectionPipelineListener>();
         this.ExecutionContext = executionContext;
         this.AspectClassResolver = aspectClassResolver;
+        this.ExecutionScenario = serviceProvider.GetRequiredService<ExecutionScenario>();
     }
 
     public void AddTransformations( ImmutableArray<ITransformation> transformations )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/MetalamaStringFormatterImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/MetalamaStringFormatterImpl.cs
@@ -127,6 +127,11 @@ namespace Metalama.Framework.Engine.Diagnostics
                     case ReferenceKinds referenceKinds:
                         return referenceKinds.ToDisplayString();
 
+                    case Enum enumValue:
+                        // Use a deterministic name: built-in Enum.ToString picks an arbitrary name when
+                        // multiple aliases share the same underlying value (e.g. Default = Success).
+                        return enumValue.ToStringSafe();
+
                     case IFormattable formattable:
                         return formattable.ToString( format, this );
 

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/EnumExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/EnumExtensions.cs
@@ -4,12 +4,18 @@
 
 using JetBrains.Annotations;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Metalama.Framework.Engine.Utilities;
 
 [PublicAPI]
 public static class EnumExtensions
 {
+    // Per-type cache of value-to-deterministic-name mappings. The diagnostic formatter is a hot path,
+    // so a lookup beats re-enumerating Enum.GetNames + Enum.Parse on every call.
+    private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<Enum, string>> _cache = new();
+
     /// <summary>
     /// Returns a deterministic string representation of an enum value. For enums with alias members
     /// (multiple names sharing the same underlying value, e.g. <c>Default = 0, Success = 0</c>), the
@@ -19,19 +25,25 @@ public static class EnumExtensions
     /// </summary>
     public static string ToStringSafe( this Enum value )
     {
-        var type = value.GetType();
-        string? bestName = null;
+        var map = _cache.GetOrAdd( value.GetType(), BuildMap );
+
+        return map.TryGetValue( value, out var name ) ? name : value.ToString();
+    }
+
+    private static IReadOnlyDictionary<Enum, string> BuildMap( Type type )
+    {
+        var result = new Dictionary<Enum, string>();
 
         foreach ( var name in Enum.GetNames( type ) )
         {
             var parsed = (Enum) Enum.Parse( type, name );
 
-            if ( parsed.Equals( value ) && (bestName == null || string.CompareOrdinal( name, bestName ) < 0) )
+            if ( !result.TryGetValue( parsed, out var existing ) || string.CompareOrdinal( name, existing ) < 0 )
             {
-                bestName = name;
+                result[parsed] = name;
             }
         }
 
-        return bestName ?? value.ToString();
+        return result;
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/EnumExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/EnumExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using System;
+
+namespace Metalama.Framework.Engine.Utilities;
+
+[PublicAPI]
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Returns a deterministic string representation of an enum value. For enums with alias members
+    /// (multiple names sharing the same underlying value, e.g. <c>Default = 0, Success = 0</c>), the
+    /// built-in <see cref="object.ToString"/> picks one of the names in an implementation-defined way
+    /// that can vary across .NET runtimes. This method always returns the alphabetically-first name
+    /// among aliases, so diagnostic messages and log output stay stable.
+    /// </summary>
+    public static string ToStringSafe( this Enum value )
+    {
+        var type = value.GetType();
+        string? bestName = null;
+
+        foreach ( var name in Enum.GetNames( type ) )
+        {
+            var parsed = (Enum) Enum.Parse( type, name );
+
+            if ( parsed.Equals( value ) && (bestName == null || string.CompareOrdinal( name, bestName ) < 0) )
+            {
+                bestName = name;
+            }
+        }
+
+        return bestName ?? value.ToString();
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/EnumExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/EnumExtensions.cs
@@ -20,8 +20,10 @@ public static class EnumExtensions
     /// Returns a deterministic string representation of an enum value. For enums with alias members
     /// (multiple names sharing the same underlying value, e.g. <c>Default = 0, Success = 0</c>), the
     /// built-in <see cref="object.ToString"/> picks one of the names in an implementation-defined way
-    /// that can vary across .NET runtimes. This method always returns the alphabetically-first name
-    /// among aliases, so diagnostic messages and log output stay stable.
+    /// that can vary across .NET runtimes. This method returns the alphabetically-first preferred
+    /// name among aliases — names marked <see cref="ObsoleteAttribute"/> and the literal name
+    /// <c>Default</c> are deprioritized and only used as a fallback when no preferred alias exists,
+    /// so diagnostic messages and log output stay stable.
     /// </summary>
     public static string ToStringSafe( this Enum value )
     {
@@ -32,13 +34,36 @@ public static class EnumExtensions
 
     private static IReadOnlyDictionary<Enum, string> BuildMap( Type type )
     {
+        var names = Enum.GetNames( type );
+        var entries = new (string Name, bool IsDeprioritized)[names.Length];
+
+        for ( var i = 0; i < names.Length; i++ )
+        {
+            var name = names[i];
+            var isObsolete = type.GetField( name )?.IsDefined( typeof(ObsoleteAttribute), inherit: false ) == true;
+            entries[i] = (name, isObsolete || name == "Default");
+        }
+
+        // Preferred names sort before deprioritized ones; ties broken by ordinal name comparison.
+        Array.Sort(
+            entries,
+            ( a, b ) =>
+            {
+                if ( a.IsDeprioritized != b.IsDeprioritized )
+                {
+                    return a.IsDeprioritized ? 1 : -1;
+                }
+
+                return string.CompareOrdinal( a.Name, b.Name );
+            } );
+
         var result = new Dictionary<Enum, string>();
 
-        foreach ( var name in Enum.GetNames( type ) )
+        foreach ( var (name, _) in entries )
         {
             var parsed = (Enum) Enum.Parse( type, name );
 
-            if ( !result.TryGetValue( parsed, out var existing ) || string.CompareOrdinal( name, existing ) < 0 )
+            if ( !result.ContainsKey( parsed ) )
             {
                 result[parsed] = name;
             }

--- a/Metalama.Framework/src/Metalama.Framework/Advising/AdviceOutcome.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Advising/AdviceOutcome.cs
@@ -56,5 +56,11 @@ public enum AdviceOutcome
     /// The <see cref="IAspect{T}.BuildAspect"/> method continues executing without throwing an exception; check <see cref="IAdviceResult.Outcome"/>
     /// to detect errors and handle them appropriately.
     /// </summary>
-    Error
+    Error,
+
+    /// <summary>
+    /// The advice was skipped by the pipeline because the current <see cref="Project.IExecutionScenario"/> does not capture the kind of
+    /// transformation it would have produced (typically non-observable transformations at design time). The skip is invisible to the design-time output.
+    /// </summary>
+    Skipped
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
@@ -290,6 +290,46 @@ public class C
         Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time." );
     }
 
+    private const string _addInitializerOnImplicitConstructorAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var ctor = builder.Target.Constructors.First();
+        var result = builder.Advice.AddInitializer(ctor, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), ctor);
+    }
+
+    [Template]
+    public void Template() {}
+}
+
+[TestAspect]
+public class C
+{
+}
+";
+
+    [Fact]
+    public async Task AddInitializer_OnImplicitConstructor_NotSkippedAtDesignTime()
+    {
+        // ConstructorInitializeAdvice introduces an explicit constructor when the target is implicit
+        // (ConstructorInitializeAdvice.cs:82-91), which is observable. Skipping would diverge the
+        // model seen by subsequent aspects.
+        var diagnostics = await this.RunAsync( _addInitializerOnImplicitConstructorAspect, ExecutionScenario.DesignTime );
+
+        Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "AddInitializer on an implicit constructor must run at design time." );
+    }
+
     private const string _introduceMethodAspect = @"
 using Metalama.Framework.Advising;
 using Metalama.Framework.Aspects;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
@@ -1,0 +1,324 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Compiler;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Pipeline.CompileTime;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Aspects;
+
+public sealed class AdviceFactoryScenarioTests : UnitTestClass
+{
+    private async Task<ImmutableArray<Diagnostic>> RunAsync( string code, ExecutionScenario scenario )
+    {
+        using var testContext = this.CreateTestContext();
+
+        var compilation = testContext.CreateCSharpCompilation( code );
+
+        using var pipeline = new CompileTimeAspectPipeline( testContext.ServiceProvider, scenario );
+        var diagnostics = new DiagnosticBag();
+
+        await pipeline.ExecuteAsync( diagnostics.Report, null, compilation, ImmutableArray<ManagedResource>.Empty );
+
+        return diagnostics.ToImmutableArray();
+    }
+
+    private static bool ContainsOutcome( ImmutableArray<Diagnostic> diagnostics, string outcome )
+        => diagnostics.Any( d => d.GetMessage().Contains( $"Outcome={outcome}", StringComparison.Ordinal ) );
+
+    private const string _overrideMethodAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var method = builder.Target.Methods.First(m => m.Name == ""M"");
+        var result = builder.Advice.Override(method, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), method);
+    }
+
+    [Template]
+    public dynamic? Template() => meta.Proceed();
+}
+
+[TestAspect]
+public class C
+{
+    public void M() {}
+}
+";
+
+    [Fact]
+    public async Task Override_OnRegularMethod_SkippedAtDesignTime()
+    {
+        var diagnostics = await this.RunAsync( _overrideMethodAspect, ExecutionScenario.DesignTime );
+
+        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time." );
+    }
+
+    [Fact]
+    public async Task Override_OnRegularMethod_NotSkippedAtCompileTime()
+    {
+        var diagnostics = await this.RunAsync( _overrideMethodAspect, ExecutionScenario.CompileTime );
+
+        Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "Did not expect Outcome=Skipped at compile time." );
+        Assert.True( ContainsOutcome( diagnostics, "Default" ), "Expected Outcome=Default at compile time." );
+    }
+
+    private const string _overridePartialMethodAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var method = builder.Target.Methods.First(m => m.Name == ""M"");
+        var result = builder.Advice.Override(method, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), method);
+    }
+
+    [Template]
+    public void Template() { meta.Proceed(); }
+}
+
+[TestAspect]
+public partial class C
+{
+    partial void M();
+}
+";
+
+    [Fact]
+    public async Task Override_OnPartialVoidMethodWithoutImplementation_SkippedAtDesignTime()
+    {
+        // For Method targets, the only HasImplementation==false case is old-style partial void, where the
+        // SetHasImplementationTransformation flag flip has no observable effect at design time.
+        var diagnostics = await this.RunAsync( _overridePartialMethodAspect, ExecutionScenario.DesignTime );
+
+        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time for partial void." );
+    }
+
+    private const string _overrideFieldAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var field = builder.Target.Fields.First(f => f.Name == ""_x"");
+        var result = builder.Advice.Override(field, nameof(GetTemplate));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), field);
+    }
+
+    [Template]
+    public dynamic? GetTemplate() => meta.Proceed();
+}
+
+[TestAspect]
+public class C
+{
+    public int _x;
+}
+";
+
+    [Fact]
+    public async Task Override_OnField_SkippedAtDesignTime()
+    {
+        // Field-to-property promotion (PromoteFieldTransformation) is CompileTimeOnly, so it isn't emitted
+        // by the design-time syntax tree generator and the linker doesn't run at design time.
+        // Skipping is observably equivalent to running.
+        var diagnostics = await this.RunAsync( _overrideFieldAspect, ExecutionScenario.DesignTime );
+
+        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time for field." );
+    }
+
+    private const string _overrideConstructorAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var ctor = builder.Target.Constructors.First();
+        var result = builder.Advice.Override(ctor, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), ctor);
+    }
+
+    [Template]
+    public void Template() { meta.Proceed(); }
+}
+
+[TestAspect]
+public class C
+{
+    public C() {}
+}
+";
+
+    [Fact]
+    public async Task Override_OnConstructor_SkippedAtDesignTime()
+    {
+        var diagnostics = await this.RunAsync( _overrideConstructorAspect, ExecutionScenario.DesignTime );
+
+        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time." );
+    }
+
+    private const string _addContractAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var method = builder.Target.Methods.First(m => m.Name == ""M"");
+        var parameter = method.Parameters[0];
+        var result = builder.Advice.AddContract(parameter, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), parameter);
+    }
+
+    [Template]
+    public void Template(dynamic? value) {}
+}
+
+[TestAspect]
+public class C
+{
+    public void M(int x) {}
+}
+";
+
+    [Fact]
+    public async Task AddContract_OnParameter_SkippedAtDesignTime()
+    {
+        var diagnostics = await this.RunAsync( _addContractAspect, ExecutionScenario.DesignTime );
+
+        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time." );
+    }
+
+    [Fact]
+    public async Task AddContract_OnParameter_NotSkippedAtCompileTime()
+    {
+        var diagnostics = await this.RunAsync( _addContractAspect, ExecutionScenario.CompileTime );
+
+        Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "Did not expect Outcome=Skipped at compile time." );
+    }
+
+    private const string _addInitializerOnConstructorAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using System.Linq;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var ctor = builder.Target.Constructors.First();
+        var result = builder.Advice.AddInitializer(ctor, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), ctor);
+    }
+
+    [Template]
+    public void Template() {}
+}
+
+[TestAspect]
+public class C
+{
+    public C() {}
+}
+";
+
+    [Fact]
+    public async Task AddInitializer_OnConstructor_SkippedAtDesignTime()
+    {
+        var diagnostics = await this.RunAsync( _addInitializerOnConstructorAspect, ExecutionScenario.DesignTime );
+
+        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time." );
+    }
+
+    private const string _introduceMethodAspect = @"
+using Metalama.Framework.Advising;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+
+public class TestAspect : TypeAspect
+{
+    private static readonly DiagnosticDefinition<string> _diagnostic
+        = new(""TST001"", Severity.Warning, ""Outcome={0}"");
+
+    public override void BuildAspect(IAspectBuilder<INamedType> builder)
+    {
+        var result = builder.Advice.IntroduceMethod(builder.Target, nameof(Template));
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), builder.Target);
+    }
+
+    [Template]
+    public void Template() {}
+}
+
+[TestAspect]
+public class C
+{
+}
+";
+
+    [Fact]
+    public async Task IntroduceMethod_NotSkippedAtDesignTime()
+    {
+        // IntroduceMethod produces an Always-observable transformation; it must run regardless of scenario.
+        var diagnostics = await this.RunAsync( _introduceMethodAspect, ExecutionScenario.DesignTime );
+
+        Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "IntroduceMethod must not be skipped at design time." );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
@@ -44,14 +44,14 @@ using System.Linq;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
     {
         var method = builder.Target.Methods.First(m => m.Name == ""M"");
         var result = builder.Advice.Override(method, nameof(Template));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), method);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), method);
     }
 
     [Template]
@@ -78,6 +78,8 @@ public class C
     {
         var diagnostics = await this.RunAsync( _overrideMethodAspect, ExecutionScenario.CompileTime );
 
+        // AdviceOutcome.Default and Success share value 0; ToStringSafe picks the alphabetically-first
+        // alias, which is "Default".
         Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "Did not expect Outcome=Skipped at compile time." );
         Assert.True( ContainsOutcome( diagnostics, "Default" ), "Expected Outcome=Default at compile time." );
     }
@@ -91,14 +93,14 @@ using System.Linq;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
     {
         var method = builder.Target.Methods.First(m => m.Name == ""M"");
         var result = builder.Advice.Override(method, nameof(Template));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), method);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), method);
     }
 
     [Template]
@@ -133,14 +135,14 @@ using System.Linq;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
     {
         var field = builder.Target.Fields.First(f => f.Name == ""_x"");
         var result = builder.Advice.Override(field, nameof(GetTemplate));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), field);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), field);
     }
 
     [Template]
@@ -174,14 +176,14 @@ using System.Linq;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
     {
         var ctor = builder.Target.Constructors.First();
         var result = builder.Advice.Override(ctor, nameof(Template));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), ctor);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), ctor);
     }
 
     [Template]
@@ -212,7 +214,7 @@ using System.Linq;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
@@ -220,7 +222,7 @@ public class TestAspect : TypeAspect
         var method = builder.Target.Methods.First(m => m.Name == ""M"");
         var parameter = method.Parameters[0];
         var result = builder.Advice.AddContract(parameter, nameof(Template));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), parameter);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), parameter);
     }
 
     [Template]
@@ -259,14 +261,14 @@ using System.Linq;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
     {
         var ctor = builder.Target.Constructors.First();
         var result = builder.Advice.AddInitializer(ctor, nameof(Template));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), ctor);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), ctor);
     }
 
     [Template]
@@ -296,13 +298,13 @@ using Metalama.Framework.Diagnostics;
 
 public class TestAspect : TypeAspect
 {
-    private static readonly DiagnosticDefinition<string> _diagnostic
+    private static readonly DiagnosticDefinition<AdviceOutcome> _diagnostic
         = new(""TST001"", Severity.Warning, ""Outcome={0}"");
 
     public override void BuildAspect(IAspectBuilder<INamedType> builder)
     {
         var result = builder.Advice.IntroduceMethod(builder.Target, nameof(Template));
-        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome.ToString()), builder.Target);
+        builder.Diagnostics.Report(_diagnostic.WithArguments(result.Outcome), builder.Target);
     }
 
     [Template]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
@@ -113,13 +113,15 @@ public partial class C
 ";
 
     [Fact]
-    public async Task Override_OnPartialVoidMethodWithoutImplementation_SkippedAtDesignTime()
+    public async Task Override_OnPartialMethodWithoutImplementation_NotSkippedAtDesignTime()
     {
-        // For Method targets, the only HasImplementation==false case is old-style partial void, where the
-        // SetHasImplementationTransformation flag flip has no observable effect at design time.
+        // Override of a partial member without implementation also emits SetHasImplementationTransformation
+        // (CompileTimeOnly). It's filtered out of the design-time syntax tree, but it IS applied to
+        // MutableCompilation, and a subsequent aspect that reads HasImplementation observes the post-override
+        // value. Skipping here would diverge the model seen by the next aspect.
         var diagnostics = await this.RunAsync( _overridePartialMethodAspect, ExecutionScenario.DesignTime );
 
-        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time for partial void." );
+        Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "Override of a partial member without implementation must run at design time." );
     }
 
     private const string _overrideFieldAspect = @"
@@ -153,14 +155,14 @@ public class C
 ";
 
     [Fact]
-    public async Task Override_OnField_SkippedAtDesignTime()
+    public async Task Override_OnField_NotSkippedAtDesignTime()
     {
-        // Field-to-property promotion (PromoteFieldTransformation) is CompileTimeOnly, so it isn't emitted
-        // by the design-time syntax tree generator and the linker doesn't run at design time.
-        // Skipping is observably equivalent to running.
+        // Override of a field promotes it to a property via PromoteFieldTransformation (CompileTimeOnly).
+        // The promotion is filtered out of the design-time syntax tree, but it IS applied to MutableCompilation,
+        // so a subsequent aspect would see the property where there was a field. The advice must still run.
         var diagnostics = await this.RunAsync( _overrideFieldAspect, ExecutionScenario.DesignTime );
 
-        Assert.True( ContainsOutcome( diagnostics, "Skipped" ), "Expected Outcome=Skipped at design time for field." );
+        Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "Override of a field must run at design time." );
     }
 
     private const string _overrideConstructorAspect = @"

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/AdviceFactoryScenarioTests.cs
@@ -78,10 +78,10 @@ public class C
     {
         var diagnostics = await this.RunAsync( _overrideMethodAspect, ExecutionScenario.CompileTime );
 
-        // AdviceOutcome.Default and Success share value 0; ToStringSafe picks the alphabetically-first
-        // alias, which is "Default".
+        // AdviceOutcome.Default and Success share value 0; ToStringSafe deprioritizes "Default", so
+        // the reported alias is "Success".
         Assert.False( ContainsOutcome( diagnostics, "Skipped" ), "Did not expect Outcome=Skipped at compile time." );
-        Assert.True( ContainsOutcome( diagnostics, "Default" ), "Expected Outcome=Default at compile time." );
+        Assert.True( ContainsOutcome( diagnostics, "Success" ), "Expected Outcome=Success at compile time." );
     }
 
     private const string _overridePartialMethodAspect = @"


### PR DESCRIPTION
## Summary

- Skip `Override*`, `AddContract`, and `AddInitializer(IConstructor, ...)` early in `AdviceFactory` when `ExecutionScenario.CapturesNonObservableTransformations` is `false` (DesignTime, CodeFix). The skip happens at the entry of each method, before any template binding or advice instantiation. Previously, the heavy work (template validation, member retrieval, parameter binding, transformation construction) ran on every advice call, and the resulting `Observability.None` transformations were silently dropped later by `AdviceFactoryState.AddTransformations`.
- New `AdviceOutcome.Skipped` value, distinct from `Ignore` (which carries `OverrideStrategy`-conflict semantics), so user code can branch on a pipeline-driven skip vs. a user-driven no-op.
- The skip is gated by per-member preconditions (`member.HasImplementation` and `member is not IField`) for `Override*` advice. Either condition would otherwise cause the advice to also produce a `CompileTimeOnly` side-effect transformation: `SetHasImplementationTransformation` for partial members without implementation, or `PromoteFieldTransformation` for field-to-property promotion. Both are filtered out of the design-time syntax tree by `DesignTimeSyntaxTreeGenerator`, but they ARE applied to `MutableCompilation`, so a subsequent aspect that reads the model would observe a different state if we skipped (covered for partial constructors by the existing `PartialConstructor_HasImplementationAfterOverride` aspect-chain test).
- `AddContract` and `AddInitializer(IConstructor, ...)` produce only pure `Observability.None` transformations, so they skip on the scenario flag alone &mdash; no per-member precondition needed.

## Issues Fixed

- #1599 &mdash; Skip non-observable advice early in AdviceFactory when scenario doesn't capture them
