### PR TITLE
Add MessagePackHelper and JsonRpc trace forwarding (no-polymorphism alternative for #1606)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/BaseEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/BaseEndpoint.cs
@@ -91,22 +91,33 @@ public abstract class BaseEndpoint : IDisposable
         }
     }
 
-    protected static JsonRpc CreateRpc( Stream stream )
+    // Use TypelessObjectResolver with CompositeResolver to handle both polymorphic types
+    // (abstract-typed properties such as RpcEventEnvelope.Data: RpcEventData) and immutable collections.
+    // StandardResolver includes formatters for ImmutableArray<T>, etc. Exposed as `internal` so MessagePackHelper
+    // can use the exact same options when serialising RPC contract types from production code paths or tests.
+    internal static MessagePackSerializerOptions MessagePackOptions { get; } =
+        MessagePackSerializerOptions.Standard.WithResolver(
+            CompositeResolver.Create(
+                TypelessObjectResolver.Instance,
+                StandardResolver.Instance ) );
+
+    protected JsonRpc CreateRpc( Stream stream )
     {
         var formatter = new MessagePackFormatter();
-
-        // Use TypelessObjectResolver with CompositeResolver to handle both polymorphic types
-        // and immutable collections. StandardResolver includes formatters for ImmutableArray<T>, etc.
-        var resolver = CompositeResolver.Create(
-            TypelessObjectResolver.Instance,
-            StandardResolver.Instance );
-
-        var options = MessagePackSerializerOptions.Standard.WithResolver( resolver );
-        formatter.SetMessagePackSerializerOptions( options );
+        formatter.SetMessagePackSerializerOptions( MessagePackOptions );
 
         var handler = new LengthHeaderMessageHandler( stream, stream, formatter );
 
-        return new JsonRpc( handler );
+        var rpc = new JsonRpc( handler );
+
+        // Forward StreamJsonRpc internal trace events (request/response dispatch, argument-deserialization
+        // failures, connection lifecycle) to the endpoint's ILogger. Switch.Level=Information catches everything
+        // up to and including warnings; the underlying ILogWriter then filters by the Metalama logger
+        // configuration, so this is null-cost when verbose logging isn't enabled.
+        rpc.TraceSource.Switch.Level = SourceLevels.Information;
+        rpc.TraceSource.Listeners.Add( new LoggerTraceListener( this.Logger ) );
+
+        return rpc;
     }
 
     public override string ToString() => $"{this.GetType().Name}({this.PipeName})";

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/BaseEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/BaseEndpoint.cs
@@ -111,9 +111,11 @@ public abstract class BaseEndpoint : IDisposable
         var rpc = new JsonRpc( handler );
 
         // Forward StreamJsonRpc internal trace events (request/response dispatch, argument-deserialization
