### PR TITLE
Fix LAMA0601 SyntaxTree.FilePath empty when WPF + WriteHtml + introduction

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/DesignTimeSyntaxTreeGenerator.cs
@@ -245,11 +245,11 @@ namespace Metalama.Framework.Engine.Pipeline.DesignTime
                 var compilationUnit = CompilationUnit()
                     .WithMembers( SingletonList( AddHeader( topDeclaration ) ) );
 
-                var generatedSyntaxTree = SyntaxTree( compilationUnit.NormalizeWhitespace(), encoding: Encoding.UTF8 );
-
-                // Find a unique syntax tree name. 
+                // Find a unique syntax tree name.
                 var safeTypeName = GetUniqueFilenameForType( declaringTypeOrExtensionBlock );
                 var syntaxTreeName = safeTypeName + ".cs";
+
+                var generatedSyntaxTree = SyntaxTree( compilationUnit.NormalizeWhitespace(), encoding: Encoding.UTF8, path: syntaxTreeName );
 
                 if ( !additionalSyntaxTreeDictionary.TryAdd(
                         syntaxTreeName,

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/App.xaml
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="Repro.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/App.xaml.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace Repro;
+
+public partial class App : Application
+{
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/IntroduceNestedTypeAttribute.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/IntroduceNestedTypeAttribute.cs
@@ -1,0 +1,14 @@
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Repro;
+
+public sealed class IntroduceNestedTypeAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceClass(
+            "Nested",
+            buildType: t => t.Accessibility = Metalama.Framework.Code.Accessibility.Public );
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/MainWindow.xaml
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/MainWindow.xaml
@@ -1,0 +1,11 @@
+<Window x:Class="Repro.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Repro"
+        mc:Ignorable="d"
+        Title="Repro" Height="200" Width="300"
+        d:DataContext="{d:DesignInstance local:Target}">
+    <Grid />
+</Window>

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/MainWindow.xaml.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/MainWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Repro;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/Repro.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/Repro.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>net9.0-windows</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UseWPF>true</UseWPF>
+        <RootNamespace>Repro</RootNamespace>
+        <MetalamaWriteHtml>true</MetalamaWriteHtml>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+        <PackageReference Include="Metalama.Extensions.HtmlWriter" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1585b/Target.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1585b/Target.cs
@@ -1,0 +1,6 @@
+namespace Repro;
+
+[IntroduceNestedType]
+public partial class Target
+{
+}


### PR DESCRIPTION
## Summary
- Fix `LAMA0601` / `ArgumentOutOfRangeException: SyntaxTree.FilePath property must be set to a non-empty value` raised when a WPF project combines `MetalamaWriteHtml=true`, a `Metalama.Extensions.HtmlWriter` package reference, and an observable transformation (e.g. `IntroduceClass`) on a partial type.
- Root cause: `DesignTimeSyntaxTreeGenerator.cs:248` created the `SyntaxTree` without passing `path:`, so `FilePath` was `""`. `PartialCompilation.Validate` (recently tightened) now rejects transformations whose tree has an empty `FilePath`.
- Fix: move the `syntaxTreeName` computation above the `SyntaxTree(...)` call and pass it as `path:`. One-line behavioral change.

## Repro
- Standalone test added at `Metalama.Framework/src/tests/Standalone/Issue1585b/` — minimal WPF + WriteHtml + `IntroduceClass` repro. Build fails on `develop/2026.1` with the exact `LAMA0601`; passes with this fix applied.
- Discovered while building `Metalama.Samples` 2026.1 — `Memento1` and `Memento2` (both WPF) were failing; non-WPF samples were unaffected.

## Follow-up
- Filed #1601 for the separate perf concern around `compilationUnit.NormalizeWhitespace()` in the same generator. Not in scope for this PR.

— Claude for @gfraiteur