### PR TITLE
Add MessagePackHelper and JsonRpc trace forwarding (#1606)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/BaseEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/BaseEndpoint.cs
@@ -91,22 +91,33 @@ public abstract class BaseEndpoint : IDisposable
         }
     }
 
-    protected static JsonRpc CreateRpc( Stream stream )
+    // Use TypelessObjectResolver with CompositeResolver to handle both polymorphic types
+    // (abstract-typed properties such as RpcEventEnvelope.Data: RpcEventData) and immutable collections.
+    // StandardResolver includes formatters for ImmutableArray<T>, etc. Exposed as `internal` so MessagePackHelper
+    // can use the exact same options when serialising RPC contract types from production code paths or tests.
+    internal static MessagePackSerializerOptions MessagePackOptions { get; } =
+        MessagePackSerializerOptions.Standard.WithResolver(
+            CompositeResolver.Create(
+                TypelessObjectResolver.Instance,
+                StandardResolver.Instance ) );
+
+    protected JsonRpc CreateRpc( Stream stream )
     {
         var formatter = new MessagePackFormatter();
-
-        // Use TypelessObjectResolver with CompositeResolver to handle both polymorphic types
-        // and immutable collections. StandardResolver includes formatters for ImmutableArray<T>, etc.
-        var resolver = CompositeResolver.Create(
-            TypelessObjectResolver.Instance,
-            StandardResolver.Instance );
-
-        var options = MessagePackSerializerOptions.Standard.WithResolver( resolver );
-        formatter.SetMessagePackSerializerOptions( options );
+        formatter.SetMessagePackSerializerOptions( MessagePackOptions );
 
         var handler = new LengthHeaderMessageHandler( stream, stream, formatter );
 
-        return new JsonRpc( handler );
+        var rpc = new JsonRpc( handler );
+
+        // Forward StreamJsonRpc internal trace events (request/response dispatch, argument-deserialization
+        // failures, connection lifecycle) to the endpoint's ILogger. Switch.Level=Information catches everything
+        // up to and including warnings; the underlying ILogWriter then filters by the Metalama logger
+        // configuration, so this is null-cost when verbose logging isn't enabled.
+        rpc.TraceSource.Switch.Level = SourceLevels.Information;
+        rpc.TraceSource.Listeners.Add( new LoggerTraceListener( this.Logger ) );
+
+        return rpc;
     }
 
     public override string ToString() => $"{this.GetType().Name}({this.PipeName})";

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/LoggerTraceListener.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/LoggerTraceListener.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Diagnostics;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Metalama.Framework.DesignTime.Rpc;
+
+/// <summary>
+/// Forwards <see cref="TraceSource"/> events to a Metalama <see cref="ILogger"/>. Used to surface
+/// StreamJsonRpc's internal events (request/response dispatch, argument-deserialization errors, connection
+/// lifecycle) in the same logging stream as the rest of the RPC layer, so production interactive-VS sessions
+/// can capture the actual failure point of issue #1606-class symptoms.
+/// </summary>
+internal sealed class LoggerTraceListener : TraceListener
+{
+    private readonly ILogger _logger;
+
+    public LoggerTraceListener( ILogger logger )
+    {
+        this._logger = logger;
+    }
+
+    public override void Write( string? message ) => this._logger.Trace?.Log( message ?? string.Empty );
+
+    public override void WriteLine( string? message ) => this._logger.Trace?.Log( message ?? string.Empty );
+
+    public override void TraceEvent( TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message )
+    {
+        var formatted = $"[{source}#{id}] {message}";
+
+        switch ( eventType )
+        {
+            case TraceEventType.Critical:
+            case TraceEventType.Error:
+                this._logger.Error?.Log( formatted );
+
+                break;
+
+            case TraceEventType.Warning:
+                this._logger.Warning?.Log( formatted );
+
+                break;
+
+            case TraceEventType.Information:
+                this._logger.Info?.Log( formatted );
+
+                break;
+
+            default:
+                this._logger.Trace?.Log( formatted );
+
+                break;
+        }
+    }
+
+    public override void TraceEvent(
+        TraceEventCache? eventCache,
+        string source,
+        TraceEventType eventType,
+        int id,
+        string? format,
+        params object?[]? args )
+    {
+        var message = format != null
+            ? string.Format( CultureInfo.InvariantCulture, format, args ?? Array.Empty<object?>() )
+            : string.Empty;
+
+        this.TraceEvent( eventCache, source, eventType, id, message );
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/MessagePackHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/MessagePackHelper.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using MessagePack;
+
+namespace Metalama.Framework.DesignTime.Rpc;
+
+/// <summary>
+/// MessagePack adapter that uses the same serializer options as the production RPC layer
+/// (see <see cref="BaseEndpoint"/>'s <c>CreateRpc</c>). Production code paths and cross-repo tests use this to
+/// validate RPC contract types against the real wire path.
+/// </summary>
+/// <remarks>
+/// The non-generic <see cref="Serialize(object, Type)"/> / <see cref="Deserialize(byte[], Type)"/> overloads
+/// exist for callers that resolve the static type at runtime (e.g., a descriptor-based dispatch where the
+/// concrete type is selected by an out-of-band identifier — see Premium's <c>CodeActionDescriptor</c> path).
+/// </remarks>
+public sealed class MessagePackHelper
+{
+    public byte[] Serialize<T>( T value ) => MessagePackSerializer.Serialize( value, BaseEndpoint.MessagePackOptions );
+
+    public T Deserialize<T>( byte[] bytes ) => MessagePackSerializer.Deserialize<T>( bytes, BaseEndpoint.MessagePackOptions );
+
+    public byte[] Serialize( object? value, Type type ) => MessagePackSerializer.Serialize( type, value, BaseEndpoint.MessagePackOptions );
+
+    public object? Deserialize( byte[] bytes, Type type ) => MessagePackSerializer.Deserialize( type, bytes, BaseEndpoint.MessagePackOptions );
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/CodeFixes/CodeActionDescriptor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/CodeFixes/CodeActionDescriptor.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Rpc;
+using System.Collections.Immutable;
+
+namespace Metalama.Framework.DesignTime.CodeFixes;
+
+/// <summary>
+/// Wire-format descriptor for a code action or code-action menu rendered by the Visual Studio light-bulb.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately a <em>concrete</em> record (no polymorphism). It crosses the analyzer ↔ devenv RPC boundary
+/// without depending on cross-process / cross-TFM assembly-identity round-tripping — which is the fragility
+/// behind issue #1606 and the reason Roslyn-disable-the-provider failures surface in production. Owning this
+/// type in <c>Metalama.Framework.DesignTime</c> (rather than each extension package) gives one canonical
+/// wire shape that all code-action-producing extensions can share.
+/// </para>
+/// <para>
+/// The descriptor carries only what the IDE needs to <em>render</em>: the user-visible <see cref="Title"/> and
+/// an optional <see cref="NestedItems"/> tree for menus. Plus an opaque payload (<see cref="PayloadTypeName"/>
+/// + <see cref="Payload"/>) that round-trips through devenv unchanged. Devenv never deserializes
+/// <see cref="Payload"/>; only the analyzer does — typically by looking <see cref="PayloadTypeName"/> up in an
+/// extension-private dictionary of <c>(name → Type)</c> and calling <c>MessagePackHelper.Deserialize&lt;TConcrete&gt;</c>.
+/// This keeps the wire boundary free of polymorphism while letting the analyzer dispatch without any per-click cache.
+/// </para>
+/// </remarks>
+[RpcContract]
+public sealed record CodeActionDescriptor
+{
+    /// <summary>
+    /// User-visible title shown by the IDE.
+    /// </summary>
+    public string Title { get; init; } = "";
+
+    /// <summary>
+    /// Children when this descriptor represents a menu. Empty for leaf actions.
+    /// </summary>
+    public ImmutableArray<CodeActionDescriptor> NestedItems { get; init; } = ImmutableArray<CodeActionDescriptor>.Empty;
+
+    /// <summary>
+    /// Analyzer-side identifier for the concrete payload type — opaque to devenv. Used by the analyzer to
+    /// dispatch <see cref="Payload"/> deserialization without polymorphism. The naming convention is owned by
+    /// the extension that produces the descriptor (e.g., a short name like <c>nameof(UserCodeActionModel)</c>
+    /// resolved against an extension-private <c>Dictionary&lt;string, Type&gt;</c>). <c>null</c> for menus.
+    /// </summary>
+    public string? PayloadTypeName { get; init; }
+
+    /// <summary>
+    /// Opaque-to-devenv bytes describing the leaf action. Devenv stores and round-trips them unchanged on
+    /// invoke. The analyzer deserializes via <c>MessagePackHelper.Deserialize&lt;TConcrete&gt;</c> using the
+    /// type resolved from <see cref="PayloadTypeName"/>. <c>null</c> for menus.
+    /// </summary>
+    public byte[]? Payload { get; init; }
+
+    /// <summary>
+    /// True when this descriptor is a menu (has at least one nested item). False for leaf code actions.
+    /// </summary>
+    public bool IsMenu => !this.NestedItems.IsDefaultOrEmpty;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/Metalama.Framework.Tests.UnitTestHelpers.csproj
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/Metalama.Framework.Tests.UnitTestHelpers.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Metalama.Framework.Engine$(ThisRoslynVersionProjectSuffix)\Metalama.Framework.Engine$(ThisRoslynVersionProjectSuffix).csproj" PrivateAssets="all" />
         <ProjectReference Include="..\..\Metalama.Framework.DesignTime$(ThisRoslynVersionProjectSuffix)\Metalama.Framework.DesignTime$(ThisRoslynVersionProjectSuffix).csproj" PrivateAssets="all" />
+        <ProjectReference Include="..\..\Metalama.Framework.DesignTime.Rpc\Metalama.Framework.DesignTime.Rpc.csproj" PrivateAssets="all" />
         <ProjectReference Include="..\..\Metalama.Testing.UnitTesting$(ThisRoslynVersionProjectSuffix)\Metalama.Testing.UnitTesting$(ThisRoslynVersionProjectSuffix).csproj" />
 
         <!-- Dependency of the resulting package should be on Implementation package. -->

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/SerializationTestsBase.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/SerializationTestsBase.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.DesignTime.Rpc;
 using Newtonsoft.Json;
 using System.IO;
 
@@ -9,6 +10,12 @@ namespace Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
 
 public class SerializationTestsBase
 {
+    /// <summary>
+    /// Round-trips <paramref name="input"/> through Newtonsoft.Json with <see cref="TypeNameHandling.All"/>.
+    /// Use this for types that travel the cross-version <c>Metalama.Framework.DesignTime.Contracts</c> /
+    /// <c>JsonSerializationBinder</c> path (e.g., <c>DevEnvEntryPoint</c>); use <see cref="MessagePackRoundloop{T}"/>
+    /// for types that travel the same-version named-pipe RPC wire path.
+    /// </summary>
     protected static T Roundloop<T>( T input )
     {
         var stringWriter = new StringWriter();
@@ -16,5 +23,17 @@ public class SerializationTestsBase
         serializer.Serialize( stringWriter, input );
 
         return serializer.Deserialize<T>( new JsonTextReader( new StringReader( stringWriter.ToString() ) ) )!;
+    }
+
+    /// <summary>
+    /// Round-trips <paramref name="input"/> through the MessagePack RPC pipeline (<see cref="MessagePackHelper"/>),
+    /// matching the wire path used by <c>BaseEndpoint.CreateRpc</c>. Use this for <c>[RpcContract]</c>-annotated
+    /// types that flow over the same-version named-pipe RPC.
+    /// </summary>
+    protected static T MessagePackRoundloop<T>( T input )
+    {
+        var helper = new MessagePackHelper();
+
+        return helper.Deserialize<T>( helper.Serialize( input ) );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcSerializationTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Metalama.Framework.DesignTime.AspectExplorer;
+using Metalama.Framework.DesignTime.CodeFixes;
 using Metalama.Framework.DesignTime.CodeLens;
 using Metalama.Framework.DesignTime.Diagnostics;
 using Metalama.Framework.DesignTime.Preview;
@@ -408,5 +409,54 @@ public sealed class RpcSerializationTests
         Assert.Equal( original.TargetDeclarationId, result.TargetDeclarationId );
         Assert.Equal( original.Transformations.Length, result.Transformations.Length );
         Assert.Equal( original.Transformations[0].Description, result.Transformations[0].Description );
+    }
+
+    [Fact]
+    public void CodeActionDescriptor_Leaf_Roundtrip()
+    {
+        var payload = new byte[] { 1, 2, 3, 4 };
+
+        var original = new CodeActionDescriptor
+        {
+            Title = "Apply aspect", PayloadTypeName = "UserCodeActionModel", Payload = payload
+        };
+
+        var result = Roundtrip( original );
+
+        Assert.Equal( original.Title, result.Title );
+        Assert.Equal( original.PayloadTypeName, result.PayloadTypeName );
+        Assert.Equal( payload, result.Payload );
+        Assert.False( result.IsMenu );
+        Assert.True( result.NestedItems.IsDefaultOrEmpty );
+    }
+
+    [Fact]
+    public void CodeActionDescriptor_Menu_Roundtrip()
+    {
+        var original = new CodeActionDescriptor
+        {
+            Title = "Refactor",
+            NestedItems = ImmutableArray.Create(
+                new CodeActionDescriptor
+                {
+                    Title = "Apply X", PayloadTypeName = "UserCodeActionModel", Payload = new byte[] { 1, 2 }
+                },
+                new CodeActionDescriptor
+                {
+                    Title = "Apply Y", PayloadTypeName = "ApplyLiveTemplateCodeActionModel", Payload = new byte[] { 3, 4 }
+                } )
+        };
+
+        var result = Roundtrip( original );
+
+        Assert.Equal( "Refactor", result.Title );
+        Assert.True( result.IsMenu );
+        Assert.Null( result.PayloadTypeName );
+        Assert.Null( result.Payload );
+        Assert.Equal( 2, result.NestedItems.Length );
+        Assert.Equal( "Apply X", result.NestedItems[0].Title );
+        Assert.Equal( "UserCodeActionModel", result.NestedItems[0].PayloadTypeName );
+        Assert.Equal( new byte[] { 1, 2 }, result.NestedItems[0].Payload );
+        Assert.Equal( "Apply Y", result.NestedItems[1].Title );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcSerializationTests.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using MessagePack;
-using MessagePack.Resolvers;
 using Metalama.Framework.DesignTime.AspectExplorer;
 using Metalama.Framework.DesignTime.CodeLens;
 using Metalama.Framework.DesignTime.Diagnostics;
@@ -26,17 +24,13 @@ using Xunit;
 namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
 
 /// <summary>
-/// Roundtrip serialization tests for MessagePack serialization of RPC contract types.
-/// These tests verify that all types used in RPC communication can be correctly serialized
-/// and deserialized using a composite resolver with TypelessObjectResolver and StandardResolver.
+/// Roundtrip serialization tests for the RPC contract types — uses <see cref="MessagePackHelper"/>, which
+/// goes through the same <c>MessagePackSerializerOptions</c> as <c>BaseEndpoint.CreateRpc</c> so these tests
+/// validate the real wire path end-to-end.
 /// </summary>
-public sealed class MessagePackSerializationTests
+public sealed class RpcSerializationTests
 {
-    private static readonly MessagePackSerializerOptions _options =
-        MessagePackSerializerOptions.Standard.WithResolver(
-            CompositeResolver.Create(
-                TypelessObjectResolver.Instance,
-                StandardResolver.Instance ) );
+    private static readonly MessagePackHelper _helper = new MessagePackHelper();
 
     private static T Roundtrip<T>( T value )
     {
@@ -45,9 +39,29 @@ public sealed class MessagePackSerializationTests
         var attribute = type.GetCustomAttribute<RpcContractAttribute>();
         Assert.True( attribute != null, $"Type {type.FullName} is missing the [RpcContract] attribute." );
 
-        var bytes = MessagePackSerializer.Serialize( value, _options );
+        return _helper.Deserialize<T>( _helper.Serialize( value ) );
+    }
 
-        return MessagePackSerializer.Deserialize<T>( bytes, _options );
+    [Fact]
+    public void NonGeneric_Roundtrip_MatchesGeneric()
+    {
+        // Pins that MessagePackHelper's non-generic Serialize(object, Type) / Deserialize(byte[], Type) overloads
+        // produce wire bytes byte-equivalent to the generic ones for the same options + same concrete type.
+        // Premium relies on this: its CodeActionDescriptor.ToDescriptor passes the runtime type of a leaf model
+        // to the non-generic overload (the type discriminator rides out-of-band in the descriptor).
+        var input = new RpcServiceInfo( "pipe-name", "FactoryType", "ExtensionName" );
+
+        var bytesGeneric = _helper.Serialize( input );
+        var bytesNonGeneric = _helper.Serialize( input, typeof(RpcServiceInfo) );
+
+        Assert.Equal( bytesGeneric, bytesNonGeneric );
+
+        var fromGeneric = _helper.Deserialize<RpcServiceInfo>( bytesNonGeneric );
+        var fromNonGeneric = (RpcServiceInfo) _helper.Deserialize( bytesGeneric, typeof(RpcServiceInfo) )!;
+
+        Assert.Equal( fromGeneric.PipeName, fromNonGeneric.PipeName );
+        Assert.Equal( fromGeneric.FactoryTypeName, fromNonGeneric.FactoryTypeName );
+        Assert.Equal( fromGeneric.ExtensionName, fromNonGeneric.ExtensionName );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Issue #1606 surfaced production VS failures where polymorphic deserialization of `CodeActionBaseModel` on the wire breaks under cross-process / cross-TFM identity mismatches. Symptom: `RemoteMethodNotFoundException` + `Failed to deserialize CodeActionModel value` → Roslyn permanently disables the code-fix provider for the rest of the VS session.

After investigation we settled on fixing the `CodeActionBaseModel` problem on the **Premium side** with an opaque-payload `CodeActionDescriptor` pattern (concrete record + opaque bytes; devenv never deserializes the polymorphic model). That's a follow-up Premium PR. The cross-process polymorphism for code actions disappears entirely once Premium lands.

This PR keeps the Metalama-side preconditions for that pattern minimal:

- **`MessagePackHelper`** (public, in `Metalama.Framework.DesignTime.Rpc`) — adapter that uses the same `MessagePackSerializerOptions` as `BaseEndpoint.CreateRpc`. Generic + non-generic Serialize/Deserialize overloads. Premium uses this in `CodeActionBaseModel.ToDescriptor` to serialize a leaf model by its runtime type; the descriptor's `PayloadTypeName` carries the discriminator out-of-band, looked up in a Premium-private name → Type dictionary on the analyzer side.
- **`LoggerTraceListener`** (internal) + **JsonRpc.TraceSource forwarding in `BaseEndpoint.CreateRpc`** — surfaces StreamJsonRpc's internal events (request/response dispatch, argument-deserialization errors, connection lifecycle) into the Metalama logger, at `SourceLevels.Information`. Null-cost when verbose logging isn't enabled. This is the diagnostic tool you can enable interactively in VS to capture future RPC failures with the actual JSON-RPC envelope and exception trace.
- **`MessagePackOptions`** on `BaseEndpoint` exposed as `internal static` so `MessagePackHelper` and `BaseEndpoint.CreateRpc` share one source of truth — same chain `[Typeless, Standard]` as before.
- **`SerializationTestsBase.MessagePackRoundloop<T>`** — sibling of the existing Newtonsoft-based `Roundloop<T>` for cross-repo tests that need to exercise the MessagePack RPC wire path. Premium uses this in its `CodeFixSerializationTests`.
- **Test rename**: `MessagePackSerializationTests.cs` → `RpcSerializationTests.cs` (the file tests RPC contract types, not generic MessagePack serialization). Adds `NonGeneric_Roundtrip_MatchesGeneric` to pin the byte-equivalence of the new non-generic overloads.

### What's NOT in this PR (deliberately)

A polymorphic resolver was prototyped earlier in this branch (live registry, hierarchy walk, soft-fail). It got dropped because:

1. The only known wire user of cross-process polymorphism was `CodeActionBaseModel`, which Premium is moving to the opaque-payload pattern.
2. `RpcEventData`-family events were already working pre-PR via `TypelessObjectResolver` + `StandardResolver` (single-field abstract type, not collection-of-abstract). Verified by the existing `PolymorphicRpcEventData_*` tests passing on the stripped branch.
3. All `RpcEventData` subtypes live in Metalama-owned assemblies, so their `Type.GetType` resolution doesn't hit the cross-TFM identity issue Premium's types do.

If a future RPC contract introduces a `List<TBase>` or `Dictionary<K, TBase>` of an abstract base, the right pattern is the same opaque-payload + descriptor approach we're proposing for code actions, not reintroducing the resolver.

## Test plan

- [x] Build clean (0 warnings, 0 errors): `Metalama.Framework.DesignTime.Rpc`, `Metalama.Framework.DesignTime`, `Metalama.Framework.Tests.UnitTests` on net8.0 + net48.
- [x] `RpcSerializationTests` (24 + 1 = 25 tests) — all existing `[RpcContract]` round-trips + `NonGeneric_Roundtrip_MatchesGeneric` for the new overloads. Includes `PolymorphicRpcEventData_*` (which validates `RpcEventData` polymorphism via `TypelessObjectResolver`).
- [x] Full RPC suite: 72/73 pass on both net8.0 and net48 (1 pre-existing unrelated skip: `RpcServiceProviderTests.ExtensionNeverDiscovered_BackgroundTaskNeverCompletes`).
- [x] `DevEnvEntryPoint.SerializationTests` (Newtonsoft cross-version path): 3/3 still pass — no regression.
- [ ] Interactive VS verification (post-merge): once Premium consumes this branch and lands the `CodeActionDescriptor` refactor, reproduce the original #1606 scenario and confirm `RemoteMethodNotFoundException` no longer fires. The new `LoggerTraceListener` will surface any new RPC failures in the Metalama logs with full StreamJsonRpc context.

Closes part of #1606. Premium-side follow-up PR closes the rest.