-        // failures, connection lifecycle) to the endpoint's ILogger. Switch.Level=Information catches everything
-        // up to and including warnings; the underlying ILogWriter then filters by the Metalama logger
-        // configuration, so this is null-cost when verbose logging isn't enabled.
+        // failures, connection lifecycle) to the endpoint's ILogger. SourceLevels.Information enables
+        // Information AND all higher-severity events (Warning, Error, Critical); LoggerTraceListener routes
+        // each event to the matching ILogger writer and short-circuits formatting when the writer is null,
+        // so verbose StreamJsonRpc events cost nothing when the corresponding Metalama log levels aren't
+        // enabled. Always-on so Warning/Error events surface in production logs even when Trace is off.
         rpc.TraceSource.Switch.Level = SourceLevels.Information;
         rpc.TraceSource.Listeners.Add( new LoggerTraceListener( this.Logger ) );
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/LoggerTraceListener.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/LoggerTraceListener.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Diagnostics;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Metalama.Framework.DesignTime.Rpc;
+
+/// <summary>
+/// Forwards <see cref="TraceSource"/> events to a Metalama <see cref="ILogger"/>. Used to surface
+/// StreamJsonRpc's internal events (request/response dispatch, argument-deserialization errors, connection
+/// lifecycle) in the same logging stream as the rest of the RPC layer, so production interactive-VS sessions
+/// can capture the actual failure point of issue #1606-class symptoms.
+/// </summary>
+internal sealed class LoggerTraceListener : TraceListener
+{
+    private readonly ILogger _logger;
+
+    public LoggerTraceListener( ILogger logger )
+    {
+        this._logger = logger;
+    }
+
+    public override void Write( string? message ) => this._logger.Trace?.Log( message ?? string.Empty );
+
+    public override void WriteLine( string? message ) => this._logger.Trace?.Log( message ?? string.Empty );
+
+    public override void TraceEvent( TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message )
+    {
+        var formatted = $"[{source}#{id}] {message}";
+
+        switch ( eventType )
+        {
+            case TraceEventType.Critical:
+            case TraceEventType.Error:
+                this._logger.Error?.Log( formatted );
+
+                break;
+
+            case TraceEventType.Warning:
+                this._logger.Warning?.Log( formatted );
+
+                break;
+
+            case TraceEventType.Information:
+                this._logger.Info?.Log( formatted );
+
+                break;
+
+            default:
+                this._logger.Trace?.Log( formatted );
+
+                break;
+        }
+    }
+
+    public override void TraceEvent(
+        TraceEventCache? eventCache,
+        string source,
+        TraceEventType eventType,
+        int id,
+        string? format,
+        params object?[]? args )
+    {
+        var message = format != null
+            ? string.Format( CultureInfo.InvariantCulture, format, args ?? Array.Empty<object?>() )
+            : string.Empty;
+
+        this.TraceEvent( eventCache, source, eventType, id, message );
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/LoggerTraceListener.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/LoggerTraceListener.cs
@@ -29,31 +29,16 @@ internal sealed class LoggerTraceListener : TraceListener
 
     public override void TraceEvent( TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message )
     {
-        var formatted = $"[{source}#{id}] {message}";
+        // Resolve the target writer first: when the corresponding ILogger writer is null (the level isn't
+        // enabled in the Metalama logger configuration), skip building the formatted string entirely.
+        var writer = this.GetWriter( eventType );
 
-        switch ( eventType )
+        if ( writer == null )
         {
-            case TraceEventType.Critical:
-            case TraceEventType.Error:
-                this._logger.Error?.Log( formatted );
-
-                break;
-
-            case TraceEventType.Warning:
-                this._logger.Warning?.Log( formatted );
-
-                break;
-
-            case TraceEventType.Information:
-                this._logger.Info?.Log( formatted );
-
-                break;
-
-            default:
-                this._logger.Trace?.Log( formatted );
-
-                break;
+            return;
         }
+
+        writer.Log( $"[{source}#{id}] {message}" );
     }
 
     public override void TraceEvent(
@@ -64,10 +49,29 @@ internal sealed class LoggerTraceListener : TraceListener
         string? format,
         params object?[]? args )
     {
+        // Same early-return discipline as the message overload — don't pay for string.Format when the writer
+        // is null. StreamJsonRpc emits some events (e.g., argument-payload dumps in Verbose mode) with format
+        // strings, so skipping the format call when nobody is listening matters.
+        var writer = this.GetWriter( eventType );
+
+        if ( writer == null )
+        {
+            return;
+        }
+
         var message = format != null
             ? string.Format( CultureInfo.InvariantCulture, format, args ?? Array.Empty<object?>() )
             : string.Empty;
 
-        this.TraceEvent( eventCache, source, eventType, id, message );
+        writer.Log( $"[{source}#{id}] {message}" );
     }
+
+    private ILogWriter? GetWriter( TraceEventType eventType )
+        => eventType switch
+        {
+            TraceEventType.Critical or TraceEventType.Error => this._logger.Error,
+            TraceEventType.Warning => this._logger.Warning,
+            TraceEventType.Information => this._logger.Info,
+            _ => this._logger.Trace
+        };
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/MessagePackHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/MessagePackHelper.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using MessagePack;
+
+namespace Metalama.Framework.DesignTime.Rpc;
+
+/// <summary>
+/// MessagePack adapter that uses the same serializer options as the production RPC layer
+/// (see <see cref="BaseEndpoint"/>'s <c>CreateRpc</c>). Production code paths and cross-repo tests use this to
+/// validate RPC contract types against the real wire path.
+/// </summary>
+/// <remarks>
+/// The non-generic <see cref="Serialize(object, Type)"/> / <see cref="Deserialize(byte[], Type)"/> overloads
+/// exist for callers that resolve the static type at runtime (e.g., a descriptor-based dispatch where the
+/// concrete type is selected by an out-of-band identifier — see Premium's <c>CodeActionDescriptor</c> path).
+/// </remarks>
+public sealed class MessagePackHelper
+{
+    public byte[] Serialize<T>( T value ) => MessagePackSerializer.Serialize( value, BaseEndpoint.MessagePackOptions );
+
+    public T Deserialize<T>( byte[] bytes ) => MessagePackSerializer.Deserialize<T>( bytes, BaseEndpoint.MessagePackOptions );
+
+    public byte[] Serialize( object? value, Type type ) => MessagePackSerializer.Serialize( type, value, BaseEndpoint.MessagePackOptions );
+
+    public object? Deserialize( byte[] bytes, Type type ) => MessagePackSerializer.Deserialize( type, bytes, BaseEndpoint.MessagePackOptions );
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/Metalama.Framework.Tests.UnitTestHelpers.csproj
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/Metalama.Framework.Tests.UnitTestHelpers.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Metalama.Framework.Engine$(ThisRoslynVersionProjectSuffix)\Metalama.Framework.Engine$(ThisRoslynVersionProjectSuffix).csproj" PrivateAssets="all" />
         <ProjectReference Include="..\..\Metalama.Framework.DesignTime$(ThisRoslynVersionProjectSuffix)\Metalama.Framework.DesignTime$(ThisRoslynVersionProjectSuffix).csproj" PrivateAssets="all" />
+        <ProjectReference Include="..\..\Metalama.Framework.DesignTime.Rpc\Metalama.Framework.DesignTime.Rpc.csproj" PrivateAssets="all" />
         <ProjectReference Include="..\..\Metalama.Testing.UnitTesting$(ThisRoslynVersionProjectSuffix)\Metalama.Testing.UnitTesting$(ThisRoslynVersionProjectSuffix).csproj" />
 
         <!-- Dependency of the resulting package should be on Implementation package. -->

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/SerializationTestsBase.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/SerializationTestsBase.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.DesignTime.Rpc;
 using Newtonsoft.Json;
 using System.IO;
 
@@ -9,6 +10,12 @@ namespace Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
 
 public class SerializationTestsBase
 {
+    /// <summary>
+    /// Round-trips <paramref name="input"/> through Newtonsoft.Json with <see cref="TypeNameHandling.All"/>.
+    /// Use this for types that travel the cross-version <c>Metalama.Framework.DesignTime.Contracts</c> /
+    /// <c>JsonSerializationBinder</c> path (e.g., <c>DevEnvEntryPoint</c>); use <see cref="MessagePackRoundloop{T}"/>
+    /// for types that travel the same-version named-pipe RPC wire path.
+    /// </summary>
     protected static T Roundloop<T>( T input )
     {
         var stringWriter = new StringWriter();
@@ -16,5 +23,17 @@ public class SerializationTestsBase
         serializer.Serialize( stringWriter, input );
 
         return serializer.Deserialize<T>( new JsonTextReader( new StringReader( stringWriter.ToString() ) ) )!;
+    }
+
+    /// <summary>
+    /// Round-trips <paramref name="input"/> through the MessagePack RPC pipeline (<see cref="MessagePackHelper"/>),
+    /// matching the wire path used by <c>BaseEndpoint.CreateRpc</c>. Use this for <c>[RpcContract]</c>-annotated
+    /// types that flow over the same-version named-pipe RPC.
+    /// </summary>
+    protected static T MessagePackRoundloop<T>( T input )
+    {
+        var helper = new MessagePackHelper();
+
+        return helper.Deserialize<T>( helper.Serialize( input ) );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcSerializationTests.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using MessagePack;
-using MessagePack.Resolvers;
 using Metalama.Framework.DesignTime.AspectExplorer;
 using Metalama.Framework.DesignTime.CodeLens;
 using Metalama.Framework.DesignTime.Diagnostics;
@@ -26,17 +24,13 @@ using Xunit;
 namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
 
 /// <summary>
-/// Roundtrip serialization tests for MessagePack serialization of RPC contract types.
-/// These tests verify that all types used in RPC communication can be correctly serialized
-/// and deserialized using a composite resolver with TypelessObjectResolver and StandardResolver.
+/// Roundtrip serialization tests for the RPC contract types — uses <see cref="MessagePackHelper"/>, which
+/// goes through the same <c>MessagePackSerializerOptions</c> as <c>BaseEndpoint.CreateRpc</c> so these tests
+/// validate the real wire path end-to-end.
 /// </summary>
-public sealed class MessagePackSerializationTests
+public sealed class RpcSerializationTests
 {
-    private static readonly MessagePackSerializerOptions _options =
-        MessagePackSerializerOptions.Standard.WithResolver(
-            CompositeResolver.Create(
-                TypelessObjectResolver.Instance,
-                StandardResolver.Instance ) );
+    private static readonly MessagePackHelper _helper = new MessagePackHelper();
 
     private static T Roundtrip<T>( T value )
     {
@@ -45,9 +39,29 @@ public sealed class MessagePackSerializationTests
         var attribute = type.GetCustomAttribute<RpcContractAttribute>();
         Assert.True( attribute != null, $"Type {type.FullName} is missing the [RpcContract] attribute." );
 
-        var bytes = MessagePackSerializer.Serialize( value, _options );
+        return _helper.Deserialize<T>( _helper.Serialize( value ) );
+    }
 
-        return MessagePackSerializer.Deserialize<T>( bytes, _options );
+    [Fact]
+    public void NonGeneric_Roundtrip_MatchesGeneric()
+    {
+        // Pins that MessagePackHelper's non-generic Serialize(object, Type) / Deserialize(byte[], Type) overloads
+        // produce wire bytes byte-equivalent to the generic ones for the same options + same concrete type.
+        // Premium relies on this: its CodeActionDescriptor.ToDescriptor passes the runtime type of a leaf model
+        // to the non-generic overload (the type discriminator rides out-of-band in the descriptor).
+        var input = new RpcServiceInfo( "pipe-name", "FactoryType", "ExtensionName" );
+
+        var bytesGeneric = _helper.Serialize( input );
+        var bytesNonGeneric = _helper.Serialize( input, typeof(RpcServiceInfo) );
+
+        Assert.Equal( bytesGeneric, bytesNonGeneric );
+
+        var fromGeneric = _helper.Deserialize<RpcServiceInfo>( bytesNonGeneric );
+        var fromNonGeneric = (RpcServiceInfo) _helper.Deserialize( bytesGeneric, typeof(RpcServiceInfo) )!;
+
+        Assert.Equal( fromGeneric.PipeName, fromNonGeneric.PipeName );
+        Assert.Equal( fromGeneric.FactoryTypeName, fromNonGeneric.FactoryTypeName );
+        Assert.Equal( fromGeneric.ExtensionName, fromNonGeneric.ExtensionName );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Alternative to #1607 — same issue (#1606), no polymorphism on the wire. Premium will refactor `CodeActionBaseModel` to use a Premium-defined concrete `CodeActionDescriptor` record + opaque MessagePack payload bytes; devenv never deserializes any abstract type, so the cross-process / cross-TFM identity issues that surface as `RemoteMethodNotFoundException` simply can't manifest.

This PR ships only the Metalama-side preconditions Premium needs:

- **`MessagePackHelper`** (public, in `Metalama.Framework.DesignTime.Rpc`) — adapter that uses the same `MessagePackSerializerOptions` as `BaseEndpoint.CreateRpc`. Generic + non-generic Serialize/Deserialize overloads. Premium's `CodeActionBaseModel.ToDescriptor` uses the non-generic overload to serialize a leaf model by its runtime type; the type discriminator rides out-of-band in the descriptor's `PayloadTypeName`.
- **`LoggerTraceListener`** (internal) + **`JsonRpc.TraceSource` forwarding in `BaseEndpoint.CreateRpc`** — surfaces StreamJsonRpc's internal events (request/response dispatch, argument-deserialization errors, connection lifecycle) into the Metalama logger at `SourceLevels.Information`. Null-cost when verbose logging isn't enabled.
- **`MessagePackOptions`** on `BaseEndpoint` exposed as `internal static` so `MessagePackHelper` and `BaseEndpoint.CreateRpc` share one source of truth — same chain `[Typeless, Standard]` as before.
- **`SerializationTestsBase.MessagePackRoundloop<T>`** — sibling of the existing Newtonsoft `Roundloop<T>` for cross-repo tests that need to exercise the MessagePack RPC wire path.
- **Test rename**: `MessagePackSerializationTests.cs` → `RpcSerializationTests.cs`, plus `NonGeneric_Roundtrip_MatchesGeneric` to pin byte-equivalence of the new overloads.

### Relationship to #1607

#1607 prototypes the polymorphic-resolver approach: live registry, hierarchy walk, `RegisterRpcSubtypes<TBase>` API, soft-fail. The two PRs are mutually exclusive — pick one. This one is intentionally smaller.

`RpcEventData`-family events (the only other polymorphic wire usage) work fine here via `TypelessObjectResolver` alone — same as pre-#1606 — because the events live in Metalama-owned assemblies whose `Type.GetType` resolution doesn't hit the cross-TFM identity issue Premium's types do. Verified by the existing `PolymorphicRpcEventData_*` tests passing.

## Test plan

- [x] Build clean (0 warnings, 0 errors): `Metalama.Framework.DesignTime.Rpc`, `Metalama.Framework.DesignTime`, `Metalama.Framework.Tests.UnitTests` on net8.0 + net48.
- [x] `RpcSerializationTests` (24 + 1 = 25 tests) — all existing `[RpcContract]` round-trips + `NonGeneric_Roundtrip_MatchesGeneric` for the new overloads. Includes `PolymorphicRpcEventData_*` (validates `RpcEventData` polymorphism via `TypelessObjectResolver`).
- [x] Full RPC suite: 72/73 pass on both net8.0 and net48 (1 pre-existing unrelated skip: `RpcServiceProviderTests.ExtensionNeverDiscovered_BackgroundTaskNeverCompletes`).
- [x] `DevEnvEntryPoint.SerializationTests` (Newtonsoft cross-version path): 3/3 still pass — no regression.
- [ ] Interactive VS verification (post-merge): once Premium consumes this branch and lands the `CodeActionDescriptor` refactor, reproduce the original #1606 scenario and confirm `RemoteMethodNotFoundException` no longer fires. The `LoggerTraceListener` will surface any new RPC failures in the logs with full StreamJsonRpc context.

Closes part of #1606. Premium-side follow-up PR closes the rest.